### PR TITLE
Remove unneeded boost bind include

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -36,7 +36,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <array>
 #include <unordered_map>
 #include <functional>
-#include <boost/bind.hpp>
 #include <tesseract_geometry/geometries.h>
 #include <tesseract_common/types.h>
 #include <tesseract_common/collision_margin_data.h>


### PR DESCRIPTION
Not needed since C++11 and this header puts placeholder objects in the global namespace on system-installed Boost versions