### PR TITLE
Move checkKinematics to getKinematicGroup and add support for clang-tidy-12

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
     misc-*,
     -misc-non-private-member-variables-in-classes,
+    -misc-no-recursion,
     modernize-*,
     -modernize-use-trailing-return-type,
     -modernize-use-nodiscard,
@@ -26,7 +27,8 @@ Checks: >
     -readability-braces-around-statements,
     -readability-named-parameter,
     -readability-magic-numbers,
-    -readability-isolate-declaration
+    -readability-isolate-declaration,
+    -readability-function-cognitive-complexity
 WarningsAsErrors: >
     -*,
     clang-diagnostic-*,
@@ -46,6 +48,7 @@ WarningsAsErrors: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
     misc-*,
     -misc-non-private-member-variables-in-classes,
+    -misc-no-recursion,
     modernize-*,
     -modernize-use-trailing-return-type,
     -modernize-use-nodiscard,
@@ -54,7 +57,8 @@ WarningsAsErrors: >
     -readability-braces-around-statements,
     -readability-named-parameter,
     -readability-magic-numbers,
-    -readability-isolate-declaration
+    -readability-isolate-declaration,
+    -readability-function-cognitive-complexity
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none

--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+  # allow manually starting this workflow
+  workflow_dispatch:
+
 jobs:
   deploy_documentation:
     runs-on: ubuntu-18.04

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -3,6 +3,9 @@ name: Benchmarking
 on:
   push:
 
+  # allow manually starting this workflow
+  workflow_dispatch:
+
 jobs:
   industrial_ci:
     name: ${{ matrix.env.CI_NAME }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+  # allow manually starting this workflow
+  workflow_dispatch:
+
 jobs:
   industrial_ci:
     if: contains(github.event.pull_request.labels.*.name, 'check-tesseract-ros') || github.event.schedule == true

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
@@ -584,7 +584,7 @@ inline btScalar addCastSingleResult(btManifoldPoint& cp,
   }
   else
   {
-    bool castShapeIsFirst = (cd0->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter) ? true : false;
+    bool castShapeIsFirst = (cd0->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter);
     btVector3 normalWorldFromCast = -(castShapeIsFirst ? 1 : -1) * cp.m_normalWorldOnB;
     const btCollisionObjectWrapper* firstColObjWrap = (castShapeIsFirst ? colObj0Wrap : colObj1Wrap);
     const btTransform& first_tf_inv = (castShapeIsFirst ? tf0_inv : tf1_inv);

--- a/tesseract_collision/bullet/src/bullet_factories.cpp
+++ b/tesseract_collision/bullet/src/bullet_factories.cpp
@@ -58,11 +58,15 @@ ContinuousContactManager::UPtr BulletCastSimpleManagerFactory::create(const std:
 
 }  // namespace tesseract_collision::tesseract_collision_bullet
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_collision::tesseract_collision_bullet::BulletDiscreteBVHManagerFactory,
                      BulletDiscreteBVHManagerFactory);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_collision::tesseract_collision_bullet::BulletDiscreteSimpleManagerFactory,
                      BulletDiscreteSimpleManagerFactory);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_collision::tesseract_collision_bullet::BulletCastBVHManagerFactory,
                      BulletCastBVHManagerFactory);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_collision::tesseract_collision_bullet::BulletCastSimpleManagerFactory,
                      BulletCastSimpleManagerFactory);

--- a/tesseract_collision/bullet/src/tesseract_convex_convex_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_convex_convex_algorithm.cpp
@@ -861,7 +861,7 @@ void TesseractConvexConvexAlgorithm::processCollision(const btCollisionObjectWra
   }
 }
 
