### PR TITLE
Add redundancy capable joints to the harmonizeTowardZero function

### DIFF
--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -336,67 +336,6 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
   return manip;
 }
 
-///**
-// * @brief Create a kinematics map from the srdf model
-// * @param scene_graph Tesseract Scene Graph
-// * @param kinematics_information Tesseract Kinematics Information
-// * @return Kinematics map between group name and kinematics object
-// */
-// template <class Chain_T, class Tree_T>
-// ForwardKinematicsConstPtrMap createKinematicsMap(const tesseract_scene_graph::SceneGraph::ConstPtr& scene_graph,
-//                                                 const tesseract_srdf::KinematicsInformation& kinematics_information)
-//{
-//  ForwardKinematicsConstPtrMap manipulators;
-//  for (const auto& group : kinematics_information.chain_groups)
-//  {
-//    if (!group.second.empty())
-//    {
-//      if (manipulators.find(group.first) == manipulators.end())
-//      {
-//        std::shared_ptr<Chain_T> manip{ std::make_shared<Chain_T>() };
-//        if (!manip->init(scene_graph, group.second, group.first))
-//        {
-//          CONSOLE_BRIDGE_logError("Failed to create kinematic chaing for manipulator %s!", group.first);
-//        }
-//        else
-//        {
-//          manipulators.insert(std::make_pair(group.first, manip));
-//        }
-//      }
-//    }
-//  }
-
-//  for (const auto& group : kinematics_information.joint_groups)
-//  {
-//    if (!group.second.empty())
-//    {
-//      if (manipulators.find(group.first) == manipulators.end())
-//      {
-//        std::shared_ptr<Tree_T> manip{ std::make_shared<Tree_T>() };
-//        if (!manip->init(scene_graph, group.second, group.first))
-//        {
-//          CONSOLE_BRIDGE_logError("Failed to create kinematic chaing for manipulator %s!", group.first);
-//        }
-//        else
-//        {
-//          manipulators.insert(std::make_pair(group.first, manip));
-//        }
-//      }
-//    }
-//  }
-
-//  for (const auto& group : kinematics_information.link_groups)
-//  {
-//    // TODO: Need to add other options
-//    if (!group.second.empty())
-//    {
-//      CONSOLE_BRIDGE_logError("Link groups are currently not supported!");
-//    }
-//  }
-
-//  return manipulators;
-//}
-
 /**
  * @brief This a recursive function for calculating all permutations of the redundant solutions.
  * @details This should not be used directly, use getRedundantSolutions function.
@@ -535,12 +474,32 @@ inline bool isValid(const std::array<FloatType, 6>& qs)
  * @param dof The length of the float array
  */
 template <typename FloatType>
