### PR TITLE
Fix KinematicGroup and JointGroup cache to clear on current state change

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Lint  (CodeCov)      | [![Build Status](https://github.com/tesseract-robotics/te
 The planning framework (Tesseract) was designed to be light weight, limiting the number of dependencies, mainly only using standard libraries like, eigen, boost, orocos and to the packages below. The core packages are ROS agnostic and have full python support.
 
 ## Dependencies
-[![ros_industrial_cmake_boilerplate](https://img.shields.io/badge/ros_industrial_cmake_boilerplate-0.2.13-brightgreen)](https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/tree/0.2.13)  
+[![ros_industrial_cmake_boilerplate](https://img.shields.io/badge/ros_industrial_cmake_boilerplate-0.2.14-brightgreen)](https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/tree/0.2.14)  
 [![opw_kinematics](https://img.shields.io/badge/opw_kinematics-0.4.4-brightgreen)](https://github.com/Jmeyer1292/opw_kinematics/tree/0.4.4)
 
 ## Tesseract Setup Wizard and Visualization Tools

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: ros_industrial_cmake_boilerplate
     uri: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
-    version: 0.2.13
+    version: 0.2.14
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git

--- a/dependencies_with_ext.rosinstall
+++ b/dependencies_with_ext.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: ros_industrial_cmake_boilerplate
     uri: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
-    version: 0.2.13
+    version: 0.2.14
 - git:
     local-name: tesseract_ext
     uri: https://github.com/ros-industrial-consortium/tesseract_ext.git

--- a/tesseract_environment/src/environment.cpp
+++ b/tesseract_environment/src/environment.cpp
@@ -877,6 +877,13 @@ void Environment::currentStateChanged()
       }
     }
   }
+
+  {  // Clear JointGroup and KinematicGroup
+    std::unique_lock<std::shared_mutex> jg_lock(joint_group_cache_mutex_);
+    std::unique_lock<std::shared_mutex> kg_lock(kinematic_group_cache_mutex_);
+    joint_group_cache_.clear();
+    kinematic_group_cache_.clear();
+  }
 }
 
 void Environment::environmentChanged()
@@ -889,10 +896,6 @@ void Environment::environmentChanged()
 
   {  // Clear JointGroup, KinematicGroup and GroupJointNames cache
     std::unique_lock<std::shared_mutex> jn_lock(group_joint_names_cache_mutex_);
-    std::unique_lock<std::shared_mutex> jg_lock(joint_group_cache_mutex_);
-    std::unique_lock<std::shared_mutex> kg_lock(kinematic_group_cache_mutex_);
-    joint_group_cache_.clear();
-    kinematic_group_cache_.clear();
     group_joint_names_cache_.clear();
   }
 


### PR DESCRIPTION
Some kinematics groups could depend on the state of the environment which contain other joints so the environment cache should be cleared on state changed. 