-bool disableCcd = false;
+static const bool disableCcd = false;
 btScalar TesseractConvexConvexAlgorithm::calculateTimeOfImpact(btCollisionObject* body0,
                                                                btCollisionObject* body1,
                                                                const btDispatcherInfo& dispatchInfo,

--- a/tesseract_collision/bullet/src/tesseract_gjk_pair_detector.cpp
+++ b/tesseract_collision/bullet/src/tesseract_gjk_pair_detector.cpp
@@ -35,10 +35,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 // must be above the machine epsilon
 #ifdef BT_USE_DOUBLE_PRECISION
 #define REL_ERROR2 btScalar(1.0e-12)
-static btScalar gGjkEpaPenetrationTolerance = 1.0e-12;
+static const btScalar gGjkEpaPenetrationTolerance = 1.0e-12;
 #else
 #define REL_ERROR2 btScalar(1.0e-6)
-static btScalar gGjkEpaPenetrationTolerance = 0.001f;
+static const btScalar gGjkEpaPenetrationTolerance = 0.001f;
 #endif
 
 namespace tesseract_collision::tesseract_collision_bullet
@@ -144,7 +144,7 @@ struct btSimplex
   int last{ -1 };         //!< index of last added point
 };
 
-static btVector3 ccd_vec3_origin(0, 0, 0);
+static const btVector3 ccd_vec3_origin(0, 0, 0);
 
 inline void btSimplexInit(btSimplex* s) { s->last = -1; }
 

--- a/tesseract_collision/fcl/src/fcl_factories.cpp
+++ b/tesseract_collision/fcl/src/fcl_factories.cpp
@@ -37,5 +37,6 @@ DiscreteContactManager::UPtr FCLDiscreteBVHManagerFactory::create(const std::str
 
 }  // namespace tesseract_collision::tesseract_collision_fcl
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_collision::tesseract_collision_fcl::FCLDiscreteBVHManagerFactory,
                      FCLDiscreteBVHManagerFactory);

--- a/tesseract_collision/test/CMakeLists.txt
+++ b/tesseract_collision/test/CMakeLists.txt
@@ -45,6 +45,7 @@ macro(add_gtest test_name test_file)
     ${test_name}
     PRIVATE GTest::GTest
             GTest::Main
+            ${PROJECT_NAME}_core
             ${PROJECT_NAME}_test_suite
             ${PROJECT_NAME}_bullet
             ${PROJECT_NAME}_fcl

--- a/tesseract_common/include/tesseract_common/utils.h
+++ b/tesseract_common/include/tesseract_common/utils.h
@@ -49,6 +49,7 @@ namespace tesseract_common
 static std::mt19937 mersenne{ static_cast<std::mt19937::result_type>(std::time(nullptr)) };
 #else
 /** @brief Random number generator */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 inline std::mt19937 mersenne{ static_cast<std::mt19937::result_type>(std::time(nullptr)) };
 #endif
 

--- a/tesseract_common/src/utils.cpp
+++ b/tesseract_common/src/utils.cpp
@@ -167,7 +167,7 @@ Eigen::Vector4d computeRandomColor()
   return c;
 }
 
-void printNestedException(const std::exception& e, int level)
+void printNestedException(const std::exception& e, int level)  // NOLINT(misc-no-recursion)
 {
   std::cerr << std::string(static_cast<unsigned>(2 * level), ' ') << "exception: " << e.what() << std::endl;
   try
@@ -203,13 +203,7 @@ bool isNumeric(const std::string& s)
 
 bool isNumeric(const std::vector<std::string>& sv)
 {
-  for (const auto& s : sv)
-  {
-    if (!isNumeric(s))
-      return false;
-  }
-
-  return true;
+  return std::all_of(sv.cbegin(), sv.cend(), [](const std::string& s) { return isNumeric(s); });
 }
 
 Eigen::VectorXd generateRandomNumber(const Eigen::Ref<const Eigen::MatrixX2d>& limits)

--- a/tesseract_common/test/test_plugin_multiply.cpp
+++ b/tesseract_common/test/test_plugin_multiply.cpp
@@ -29,4 +29,5 @@
 
 double tesseract_common::TestPluginMultiply::multiply(double x, double y) { return x * y; }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_common::TestPluginMultiply, plugin)

