### PR TITLE
Add determinant check and make kdl solvers thread safe

### DIFF
--- a/tesseract_kinematics/core/src/kinematic_group.cpp
+++ b/tesseract_kinematics/core/src/kinematic_group.cpp
@@ -116,6 +116,7 @@ IKSolutions KinematicGroup::calcInvKin(const KinGroupIKInputs& tip_link_poses,
   {
     assert(std::find(working_frames_.begin(), working_frames_.end(), tip_link_pose.working_frame) !=
            working_frames_.end());
+    assert(std::abs(1.0 - tip_link_pose.pose.matrix().determinant()) < 1e-6);
 
     // The IK Solvers tip link and working frame
     std::string ik_solver_tip_link = inv_tip_links_map_.at(tip_link_pose.tip_link_name);

--- a/tesseract_kinematics/core/src/kinematic_group.cpp
+++ b/tesseract_kinematics/core/src/kinematic_group.cpp
@@ -116,7 +116,7 @@ IKSolutions KinematicGroup::calcInvKin(const KinGroupIKInputs& tip_link_poses,
   {
     assert(std::find(working_frames_.begin(), working_frames_.end(), tip_link_pose.working_frame) !=
            working_frames_.end());
-    assert(std::abs(1.0 - tip_link_pose.pose.matrix().determinant()) < 1e-6);
+    assert(std::abs(1.0 - tip_link_pose.pose.matrix().determinant()) < 1e-6);  // NOLINT
 
     // The IK Solvers tip link and working frame
     std::string ik_solver_tip_link = inv_tip_links_map_.at(tip_link_pose.tip_link_name);

--- a/tesseract_kinematics/core/src/rep_inv_kin.cpp
+++ b/tesseract_kinematics/core/src/rep_inv_kin.cpp
@@ -236,6 +236,7 @@ IKSolutions REPInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link
                                   const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
   assert(tip_link_poses.find(manip_tip_link_) != tip_link_poses.end());
+  assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);
 
   return calcInvKinHelper(tip_link_poses, seed);
 }

--- a/tesseract_kinematics/core/src/rep_inv_kin.cpp
+++ b/tesseract_kinematics/core/src/rep_inv_kin.cpp
@@ -236,7 +236,7 @@ IKSolutions REPInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link
                                   const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
   assert(tip_link_poses.find(manip_tip_link_) != tip_link_poses.end());
-  assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);
+  assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);  // NOLINT
 
   return calcInvKinHelper(tip_link_poses, seed);
 }

--- a/tesseract_kinematics/core/src/rop_inv_kin.cpp
+++ b/tesseract_kinematics/core/src/rop_inv_kin.cpp
@@ -238,6 +238,7 @@ IKSolutions ROPInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link
                                   const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
   assert(tip_link_poses.find(manip_tip_link_) != tip_link_poses.end());  // NOLINT
+  assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);
 
   return calcInvKinHelper(tip_link_poses, seed);  // NOLINT
 }

--- a/tesseract_kinematics/core/src/rop_inv_kin.cpp
+++ b/tesseract_kinematics/core/src/rop_inv_kin.cpp
@@ -237,8 +237,8 @@ void ROPInvKin::ikAt(IKSolutions& solutions,
 IKSolutions ROPInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link_poses,
                                   const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
-  assert(tip_link_poses.find(manip_tip_link_) != tip_link_poses.end());  // NOLINT
-  assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);
+  assert(tip_link_poses.find(manip_tip_link_) != tip_link_poses.end());                      // NOLINT
+  assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);  // NOLINT
 
   return calcInvKinHelper(tip_link_poses, seed);  // NOLINT
 }