+DEPRECATED("Use redundancy version")
 inline void harmonizeTowardZero(Eigen::Ref<VectorX<FloatType>> qs)
 {
   const static auto pi = FloatType(M_PI);
   const static auto two_pi = FloatType(2.0 * M_PI);
 
   for (Eigen::Index i = 0; i < qs.rows(); ++i)
+  {
+    FloatType diff = std::fmod(qs[i] + pi, two_pi);
+    qs[i] = (diff < 0) ? (diff + pi) : (diff - pi);
+  }
+}
+
+/**
+ * @brief This take an array of floats and modifies them in place to be between [-PI, PI]
+ * @param qs A pointer to a float array
+ * @param dof The length of the float array
+ */
+template <typename FloatType>
+inline void harmonizeTowardZero(Eigen::Ref<VectorX<FloatType>> qs,
+                                const std::vector<Eigen::Index>& redundancy_capable_joints)
+{
+  const static auto pi = FloatType(M_PI);
+  const static auto two_pi = FloatType(2.0 * M_PI);
+
+  for (const auto& i : redundancy_capable_joints)
   {
     FloatType diff = std::fmod(qs[i] + pi, two_pi);
     qs[i] = (diff < 0) ? (diff + pi) : (diff - pi);

--- a/tesseract_kinematics/ikfast/include/tesseract_kinematics/ikfast/ikfast_inv_kin.h
+++ b/tesseract_kinematics/ikfast/include/tesseract_kinematics/ikfast/ikfast_inv_kin.h
@@ -106,6 +106,7 @@ public:
   IKFastInvKin(std::string base_link_name,
                std::string tip_link_name,
                std::vector<std::string> joint_names,
+               std::vector<Eigen::Index> redundancy_capable_joints,
                std::string solver_name = IKFAST_INV_KIN_CHAIN_SOLVER_NAME,
                std::vector<std::vector<double>> free_joint_states = {});
 
@@ -132,9 +133,10 @@ public:
   generateAllFreeJointStateCombinations(const std::vector<std::vector<double>>& free_joint_samples);
 
 protected:
-  std::string base_link_name_;           /**< @brief Link name of first link in the kinematic object */
-  std::string tip_link_name_;            /**< @brief Link name of last kink in the kinematic object */
-  std::vector<std::string> joint_names_; /**< @brief Joint names for the kinematic object */
+  std::string base_link_name_;                          /**< @brief Link name of first link in the kinematic object */
+  std::string tip_link_name_;                           /**< @brief Link name of last kink in the kinematic object */
+  std::vector<std::string> joint_names_;                /**< @brief Joint names for the kinematic object */
+  std::vector<Eigen::Index> redundancy_capable_joints_; /** @brief Redundancy capable joints */
   std::string solver_name_{ IKFAST_INV_KIN_CHAIN_SOLVER_NAME }; /**< @brief Name of this solver */
   /**< @brief combinations of free joints to sample when computing IK
    * Example: Given 3 free joints, a valid input would be [[0,0,0][0,0,1][-1,0,1][0,2,0]] */

--- a/tesseract_kinematics/ikfast/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
+++ b/tesseract_kinematics/ikfast/include/tesseract_kinematics/ikfast/impl/ikfast_inv_kin.hpp
@@ -46,11 +46,13 @@ namespace tesseract_kinematics
 inline IKFastInvKin::IKFastInvKin(std::string base_link_name,
                                   std::string tip_link_name,
                                   std::vector<std::string> joint_names,
+                                  std::vector<Eigen::Index> redundancy_capable_joints,
                                   std::string solver_name,
                                   std::vector<std::vector<double>> free_joint_states)
   : base_link_name_(std::move(base_link_name))
   , tip_link_name_(std::move(tip_link_name))
   , joint_names_(std::move(joint_names))
+  , redundancy_capable_joints_(std::move(redundancy_capable_joints))
   , solver_name_(std::move(solver_name))
   , free_joint_states_(std::move(free_joint_states))
 {
@@ -65,6 +67,7 @@ inline IKFastInvKin& IKFastInvKin::operator=(const IKFastInvKin& other)
   base_link_name_ = other.base_link_name_;
   tip_link_name_ = other.tip_link_name_;
   joint_names_ = other.joint_names_;
+  redundancy_capable_joints_ = other.redundancy_capable_joints_;
   solver_name_ = other.solver_name_;
   free_joint_states_ = other.free_joint_states_;
 
@@ -139,7 +142,7 @@ inline IKSolutions IKFastInvKin::calcInvKin(const tesseract_common::TransformMap
     Eigen::Map<Eigen::VectorXd> eigen_sol(sols.data() + ikfast_dof * i, static_cast<Eigen::Index>(ikfast_dof));
     if (eigen_sol.array().allFinite())
     {
-      harmonizeTowardZero<double>(eigen_sol);  // Modifies 'sol' in place
+      harmonizeTowardZero<double>(eigen_sol, redundancy_capable_joints_);  // Modifies 'sol' in place
       solution_set.push_back(eigen_sol);
     }
   }

--- a/tesseract_kinematics/opw/src/opw_inv_kin.cpp
+++ b/tesseract_kinematics/opw/src/opw_inv_kin.cpp
@@ -34,6 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_kinematics/opw/opw_inv_kin.h>
 #include <tesseract_kinematics/core/utils.h>
 
+static const std::vector<Eigen::Index> REDUNDANT_CAPABLE_JOINTS{ 0, 1, 2, 3, 4, 5 };
+
 namespace tesseract_kinematics
 {
 OPWInvKin::OPWInvKin(opw_kinematics::Parameters<double> params,
@@ -84,7 +86,7 @@ IKSolutions OPWInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link
       Eigen::Map<Eigen::VectorXd> eigen_sol(sol.data(), static_cast<Eigen::Index>(sol.size()));
 
       // Harmonize between [-PI, PI]
-      harmonizeTowardZero<double>(eigen_sol);  // Modifies 'sol' in place
+      harmonizeTowardZero<double>(eigen_sol, REDUNDANT_CAPABLE_JOINTS);  // Modifies 'sol' in place
 
       // Add solution
       solution_set.push_back(eigen_sol);

--- a/tesseract_kinematics/test/abb_irb2400_ikfast_kinematics.cpp
+++ b/tesseract_kinematics/test/abb_irb2400_ikfast_kinematics.cpp
@@ -28,7 +28,7 @@ namespace tesseract_kinematics
 AbbIRB2400Kinematics::AbbIRB2400Kinematics(std::string base_link_name,
                                            std::string tip_link_name,
                                            std::vector<std::string> joint_names)
-  : IKFastInvKin(base_link_name, tip_link_name, joint_names)
+  : IKFastInvKin(base_link_name, tip_link_name, joint_names, { 0, 1, 2, 3, 4, 5 })
 {
 }
 

--- a/tesseract_kinematics/test/iiwa7_ikfast_kinematics.cpp
+++ b/tesseract_kinematics/test/iiwa7_ikfast_kinematics.cpp
@@ -30,7 +30,7 @@ iiwa7Kinematics::iiwa7Kinematics(std::string base_link_name,
                                  std::vector<std::string> joint_names,
                                  std::string solver_name,
                                  std::vector<std::vector<double> > free_joint_combos)
-  : IKFastInvKin(base_link_name, tip_link_name, joint_names, solver_name, free_joint_combos)
+  : IKFastInvKin(base_link_name, tip_link_name, joint_names, { 0, 1, 2, 3, 4, 5 }, solver_name, free_joint_combos)
 {
 }
 

--- a/tesseract_kinematics/test/kinematics_core_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_core_unit.cpp
@@ -15,21 +15,21 @@ TEST(TesseractKinematicsUnit, UtilsHarmonizeUnit)  // NOLINT
   q[0] = (4 * M_PI) + M_PI_4;
   q[1] = -(4 * M_PI) - M_PI_4;
 
-  tesseract_kinematics::harmonizeTowardZero<double>(q);
+  tesseract_kinematics::harmonizeTowardZero<double>(q, { 0, 1 });
   EXPECT_NEAR(q[0], M_PI_4, 1e-6);
   EXPECT_NEAR(q[1], -M_PI_4, 1e-6);
 
   q[0] = M_PI_4;
   q[1] = -M_PI_4;
 
-  tesseract_kinematics::harmonizeTowardZero<double>(q);
+  tesseract_kinematics::harmonizeTowardZero<double>(q, { 0, 1 });
   EXPECT_NEAR(q[0], M_PI_4, 1e-6);
   EXPECT_NEAR(q[1], -M_PI_4, 1e-6);
 
   q[0] = 5 * M_PI_4;
   q[1] = -5 * M_PI_4;
 
-  tesseract_kinematics::harmonizeTowardZero<double>(q);
+  tesseract_kinematics::harmonizeTowardZero<double>(q, { 0, 1 });
   EXPECT_NEAR(q[0], -3 * M_PI_4, 1e-6);
   EXPECT_NEAR(q[1], 3 * M_PI_4, 1e-6);
 }

--- a/tesseract_kinematics/ur/src/ur_inv_kin.cpp
+++ b/tesseract_kinematics/ur/src/ur_inv_kin.cpp
@@ -38,6 +38,8 @@
 #include <tesseract_kinematics/ur/ur_inv_kin.h>
 #include <tesseract_kinematics/core/utils.h>
 
+static const std::vector<Eigen::Index> REDUNDANT_CAPABLE_JOINTS{ 0, 1, 2, 3, 4, 5 };
+
 namespace tesseract_kinematics
 {
 // LCOV_EXCL_START
@@ -273,7 +275,7 @@ IKSolutions URInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link_
     Eigen::Map<Eigen::VectorXd> eigen_sol(sols[i].data(), static_cast<Eigen::Index>(sols[i].size()));
 
     // Harmonize between [-PI, PI]
-    harmonizeTowardZero<double>(eigen_sol);  // Modifies 'sol' in place
+    harmonizeTowardZero<double>(eigen_sol, REDUNDANT_CAPABLE_JOINTS);  // Modifies 'sol' in place
 
     // Add solution
     solution_set.push_back(eigen_sol);


### PR DESCRIPTION
This function cannot be used to harmonize non-revolute joints. The redundancy cable joints identifies which joint has the possibility of redundant solutions. For example this should not be applied to prismatic joints.