--- a/tesseract_environment/src/environment.cpp
+++ b/tesseract_environment/src/environment.cpp
@@ -29,6 +29,7 @@
 #include <tesseract_collision/core/common.h>
 #include <tesseract_srdf/utils.h>
 #include <tesseract_state_solver/ofkt/ofkt_state_solver.h>
+#include <tesseract_kinematics/core/validate.h>
 
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <queue>
@@ -397,6 +398,14 @@ tesseract_kinematics::KinematicGroup::UPtr Environment::getKinematicGroup(const 
       group_name, joint_names, std::move(inv_kin), *scene_graph_const_, current_state_);
 
   kinematic_group_cache_[group_name] = std::make_unique<tesseract_kinematics::KinematicGroup>(*kg);
+
+#ifndef NDEBUG
+  if (!tesseract_kinematics::checkKinematics(*kg))
+  {
+    CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that inverse kinematics solution for a pose do not "
+                            "match forward kinematics solution. Did you change the URDF recently?");
+  }
+#endif
 
   return kg;
 }

--- a/tesseract_geometry/include/tesseract_geometry/impl/octree.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/octree.h
@@ -176,6 +176,7 @@ private:
     return true;
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   static void pruneRecurs(octomap::OcTree& octree,
                           octomap::OcTreeNode* node,
                           unsigned int depth,

--- a/tesseract_kinematics/core/CMakeLists.txt
+++ b/tesseract_kinematics/core/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(
   src/rep_inv_kin.cpp
   src/joint_group.cpp
   src/kinematic_group.cpp
-  src/kinematics_plugin_factory.cpp)
+  src/kinematics_plugin_factory.cpp
+  src/validate.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_core
   PUBLIC Eigen3::Eigen

--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/validate.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/validate.h
@@ -25,15 +25,7 @@
  */
 #ifndef TESSERACT_KINEMATICS_VALIDATE_H
 #define TESSERACT_KINEMATICS_VALIDATE_H
-#include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Geometry>
-#include <console_bridge/console.h>
-#include <algorithm>
-#include <sstream>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_common/utils.h>
 #include <tesseract_kinematics/core/kinematic_group.h>
 
 namespace tesseract_kinematics
@@ -46,134 +38,7 @@ namespace tesseract_kinematics
  * @param manip The kinematic group for a manipulator
  * @return True it they match, otherwise false.
  */
-inline bool checkKinematics(const KinematicGroup& manip, double tol = 1e-3)
-{
-  Eigen::Isometry3d test1;
-  Eigen::Isometry3d test2;
-  Eigen::VectorXd seed_angles(manip.numJoints());
-  Eigen::VectorXd joint_angles2(manip.numJoints());
-  std::vector<std::string> tip_links = manip.getAllPossibleTipLinkNames();
-  std::vector<std::string> working_frames = manip.getAllValidWorkingFrames();
-  const int nj = static_cast<int>(manip.numJoints());
-
-  std::vector<std::vector<double>> passed_data;
-  std::vector<std::vector<double>> failed_data;
-  int translation_failures{ 0 };
-  int angular_failures{ 0 };
-  double translation_max{ 0 };
-  double angular_max{ 0 };
-
-  for (const auto& tip_link : tip_links)
-  {
-    for (const auto& working_frame : working_frames)
-    {
-      seed_angles.setZero();
-      joint_angles2.setZero();
-
-      for (int t = 0; t < nj; ++t)
-      {
-        joint_angles2[t] = M_PI_4;
-
-        auto poses1 = manip.calcFwdKin(joint_angles2);
-        test1 = poses1.at(working_frame).inverse() * poses1.at(tip_link);
-        KinGroupIKInput ik_input(test1, working_frame, tip_link);
-        IKSolutions sols = manip.calcInvKin({ ik_input }, seed_angles);
-        for (const auto& sol : sols)
-        {
-          auto poses2 = manip.calcFwdKin(sol);
-          test2 = poses2.at(working_frame).inverse() * poses2.at(tip_link);
-
-          double translation_distance = (test1.translation() - test2.translation()).norm();
-          double angular_distance =
-              Eigen::Quaterniond(test1.linear()).angularDistance(Eigen::Quaterniond(test2.linear()));
-          if (translation_distance > tol || angular_distance > tol)
-          {
-            if (translation_distance > tol)
-              ++translation_failures;
-
-            if (angular_distance > tol)
-              ++angular_failures;
-
-            if (angular_distance > angular_max)
-              angular_max = angular_distance;
-
-            if (translation_distance > translation_max)
-              translation_max = translation_distance;
-
-            std::vector<double> data{ translation_distance, tol, angular_distance, tol };
-            for (Eigen::Index i = 0; i < sol.rows(); ++i)
-              data.push_back(sol(i));
-
-            failed_data.push_back(data);
-          }
-          else
-          {
-            std::vector<double> data{ translation_distance, tol, angular_distance, tol };
-            for (Eigen::Index i = 0; i < sol.rows(); ++i)
-              data.push_back(sol(i));
-
-            passed_data.push_back(data);
-          }
-        }
-
-        joint_angles2[t] = 0;
-      }
-    }
-  }
-
-  if (!failed_data.empty())
-  {
-    CONSOLE_BRIDGE_logError("checkKinematics failed %d out of %d\n           Translation failures %d out of %d (max: "
-                            "%f)\n           Angular failures %d out of %d (max: %f)",
-                            failed_data.size(),
-                            (failed_data.size() + passed_data.size()),
-                            translation_failures,
-                            failed_data.size(),
-                            translation_max,
-                            angular_failures,
-                            failed_data.size(),
-                            angular_max);
-    std::stringstream msg;
-    msg << std::endl;
-    msg << "*****************************" << std::endl;
-    msg << "******** Failed Data ********" << std::endl;
-    msg << "*****************************" << std::endl;
-
-    std::string header = "Trans. Dist. (m), tol, Angle Dist. (rad), tol";
-    for (const auto& jn : manip.getJointNames())
-      header += ", " + jn;
-
-    msg << header << std::endl;
-    for (const auto& d : failed_data)
-    {
-      for (const auto& val : d)
-        msg << val << ", ";
-      msg << std::endl;
-    }
-
-    msg << "*****************************" << std::endl;
-    msg << "******** Passed Data ********" << std::endl;
-    msg << "*****************************" << std::endl;
-    if (passed_data.empty())
-    {
-      msg << "No Data!" << std::endl;
-    }
-    else
-    {
-      for (const auto& d : passed_data)
-      {
-        for (const auto& val : d)
-          msg << val << ", ";
-        msg << std::endl;
-      }
-    }
-
-    CONSOLE_BRIDGE_logError("%s", msg.str().c_str());
-    return false;
-  }
-
-  return true;
-}
+bool checkKinematics(const KinematicGroup& manip, double tol = 1e-3);
 
 }  // namespace tesseract_kinematics
 #endif  // TESSERACT_KINEMATICS_VALIDATE_H