--- a/tesseract_kinematics/ikfast/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
+++ b/tesseract_kinematics/ikfast/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
@@ -76,6 +76,7 @@ inline IKSolutions IKFastInvKin::calcInvKin(const tesseract_common::TransformMap
 {
   assert(tip_link_poses.size() == 1);
   assert(tip_link_poses.find(tip_link_name_) != tip_link_poses.end());
+  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);
 
   const Eigen::Isometry3d& pose = tip_link_poses.at(tip_link_name_);
 

--- a/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain.h
+++ b/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <kdl/chainjnttojacsolver.hpp>
 #include <unordered_map>
 #include <console_bridge/console.h>
+#include <mutex>
 
 #include <tesseract_scene_graph/graph.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -115,6 +116,7 @@ private:
   std::unique_ptr<KDL::ChainFkSolverPos_recursive> fk_solver_; /**< KDL Forward Kinematic Solver */
   std::unique_ptr<KDL::ChainJntToJacSolver> jac_solver_;       /**< KDL Jacobian Solver */
   std::string solver_name_{ KDL_FWD_KIN_CHAIN_SOLVER_NAME };   /**< @brief Name of this solver */
+  mutable std::mutex mutex_; /**< @brief KDL is not thread safe due to mutable variables in Joint Class */
 
   /** @brief calcFwdKin helper function */
   tesseract_common::TransformMap calcFwdKinHelperAll(const Eigen::Ref<const Eigen::VectorXd>& joint_angles) const;

--- a/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain.h
+++ b/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_fwd_kin_chain.h
@@ -71,8 +71,8 @@ public:
   ~KDLFwdKinChain() override = default;
   KDLFwdKinChain(const KDLFwdKinChain& other);
   KDLFwdKinChain& operator=(const KDLFwdKinChain& other);
-  KDLFwdKinChain(KDLFwdKinChain&&) = default;
-  KDLFwdKinChain& operator=(KDLFwdKinChain&&) = default;
+  KDLFwdKinChain(KDLFwdKinChain&&) = delete;
+  KDLFwdKinChain& operator=(KDLFwdKinChain&&) = delete;
 
   /**
    * @brief Initializes Forward Kinematics as chain

--- a/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h
+++ b/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <kdl/chainiksolverpos_lma.hpp>
 #include <unordered_map>
 #include <console_bridge/console.h>
+#include <mutex>
 
 #include <tesseract_scene_graph/graph.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -108,6 +109,7 @@ private:
   KDLChainData kdl_data_;                                        /**< @brief KDL data parsed from Scene Graph */
   std::unique_ptr<KDL::ChainIkSolverPos_LMA> ik_solver_;         /**< @brief KDL Inverse kinematic solver */
   std::string solver_name_{ KDL_INV_KIN_CHAIN_LMA_SOLVER_NAME }; /**< @brief Name of this solver */
+  mutable std::mutex mutex_; /**< @brief KDL is not thread safe due to mutable variables in Joint Class */
 
   /** @brief calcFwdKin helper function */
   IKSolutions calcInvKinHelper(const Eigen::Isometry3d& pose,

--- a/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h
+++ b/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_lma.h
@@ -67,8 +67,8 @@ public:
   ~KDLInvKinChainLMA() override = default;
   KDLInvKinChainLMA(const KDLInvKinChainLMA& other);
   KDLInvKinChainLMA& operator=(const KDLInvKinChainLMA& other);
-  KDLInvKinChainLMA(KDLInvKinChainLMA&&) = default;
-  KDLInvKinChainLMA& operator=(KDLInvKinChainLMA&&) = default;
+  KDLInvKinChainLMA(KDLInvKinChainLMA&&) = delete;
+  KDLInvKinChainLMA& operator=(KDLInvKinChainLMA&&) = delete;
 
   /**
    * @brief Construct Inverse Kinematics as chain

--- a/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr.h
+++ b/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr.h
@@ -68,8 +68,8 @@ public:
   ~KDLInvKinChainNR() override = default;
   KDLInvKinChainNR(const KDLInvKinChainNR& other);
   KDLInvKinChainNR& operator=(const KDLInvKinChainNR& other);
-  KDLInvKinChainNR(KDLInvKinChainNR&&) = default;
-  KDLInvKinChainNR& operator=(KDLInvKinChainNR&&) = default;
+  KDLInvKinChainNR(KDLInvKinChainNR&&) = delete;
+  KDLInvKinChainNR& operator=(KDLInvKinChainNR&&) = delete;
 
   /**
    * @brief Construct KDL Forward Kinematics

--- a/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr.h
+++ b/tesseract_kinematics/kdl/include/tesseract_kinematics/kdl/kdl_inv_kin_chain_nr.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <kdl/chainfksolverpos_recursive.hpp>
 #include <unordered_map>
 #include <console_bridge/console.h>
+#include <mutex>
 
 #include <tesseract_scene_graph/graph.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
@@ -111,6 +112,7 @@ private:
   std::unique_ptr<KDL::ChainIkSolverVel_pinv> ik_vel_solver_;   /**< @brief KDL Inverse kinematic velocity solver */
   std::unique_ptr<KDL::ChainIkSolverPos_NR> ik_solver_;         /**< @brief KDL Inverse kinematic solver */
   std::string solver_name_{ KDL_INV_KIN_CHAIN_NR_SOLVER_NAME }; /**< @brief Name of this solver */
+  mutable std::mutex mutex_; /**< @brief KDL is not thread safe due to mutable variables in Joint Class */
 
   /** @brief calcFwdKin helper function */
   IKSolutions calcInvKinHelper(const Eigen::Isometry3d& pose,

--- a/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_lma.cpp
+++ b/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_lma.cpp
@@ -79,7 +79,7 @@ IKSolutions KDLInvKinChainLMA::calcInvKinHelper(const Eigen::Isometry3d& pose,
                                                 const Eigen::Ref<const Eigen::VectorXd>& seed,
                                                 int /*segment_num*/) const
 {
-  assert(std::abs(1.0 - pose.matrix().determinant()) < 1e-6);
+  assert(std::abs(1.0 - pose.matrix().determinant()) < 1e-6);  // NOLINT
   KDL::JntArray kdl_seed, kdl_solution;
   EigenToKDL(seed, kdl_seed);
   kdl_solution.resize(static_cast<unsigned>(seed.size()));

--- a/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_nr.cpp
+++ b/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_nr.cpp
@@ -83,7 +83,7 @@ IKSolutions KDLInvKinChainNR::calcInvKinHelper(const Eigen::Isometry3d& pose,
                                                const Eigen::Ref<const Eigen::VectorXd>& seed,
                                                int /*segment_num*/) const
 {
-  assert(std::abs(1.0 - pose.matrix().determinant()) < 1e-6);
+  assert(std::abs(1.0 - pose.matrix().determinant()) < 1e-6);  // NOLINT
   KDL::JntArray kdl_seed, kdl_solution;
   EigenToKDL(seed, kdl_seed);
   kdl_solution.resize(static_cast<unsigned>(seed.size()));

--- a/tesseract_kinematics/opw/src/opw_inv_kin.cpp
+++ b/tesseract_kinematics/opw/src/opw_inv_kin.cpp
@@ -68,9 +68,9 @@ OPWInvKin& OPWInvKin::operator=(const OPWInvKin& other)
 IKSolutions OPWInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link_poses,
                                   const Eigen::Ref<const Eigen::VectorXd>& /*seed*/) const
 {
-  assert(tip_link_poses.size() == 1);
-  assert(tip_link_poses.find(tip_link_name_) != tip_link_poses.end());
-  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);
+  assert(tip_link_poses.size() == 1);                                                       // NOLINT
+  assert(tip_link_poses.find(tip_link_name_) != tip_link_poses.end());                      // NOLINT
+  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);  // NOLINT
 
   opw_kinematics::Solutions<double> sols = opw_kinematics::inverse(params_, tip_link_poses.at(tip_link_name_));
 

--- a/tesseract_kinematics/opw/src/opw_inv_kin.cpp
+++ b/tesseract_kinematics/opw/src/opw_inv_kin.cpp
@@ -70,6 +70,7 @@ IKSolutions OPWInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link
 {
   assert(tip_link_poses.size() == 1);
   assert(tip_link_poses.find(tip_link_name_) != tip_link_poses.end());
+  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);
 
   opw_kinematics::Solutions<double> sols = opw_kinematics::inverse(params_, tip_link_poses.at(tip_link_name_));
 

--- a/tesseract_kinematics/ur/src/ur_inv_kin.cpp
+++ b/tesseract_kinematics/ur/src/ur_inv_kin.cpp
@@ -255,7 +255,7 @@ IKSolutions URInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link_
 {
   assert(tip_link_poses.size() == 1);
   assert(tip_link_poses.find(tip_link_name_) != tip_link_poses.end());
-  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);
+  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);  // NOLINT
 
   Eigen::Isometry3d base_offset = Eigen::Isometry3d::Identity() * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitZ());
   Eigen::Isometry3d corrected_pose = base_offset.inverse() * tip_link_poses.at(tip_link_name_);

--- a/tesseract_kinematics/ur/src/ur_inv_kin.cpp
+++ b/tesseract_kinematics/ur/src/ur_inv_kin.cpp
@@ -255,6 +255,7 @@ IKSolutions URInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link_
 {
   assert(tip_link_poses.size() == 1);
   assert(tip_link_poses.find(tip_link_name_) != tip_link_poses.end());
+  assert(std::abs(1.0 - tip_link_poses.at(tip_link_name_).matrix().determinant()) < 1e-6);
 
   Eigen::Isometry3d base_offset = Eigen::Isometry3d::Identity() * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitZ());
   Eigen::Isometry3d corrected_pose = base_offset.inverse() * tip_link_poses.at(tip_link_name_);


### PR DESCRIPTION
Add determinant check to each inverse kinematics solver on the incoming pose.

Also, it turns out that KDL is not thread-safe because the Joint class leverages mutable variables. This add mutex to the solvers to resolve the issue and also opened an issue on KDL's repository.