### PR TITLE
Add contact margin data override type MODIFY

### DIFF
--- a/tesseract_collision/test/collision_margin_data_unit.cpp
+++ b/tesseract_collision/test/collision_margin_data_unit.cpp
@@ -216,6 +216,40 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
   }
 
+  {  // Test Apply Override Modify
+    double default_margin = 0.0254;
+    double pair_margin = 0.5;
+    CollisionMarginData data(default_margin);
+    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+
+    CollisionMarginData override_data(default_margin * 3);
+    override_data.setPairCollisionMargin("link_1", "link_3", pair_margin * 3);
+    data.apply(override_data, CollisionMarginOverrideType::MODIFY);
+    EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin * 3, tol);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * 3, tol);
+    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
+    EXPECT_EQ(data.getPairCollisionMargins().size(), 2);
+  }
+
+  {  // Test Apply Override Modify with pair that already exists
+    double default_margin = 0.0254;
+    double pair_margin = 0.5;
+    CollisionMarginData data(default_margin);
+    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+
+    pair_margin = pair_margin * 3;
+    CollisionMarginData override_data(default_margin * 3);
+    override_data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    override_data.setPairCollisionMargin("link_1", "link_3", pair_margin * 3);
+    data.apply(override_data, CollisionMarginOverrideType::MODIFY);
+    EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin * 3, tol);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * 3, tol);
+    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
+    EXPECT_EQ(data.getPairCollisionMargins().size(), 2);
+  }
+
   {  // Test Apply Override Modify Pair
     double default_margin = 0.0254;
     double pair_margin = 0.5;

--- a/tesseract_common/include/tesseract_common/collision_margin_data.h
+++ b/tesseract_common/include/tesseract_common/collision_margin_data.h
@@ -47,6 +47,12 @@ enum class CollisionMarginOverrideType
   NONE,
   /** @brief Replace the contact manager's CollisionMarginData */
   REPLACE,
+  /**
+   * @brief Modify the contact managers default margin and pair margins
+   * @details This will preserve existing pairs not being modified by the provided margin data.
+   * If a pair already exist it will be updated with the provided margin data.
+   */
+  MODIFY,
   /** @brief Override the contact managers default margin only */
   OVERRIDE_DEFAULT_MARGIN,
   /** @brief Override the contact managers pair margin only. This does not preserve any existing pair margin data */
@@ -170,7 +176,7 @@ public:
 
   /**
    * @brief Scale all margins by input value
-   * @param scale Value by which all margins are multipled
+   * @param scale Value by which all margins are multiplied
    */
   void scaleMargins(const double& scale)
   {
@@ -192,6 +198,16 @@ public:
       case CollisionMarginOverrideType::REPLACE:
       {
         *this = collision_margin_data;
+        break;
+      }
+      case CollisionMarginOverrideType::MODIFY:
+      {
+        default_collision_margin_ = collision_margin_data.default_collision_margin_;
+
+        for (const auto& p : collision_margin_data.lookup_table_)
+          lookup_table_[p.first] = p.second;
+
+        updateMaxCollisionMargin();
         break;
       }
       case CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN:


### PR DESCRIPTION
This add an override type that allows you to modify both the default margin and pair margins which was not possible.