--- a/tesseract_kinematics/core/src/rep_factory.cpp
+++ b/tesseract_kinematics/core/src/rep_factory.cpp
@@ -171,4 +171,5 @@ InverseKinematics::UPtr REPInvKinFactory::create(const std::string& solver_name,
 }
 }  // namespace tesseract_kinematics
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::REPInvKinFactory, REPInvKinFactory);

--- a/tesseract_kinematics/core/src/rop_factory.cpp
+++ b/tesseract_kinematics/core/src/rop_factory.cpp
@@ -172,4 +172,5 @@ InverseKinematics::UPtr ROPInvKinFactory::create(const std::string& solver_name,
 }
 }  // namespace tesseract_kinematics
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::ROPInvKinFactory, ROPInvKinFactory);

--- a/tesseract_kinematics/core/src/validate.cpp
+++ b/tesseract_kinematics/core/src/validate.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file validate.cpp
+ * @brief This contains utility function validate things like forward kinematics match inverse kinematics
+ *
+ * @author Levi Armstrong
+ * @date April 15, 2018
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2013, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <Eigen/Geometry>
+#include <console_bridge/console.h>
+#include <algorithm>
+#include <sstream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/utils.h>
+#include <tesseract_kinematics/core/validate.h>
+
+namespace tesseract_kinematics
+{
+bool checkKinematics(const KinematicGroup& manip, double tol)
+{
+  Eigen::Isometry3d test1;
+  Eigen::Isometry3d test2;
+  Eigen::VectorXd seed_angles(manip.numJoints());
+  Eigen::VectorXd joint_angles2(manip.numJoints());
+  std::vector<std::string> tip_links = manip.getAllPossibleTipLinkNames();
+  std::vector<std::string> working_frames = manip.getAllValidWorkingFrames();
+  const int nj = static_cast<int>(manip.numJoints());
+
+  std::vector<std::vector<double>> passed_data;
+  std::vector<std::vector<double>> failed_data;
+  int translation_failures{ 0 };
+  int angular_failures{ 0 };
+  double translation_max{ 0 };
+  double angular_max{ 0 };
+
+  std::vector<std::pair<std::string, std::string>> checks;
+  checks.reserve(tip_links.size() + working_frames.size());
+
+  for (const auto& tip_link : tip_links)
+    checks.emplace_back(working_frames[0], tip_link);
+
+  for (const auto& working_frame : working_frames)
+    checks.emplace_back(working_frame, tip_links[0]);
+
+  for (const auto& check : checks)
+  {
+    seed_angles.setZero();
+    joint_angles2.setZero();
+
+    for (int t = 0; t < nj; ++t)
+    {
+      joint_angles2[t] = M_PI_4;
+
+      auto poses1 = manip.calcFwdKin(joint_angles2);
+      test1 = poses1.at(check.first).inverse() * poses1.at(check.second);
+      KinGroupIKInput ik_input(test1, check.first, check.second);
+      IKSolutions sols = manip.calcInvKin({ ik_input }, seed_angles);
+      for (const auto& sol : sols)
+      {
+        auto poses2 = manip.calcFwdKin(sol);
+        test2 = poses2.at(check.first).inverse() * poses2.at(check.second);
+
+        double translation_distance = (test1.translation() - test2.translation()).norm();
+        double angular_distance =
+            Eigen::Quaterniond(test1.linear()).angularDistance(Eigen::Quaterniond(test2.linear()));
+        if (translation_distance > tol || angular_distance > tol)
+        {
+          if (translation_distance > tol)
+            ++translation_failures;
+
+          if (angular_distance > tol)
+            ++angular_failures;
+
+          if (angular_distance > angular_max)
+            angular_max = angular_distance;
+
+          if (translation_distance > translation_max)
+            translation_max = translation_distance;
+
+          std::vector<double> data{ translation_distance, tol, angular_distance, tol };
+          for (Eigen::Index i = 0; i < sol.rows(); ++i)
+            data.push_back(sol(i));
+
+          failed_data.push_back(data);
+        }
+        else
+        {
+          std::vector<double> data{ translation_distance, tol, angular_distance, tol };
+          for (Eigen::Index i = 0; i < sol.rows(); ++i)
+            data.push_back(sol(i));
+
+          passed_data.push_back(data);
+        }
+      }
+
+      joint_angles2[t] = 0;
+    }
+  }
+
+  if (!failed_data.empty())
+  {
+    CONSOLE_BRIDGE_logError("checkKinematics failed %d out of %d\n           Translation failures %d out of %d (max: "
+                            "%f)\n           Angular failures %d out of %d (max: %f)",
+                            failed_data.size(),
+                            (failed_data.size() + passed_data.size()),
+                            translation_failures,
+                            failed_data.size(),
+                            translation_max,
+                            angular_failures,
+                            failed_data.size(),
+                            angular_max);
+    std::stringstream msg;
+    msg << std::endl;
+    msg << "*****************************" << std::endl;
+    msg << "******** Failed Data ********" << std::endl;
+    msg << "*****************************" << std::endl;
+
+    std::string header = "Trans. Dist. (m), tol, Angle Dist. (rad), tol";
+    for (const auto& jn : manip.getJointNames())
+      header += ", " + jn;
+
+    msg << header << std::endl;
+    for (const auto& d : failed_data)
+    {
+      for (const auto& val : d)
+        msg << val << ", ";
+      msg << std::endl;
+    }
+
+    msg << "*****************************" << std::endl;
+    msg << "******** Passed Data ********" << std::endl;
+    msg << "*****************************" << std::endl;
+    if (passed_data.empty())
+    {
+      msg << "No Data!" << std::endl;
+    }
+    else
+    {
+      for (const auto& d : passed_data)
+      {
+        for (const auto& val : d)
+          msg << val << ", ";
+        msg << std::endl;
+      }
+    }
+
+    CONSOLE_BRIDGE_logError("%s", msg.str().c_str());
+    return false;
+  }
+
+  return true;
+}
+}  // namespace tesseract_kinematics

