### PR TITLE
Add docker creation for major.minor

### DIFF
--- a/.github/workflows/bionic_build.yml
+++ b/.github/workflows/bionic_build.yml
@@ -69,7 +69,8 @@ jobs:
             suffix=
           tags: |
             type=ref,event=branch,prefix=${{ env.ROS_DISTRO }}-
-            type=ref,event=tag,prefix=${{ env.ROS_DISTRO }}-
+            type=semver,pattern={{version}},prefix=${{ env.ROS_DISTRO }}-
+            type=semver,pattern={{major}}.{{minor}},prefix=${{ env.ROS_DISTRO }}-
 
       - name: Set build type
         run: |

--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -69,7 +69,8 @@ jobs:
             suffix=
           tags: |
             type=ref,event=branch,prefix=${{ env.ROS_DISTRO }}-
-            type=ref,event=tag,prefix=${{ env.ROS_DISTRO }}-
+            type=semver,pattern={{version}},prefix=${{ env.ROS_DISTRO }}-
+            type=semver,pattern={{major}}.{{minor}},prefix=${{ env.ROS_DISTRO }}-
 
       - name: Set build type
         run: |


### PR DESCRIPTION
Currently a docker is create for major.minor.patch but this also adds one with just major.minor which will be used for other CI pipelines to avoid having to frequently update other CI pipelines for patch versions.