### PR TITLE
Add modify_object_enabled to ContactManagerConfig

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,13 +15,12 @@ jobs:
     env:
       CI_NAME: CodeCov
       OS_NAME: ubuntu
-      OS_CODE_NAME: bionic
-      ROS_DISTRO: melodic
+      OS_CODE_NAME: focal
+      ROS_DISTRO: noetic
       ROS_REPO: main
       UPSTREAM_WORKSPACE: 'dependencies.rosinstall'
       ROSDEP_SKIP_KEYS: "bullet fcl ompl orocos_kdl python-numpy ifopt python descartes_opw descartes_samplers descartes_light opw_kinematics ros_industrial_cmake_boilerplate iwyu taskflow"
-      DOCKER_IMAGE: "rosindustrial/tesseract:melodic"
-      CCACHE_DIR: "/home/runner/work/tesseract/tesseract/CodeCov/.ccache"
+      DOCKER_IMAGE: "rosindustrial/tesseract:noetic"
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
       AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_urdf --make-args ccov-all
@@ -37,22 +36,6 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
-
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
-
-      - name: ccache cache files
-        continue-on-error: true
-        uses: actions/cache@v1.1.0
-        with:
-          path: ${{ env.CI_NAME }}/.ccache
-          key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ env.CI_NAME }}-ccache-
 
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{env}}

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -259,6 +259,9 @@ enum class ACMOverrideType
  *
  * It should not contain information that is usually specific to a single contactTest such as CollisionObjectTransforms
  * or specific to the way contactTests are carried out such as LVS parameters
+ *
+ * @note Active links were not added to this config since this config could be shared by multiple manipulators, and
+ * those are set based on which one is being checked
  */
 struct ContactManagerConfig
 {
@@ -269,10 +272,15 @@ struct ContactManagerConfig
   CollisionMarginOverrideType margin_data_override_type{ CollisionMarginOverrideType::NONE };
   /** @brief Stores information about how the margins allowed between collision objects*/
   CollisionMarginData margin_data;
+
   /** @brief Additional AllowedCollisionMatrix to consider for this collision check.  */
   tesseract_common::AllowedCollisionMatrix acm;
   /** @brief Specifies how to combine the IsContactAllowedFn from acm with the one preset in the contact manager */
   ACMOverrideType acm_override_type{ ACMOverrideType::OR };
+
+  /** @brief Each key is an object name. Objects will be enabled/disabled based on the value. Objects that aren't in the
+   * map are unmodified from the defaults*/
+  std::unordered_map<std::string, bool> modify_object_enabled;
 };
 
 /**

--- a/tesseract_collision/core/src/continuous_contact_manager.cpp
+++ b/tesseract_collision/core/src/continuous_contact_manager.cpp
@@ -33,5 +33,6 @@ void ContinuousContactManager::applyContactManagerConfig(const ContactManagerCon
 {
   setCollisionMarginData(config.margin_data, config.margin_data_override_type);
   applyIsContactAllowedFnOverride(*this, config.acm, config.acm_override_type);
+  applyModifyObjectEnabled(*this, config.modify_object_enabled);
 }
 }  // namespace tesseract_collision

--- a/tesseract_collision/core/src/discrete_contact_manager.cpp
+++ b/tesseract_collision/core/src/discrete_contact_manager.cpp
@@ -33,5 +33,6 @@ void DiscreteContactManager::applyContactManagerConfig(const ContactManagerConfi
 {
   setCollisionMarginData(config.margin_data, config.margin_data_override_type);
   applyIsContactAllowedFnOverride(*this, config.acm, config.acm_override_type);
+  applyModifyObjectEnabled(*this, config.modify_object_enabled);
 }
 }  // namespace tesseract_collision

--- a/tesseract_collision/core/src/utils.cpp
+++ b/tesseract_collision/core/src/utils.cpp
@@ -49,27 +49,4 @@ IsContactAllowedFn combineContactAllowedFn(const IsContactAllowedFn& original,
       return original;
   }
 }
-
-void applyIsContactAllowedFnOverride(tesseract_collision::ContinuousContactManager& manager,
-                                     const tesseract_common::AllowedCollisionMatrix& acm,
-                                     ACMOverrideType type)
-{
-  IsContactAllowedFn original = manager.getIsContactAllowedFn();
-  IsContactAllowedFn override = [acm](const std::string& str1, const std::string& str2) {
-    return acm.isCollisionAllowed(str1, str2);
-  };
-  manager.setIsContactAllowedFn(combineContactAllowedFn(original, override, type));
-}
-
-void applyIsContactAllowedFnOverride(tesseract_collision::DiscreteContactManager& manager,
-                                     const tesseract_common::AllowedCollisionMatrix& acm,
-                                     ACMOverrideType type)
-{
-  IsContactAllowedFn original = manager.getIsContactAllowedFn();
-  IsContactAllowedFn override = [acm](const std::string& str1, const std::string& str2) {
-    return acm.isCollisionAllowed(str1, str2);
-  };
-  manager.setIsContactAllowedFn(combineContactAllowedFn(original, override, type));
-}
-
 }  // namespace tesseract_collision


### PR DESCRIPTION
Adds the ability to enable/disable links from the contact manager config. The reasoning here is similar to having the acm in the config. You might want to completely disable some links for some planning Tasks and re-enable them for others.