--- a/tesseract_kinematics/kdl/src/kdl_factories.cpp
+++ b/tesseract_kinematics/kdl/src/kdl_factories.cpp
@@ -123,6 +123,9 @@ InverseKinematics::UPtr KDLInvKinChainNRFactory::create(const std::string& solve
 
 }  // namespace tesseract_kinematics
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::KDLFwdKinChainFactory, KDLFwdKinChainFactory);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::KDLInvKinChainLMAFactory, KDLInvKinChainLMAFactory);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::KDLInvKinChainNRFactory, KDLInvKinChainNRFactory);

--- a/tesseract_kinematics/opw/src/opw_factory.cpp
+++ b/tesseract_kinematics/opw/src/opw_factory.cpp
@@ -132,4 +132,5 @@ InverseKinematics::UPtr OPWInvKinFactory::create(const std::string& solver_name,
 }
 }  // namespace tesseract_kinematics
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::OPWInvKinFactory, OPWInvKinFactory);

--- a/tesseract_kinematics/test/kinematics_test_utils.h
+++ b/tesseract_kinematics/test/kinematics_test_utils.h
@@ -39,6 +39,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_kinematics/core/types.h>
 #include <tesseract_kinematics/core/kinematic_group.h>
 #include <tesseract_kinematics/core/kinematics_plugin_factory.h>
