### PR TITLE
Switch docker build to use pep440

### DIFF
--- a/.github/workflows/bionic_build.yml
+++ b/.github/workflows/bionic_build.yml
@@ -69,8 +69,8 @@ jobs:
             suffix=
           tags: |
             type=ref,event=branch,prefix=${{ env.ROS_DISTRO }}-
-            type=semver,pattern={{version}},prefix=${{ env.ROS_DISTRO }}-
-            type=semver,pattern={{major}}.{{minor}},prefix=${{ env.ROS_DISTRO }}-
+            type=pep440,pattern={{version}},prefix=${{ env.ROS_DISTRO }}-
+            type=pep440,pattern={{major}}.{{minor}},prefix=${{ env.ROS_DISTRO }}-
 
       - name: Set build type
         run: |

--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -69,8 +69,8 @@ jobs:
             suffix=
           tags: |
             type=ref,event=branch,prefix=${{ env.ROS_DISTRO }}-
-            type=semver,pattern={{version}},prefix=${{ env.ROS_DISTRO }}-
-            type=semver,pattern={{major}}.{{minor}},prefix=${{ env.ROS_DISTRO }}-
+            type=pep440,pattern={{version}},prefix=${{ env.ROS_DISTRO }}-
+            type=pep440,pattern={{major}}.{{minor}},prefix=${{ env.ROS_DISTRO }}-
 
       - name: Set build type
         run: |


### PR DESCRIPTION
It looks like type=semver expects the tag to start with a `v` so switching to pep440.