+#include <tesseract_kinematics/core/validate.h>
 
 #include <tesseract_scene_graph/graph.h>
 #include <tesseract_state_solver/kdl/kdl_state_solver.h>
@@ -495,6 +496,8 @@ inline void runInvKinTest(const tesseract_kinematics::KinematicGroup& kin_group,
     Eigen::Quaterniond rot_result(result.rotation());
     EXPECT_TRUE(rot_pose.isApprox(rot_result, 1e-3));
   }
+
+  EXPECT_TRUE(checkKinematics(kin_group));
 }
 
 inline void runFwdKinIIWATest(tesseract_kinematics::ForwardKinematics& kin)

--- a/tesseract_kinematics/ur/src/ur_factory.cpp
+++ b/tesseract_kinematics/ur/src/ur_factory.cpp
@@ -131,4 +131,5 @@ InverseKinematics::UPtr URInvKinFactory::create(const std::string& solver_name,
 }
 }  // namespace tesseract_kinematics
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TESSERACT_ADD_PLUGIN(tesseract_kinematics::URInvKinFactory, URInvKinFactory);

--- a/tesseract_scene_graph/include/tesseract_scene_graph/link.h
+++ b/tesseract_scene_graph/include/tesseract_scene_graph/link.h
@@ -90,7 +90,7 @@ private:
 };
 
 #ifndef SWIG
-static auto DEFAULT_TESSERACT_MATERIAL = std::make_shared<Material>("default_tesseract_material");
+static const auto DEFAULT_TESSERACT_MATERIAL = std::make_shared<Material>("default_tesseract_material");
 #endif  // SWIG
 
 class Inertial


### PR DESCRIPTION
Previously this was called in the motion planners resulting in multiple calls impacting planning time. This has been moved here to only run when a new instance of the kinematics object is created.