### PR TITLE
Add ability to provide calibration information in the SRDF

### DIFF
--- a/.github/workflows/bionic_build.yml
+++ b/.github/workflows/bionic_build.yml
@@ -94,7 +94,7 @@ jobs:
           PREFIX: ${{ github.repository }}_
           UPSTREAM_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Release'
           TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
-          AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_state_solver tesseract_urdf --make-args test'
+          AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_srdf tesseract_state_solver tesseract_urdf --make-args test'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
 
       - name: Push post-build Docker

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,7 +23,7 @@ jobs:
       DOCKER_IMAGE: "rosindustrial/tesseract:noetic"
       UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
       TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
-      AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_urdf --make-args ccov-all
+      AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_srdf tesseract_state_solver tesseract_scene_graph tesseract_urdf --make-args ccov-all
                      && bash <(curl -s https://codecov.io/bash) -t c4af0da7-9fc3-4d3c-bb2e-6b2523ddd382 -s $target_ws/build -f *all-merged.info'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -95,7 +95,7 @@ jobs:
           BEFORE_RUN_TARGET_TEST_EMBED: "ici_with_unset_variables source $BASEDIR/${PREFIX}target_ws/install/setup.bash"
           UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
           TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTESSERACT_ENABLE_TESTING=ON"
-          AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_state_solver tesseract_urdf --make-args test'
+          AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_srdf tesseract_state_solver tesseract_urdf --make-args test'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
 
       - name: Push post-build Docker

--- a/tesseract_common/include/tesseract_common/types.h
+++ b/tesseract_common/include/tesseract_common/types.h
@@ -160,6 +160,29 @@ struct ContactManagersPluginInfo
   // Yaml Config key
   static inline const std::string CONFIG_KEY{ "contact_manager_plugins" };
 };
+
+/** @brief The CalibrationInfo struct */
+struct CalibrationInfo
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  CalibrationInfo() = default;
+
+  /** @brief The joint origin calibration information */
+  tesseract_common::TransformMap joints;
+
+  /** @brief Insert the content of an other CalibrationInfo */
+  void insert(const CalibrationInfo& other);
+
+  /** @brief Clear the contents */
+  void clear();
+
+  /** @brief Check if structure is empty */
+  bool empty() const;
+
+  // Yaml Config key
+  static inline const std::string CONFIG_KEY{ "calibration" };
+};
 }  // namespace tesseract_common
 
 #endif  // TESSERACT_COMMON_TYPES_H

--- a/tesseract_common/include/tesseract_common/types.h
+++ b/tesseract_common/include/tesseract_common/types.h
@@ -168,7 +168,11 @@ struct CalibrationInfo
 
   CalibrationInfo() = default;
 
-  /** @brief The joint origin calibration information */
+  /**
+   *  @brief The joint origin calibration information
+   *  @details For each entry in \p joints the environment will apply a ChangeJointOriginCommand replacing the current
+   * joint origin with what is stored in the TransformMap
+   */
   tesseract_common::TransformMap joints;
 
   /** @brief Insert the content of an other CalibrationInfo */

--- a/tesseract_common/include/tesseract_common/yaml_utils.h
+++ b/tesseract_common/include/tesseract_common/yaml_utils.h
@@ -498,9 +498,6 @@ struct convert<tesseract_common::CalibrationInfo>
   {
     const YAML::Node& joints_node = node["joints"];
 
-    if (!joints_node.IsMap())
-      return false;
-
     rhs.joints = joints_node.as<tesseract_common::TransformMap>();
 
     return true;

--- a/tesseract_common/include/tesseract_common/yaml_utils.h
+++ b/tesseract_common/include/tesseract_common/yaml_utils.h
@@ -458,6 +458,54 @@ struct convert<tesseract_common::ContactManagersPluginInfo>
     return true;
   }
 };
+
+template <>
+struct convert<tesseract_common::TransformMap>
+{
+  static Node encode(const tesseract_common::TransformMap& rhs)
+  {
+    Node node;
+    for (const auto& pair : rhs)
+      node[pair.first] = pair.second;
+
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_common::TransformMap& rhs)
+  {
+    if (!node.IsMap())
+      return false;
+
+    for (const auto& pair : node)
+      rhs[pair.first.as<std::string>()] = pair.second.as<Eigen::Isometry3d>();
+
+    return true;
+  }
+};
+
+template <>
+struct convert<tesseract_common::CalibrationInfo>
+{
+  static Node encode(const tesseract_common::CalibrationInfo& rhs)
+  {
+    Node node;
+    node["joints"] = rhs.joints;
+
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_common::CalibrationInfo& rhs)
+  {
+    const YAML::Node& joints_node = node["joints"];
+
+    if (!joints_node.IsMap())
+      return false;
+
+    rhs.joints = joints_node.as<tesseract_common::TransformMap>();
+
+    return true;
+  }
+};
 }  // namespace YAML
 
 #endif  // TESSERACT_COMMON_YAML_UTILS_H

--- a/tesseract_common/src/types.cpp
+++ b/tesseract_common/src/types.cpp
@@ -85,6 +85,12 @@ bool ContactManagersPluginInfo::empty() const
           continuous_plugin_infos.plugins.empty());
 }
 
+void CalibrationInfo::insert(const CalibrationInfo& other) { joints.insert(other.joints.begin(), other.joints.end()); }
+
+void CalibrationInfo::clear() { joints.clear(); }
+
+bool CalibrationInfo::empty() const { return joints.empty(); }
+
 std::size_t PairHash::operator()(const LinkNamesPair& pair) const
 {
   return std::hash<std::string>()(pair.first + pair.second);

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -1557,6 +1557,49 @@ TEST(TesseractContactManagersFactoryUnit, ContactManagersPluginInfoYamlUnit)  //
   }
 }
 
+TEST(TesseractCommonUnit, CalibrationInfoYamlUnit)  // NOLINT
+{
+  std::string yaml_string =
+      R"(calibration:
+           joints:
+             joint_1:
+               position:
+                 x: 1
+                 y: 2
+                 z: 3
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1
+             joint_2:
+               position:
+                 x: 4
+                 y: 5
+                 z: 6
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1)";
+
+  YAML::Node node = YAML::Load(yaml_string);
+  auto cal_info = node[tesseract_common::CalibrationInfo::CONFIG_KEY].as<tesseract_common::CalibrationInfo>();
+  EXPECT_FALSE(cal_info.empty());
+  EXPECT_TRUE(cal_info.joints.find("joint_1") != cal_info.joints.end());
+  EXPECT_TRUE(cal_info.joints.find("joint_2") != cal_info.joints.end());
+
+  tesseract_common::CalibrationInfo cal_insert;
+  EXPECT_TRUE(cal_insert.empty());
+  cal_insert.insert(cal_info);
+  EXPECT_FALSE(cal_insert.empty());
+  EXPECT_TRUE(cal_insert.joints.find("joint_1") != cal_insert.joints.end());
+  EXPECT_TRUE(cal_insert.joints.find("joint_2") != cal_insert.joints.end());
+
+  cal_info.clear();
+  EXPECT_TRUE(cal_info.empty());
+}
+
 TEST(TesseractCommonUnit, linkNamesPairUnit)  // NOLINT
 {
   tesseract_common::LinkNamesPair p1 = tesseract_common::makeOrderedLinkPair("link_1", "link_2");

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -1557,6 +1557,68 @@ TEST(TesseractContactManagersFactoryUnit, ContactManagersPluginInfoYamlUnit)  //
   }
 }
 
+TEST(TesseractCommonUnit, TransformMapYamlUnit)  // NOLINT
+{
+  std::string yaml_string =
+      R"(joints:
+           joint_1:
+             position:
+               x: 1
+               y: 2
+               z: 3
+             orientation:
+               x: 0
+               y: 0
+               z: 0
+               w: 1
+           joint_2:
+             position:
+               x: 4
+               y: 5
+               z: 6
+             orientation:
+               x: 0
+               y: 0
+               z: 0
+               w: 1)";
+
+  {  // valid string
+    YAML::Node node = YAML::Load(yaml_string);
+    auto trans_map = node["joints"].as<tesseract_common::TransformMap>();
+    EXPECT_EQ(trans_map.size(), 2);
+    EXPECT_FALSE(trans_map.empty());
+    EXPECT_TRUE(trans_map.find("joint_1") != trans_map.end());
+    EXPECT_TRUE(trans_map.find("joint_2") != trans_map.end());
+  }
+
+  std::string bad_yaml_string =
+      R"(joints:
+           - joint_1:
+               position:
+                 x: 1
+                 y: 2
+                 z: 3
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1
+           - joint_2:
+               position:
+                 x: 4
+                 y: 5
+                 z: 6
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1)";
+  {  // invalid string
+    YAML::Node node = YAML::Load(bad_yaml_string);
+    EXPECT_ANY_THROW(node["joints"].as<tesseract_common::TransformMap>());  // NOLINT
+  }
+}
+
 TEST(TesseractCommonUnit, CalibrationInfoYamlUnit)  // NOLINT
 {
   std::string yaml_string =

--- a/tesseract_common/test/utils_unit.cpp
+++ b/tesseract_common/test/utils_unit.cpp
@@ -7,7 +7,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_common/utils.h>
 
 /// Testing getAllowedCollisions
-TEST(TesseractSceneGraphUnit, TestGetAllowedCollisions)  // NOLINT
+TEST(TesseractCommonUtilsUnit, TestGetAllowedCollisions)  // NOLINT
 {
   tesseract_common::AllowedCollisionMatrix acm;
 

--- a/tesseract_environment/src/environment.cpp
+++ b/tesseract_environment/src/environment.cpp
@@ -257,6 +257,10 @@ Commands Environment::getInitCommands(const tesseract_scene_graph::SceneGraph& s
     commands.push_back(std::make_shared<AddContactManagersPluginInfoCommand>(srdf_model->contact_managers_plugin_info));
     commands.push_back(std::make_shared<AddKinematicsInformationCommand>(srdf_model->kinematics_information));
 
+    // Apply calibration information
+    for (const auto& cal : srdf_model->calibration_info.joints)
+      commands.push_back(std::make_shared<ChangeJointOriginCommand>(cal.first, cal.second));
+
     // Check srdf for collision margin data
     if (srdf_model->collision_margin_data)
       commands.push_back(std::make_shared<ChangeCollisionMarginsCommand>(

--- a/tesseract_srdf/CMakeLists.txt
+++ b/tesseract_srdf/CMakeLists.txt
@@ -44,6 +44,7 @@ add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENA
 add_library(
   ${PROJECT_NAME}
   src/collision_margins.cpp
+  src/configs.cpp
   src/disabled_collisions.cpp
   src/group_states.cpp
   src/group_tool_center_points.cpp

--- a/tesseract_srdf/include/tesseract_srdf/configs.h
+++ b/tesseract_srdf/include/tesseract_srdf/configs.h
@@ -1,0 +1,96 @@
+/**
+ * @file collision_margins.h
+ * @brief Parse config files
+ *
+ * @author Levi Armstrong
+ * @date January 25, 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2022, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_SRDF_CONFIGS_H
+#define TESSERACT_SRDF_CONFIGS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <array>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/types.h>
+#include <tesseract_common/resource_locator.h>
+
+namespace tinyxml2
+{
+class XMLElement;
+}
+namespace tesseract_scene_graph
+{
+class SceneGraph;
+}
+
+namespace tesseract_srdf
+{
+/**
+ * @brief Parse a config xml element
+ * @details It expects the element to have the attribute 'filename'
+ * @param locator The locator used to process the file name URL
+ * @param xml_element The xml element to process
+ * @param version The SRDF version
+ * @return The extracted file path
+ */
+tesseract_common::fs::path parseConfigFilePath(const tesseract_common::ResourceLocator& locator,
+                                               const tinyxml2::XMLElement* xml_element,
+                                               const std::array<int, 3>& version);
+
+/**
+ * @brief Parse calibration config xml element
+ * @param scene_graph The scene graph
+ * @param locator The locator used to process the file name URL
+ * @param xml_element The xml element to process
+ * @param version The SRDF version
+ * @return The calibration information
+ */
+tesseract_common::CalibrationInfo parseCalibrationConfig(const tesseract_scene_graph::SceneGraph& scene_graph,
+                                                         const tesseract_common::ResourceLocator& locator,
+                                                         const tinyxml2::XMLElement* xml_element,
+                                                         const std::array<int, 3>& version);
+
+/**
+ * @brief Parse kinematics plugin config xml element
+ * @param locator The locator used to process the file name URL
+ * @param xml_element The xml element to process
+ * @param version The SRDF version
+ * @return The kinematics plugin information
+ */
+tesseract_common::KinematicsPluginInfo parseKinematicsPluginConfig(const tesseract_common::ResourceLocator& locator,
+                                                                   const tinyxml2::XMLElement* xml_element,
+                                                                   const std::array<int, 3>& version);
+
+/**
+ * @brief Parse contact managers plugin config xml element
+ * @param locator The locator used to process the file name URL
+ * @param xml_element The xml element to process
+ * @param version The SRDF version
+ * @return The contact managers plugin information
+ */
+tesseract_common::ContactManagersPluginInfo
+parseContactManagersPluginConfig(const tesseract_common::ResourceLocator& locator,
+                                 const tinyxml2::XMLElement* xml_element,
+                                 const std::array<int, 3>& version);
+}  // namespace tesseract_srdf
+#endif  // TESSERACT_SRDF_CONFIGS_H

--- a/tesseract_srdf/include/tesseract_srdf/srdf_model.h
+++ b/tesseract_srdf/include/tesseract_srdf/srdf_model.h
@@ -108,6 +108,9 @@ public:
 
   /** @brief Collision margin data */
   tesseract_common::CollisionMarginData::Ptr collision_margin_data;
+
+  /** @brief The calibration information */
+  tesseract_common::CalibrationInfo calibration_info;
 };
 
 }  // namespace tesseract_srdf

--- a/tesseract_srdf/src/configs.cpp
+++ b/tesseract_srdf/src/configs.cpp
@@ -1,0 +1,139 @@
+/**
+ * @file collision_margins.h
+ * @brief Parse config files
+ *
+ * @author Levi Armstrong
+ * @date January 25, 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2022, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <console_bridge/console.h>
+#include <tinyxml2.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_scene_graph/graph.h>
+#include <tesseract_common/utils.h>
+#include <tesseract_common/yaml_utils.h>
+#include <tesseract_srdf/configs.h>
+
+namespace tesseract_srdf
+{
+tesseract_common::fs::path parseConfigFilePath(const tesseract_common::ResourceLocator& locator,
+                                               const tinyxml2::XMLElement* xml_element,
+                                               const std::array<int, 3>& /*version*/)
+{
+  std::string filename;
+  tinyxml2::XMLError status = tesseract_common::QueryStringAttributeRequired(xml_element, "filename", filename);
+  if (status != tinyxml2::XML_SUCCESS)
+    std::throw_with_nested(std::runtime_error(std::string(xml_element->Value()) + ": Missing or failed to parse "
+                                                                                  "'filename' attribute."));
+
+  tesseract_common::Resource::Ptr resource = locator.locateResource(filename);
+  if (resource == nullptr)
+    std::throw_with_nested(
+        std::runtime_error(std::string(xml_element->Value()) + ": Failed to locate resource '" + filename + "'."));
+
+  tesseract_common::fs::path file_path(resource->getFilePath());
+  if (!tesseract_common::fs::exists(file_path))
+    std::throw_with_nested(std::runtime_error(std::string(xml_element->Value()) +
+                                              ": config file does not exist: "
+                                              "'" +
+                                              file_path.string() + "'."));
+  return file_path;
+}
+
+tesseract_common::CalibrationInfo parseCalibrationConfig(const tesseract_scene_graph::SceneGraph& scene_graph,
+                                                         const tesseract_common::ResourceLocator& locator,
+                                                         const tinyxml2::XMLElement* xml_element,
+                                                         const std::array<int, 3>& version)
+{
+  tesseract_common::fs::path cal_config_file_path = parseConfigFilePath(locator, xml_element, version);
+  YAML::Node config;
+  try
+  {
+    config = YAML::LoadFile(cal_config_file_path.string());
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("calibration_config: YAML failed to parse calibration config "
+                                              "file '" +
+                                              cal_config_file_path.string() + "'."));
+  }
+
+  const YAML::Node& cal_info = config[tesseract_common::CalibrationInfo::CONFIG_KEY];
+  auto info = cal_info.as<tesseract_common::CalibrationInfo>();
+
+  // Check to make sure calibration joints exist
+  for (const auto& cal_joint : info.joints)
+  {
+    if (scene_graph.getJoint(cal_joint.first) == nullptr)
+      std::throw_with_nested(std::runtime_error("calibration_config: joint '" + cal_joint.first + "' does not exist!"));
+  }
+
+  return info;
+}
+
+tesseract_common::KinematicsPluginInfo parseKinematicsPluginConfig(const tesseract_common::ResourceLocator& locator,
+                                                                   const tinyxml2::XMLElement* xml_element,
+                                                                   const std::array<int, 3>& version)
+{
+  tesseract_common::fs::path kin_plugin_file_path = parseConfigFilePath(locator, xml_element, version);
+  YAML::Node config;
+  try
+  {
+    config = YAML::LoadFile(kin_plugin_file_path.string());
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("kinematics_plugin_config: YAML failed to parse kinematics plugins "
+                                              "file '" +
+                                              kin_plugin_file_path.string() + "'."));
+  }
+
+  const YAML::Node& kin_plugin_info = config[tesseract_common::KinematicsPluginInfo::CONFIG_KEY];
+
+  return kin_plugin_info.as<tesseract_common::KinematicsPluginInfo>();
+}
+
+tesseract_common::ContactManagersPluginInfo
+parseContactManagersPluginConfig(const tesseract_common::ResourceLocator& locator,
+                                 const tinyxml2::XMLElement* xml_element,
+                                 const std::array<int, 3>& version)
+{
+  tesseract_common::fs::path cm_plugin_file_path = parseConfigFilePath(locator, xml_element, version);
+  YAML::Node config;
+  try
+  {
+    config = YAML::LoadFile(cm_plugin_file_path.string());
+  }
+  catch (...)
+  {
+    std::throw_with_nested(std::runtime_error("contact_managers_plugin_config: YAML failed to parse contact "
+                                              "managers plugins "
+                                              "file '" +
+                                              cm_plugin_file_path.string() + "'."));
+  }
+
+  const YAML::Node& cm_plugin_info = config[tesseract_common::ContactManagersPluginInfo::CONFIG_KEY];
+  return cm_plugin_info.as<tesseract_common::ContactManagersPluginInfo>();
+}
+}  // namespace tesseract_srdf

--- a/tesseract_srdf/test/tesseract_srdf_unit.cpp
+++ b/tesseract_srdf/test/tesseract_srdf_unit.cpp
@@ -592,25 +592,29 @@ TEST(TesseractSRDFUnit, LoadSRDFSaveUnit)  // NOLINT
       R"(kinematic_plugins:
            fwd_kin_plugins:
              manipulator:
-               KDLFwdKinChain:
-                 class: KDLFwdKinChainFactory
-                 default: true
-                 config:
-                   base_link: base_link
-                   tip_link: tool0
+               default: KDLFwdKinChain
+               plugins:
+                 KDLFwdKinChain:
+                   class: KDLFwdKinChainFactory
+                   default: true
+                   config:
+                     base_link: base_link
+                     tip_link: tool0
            inv_kin_plugins:
              manipulator:
-               KDLInvKinChainLMA:
-                 class: KDLInvKinChainLMAFactory
-                 default: true
-                 config:
-                   base_link: base_link
-                   tip_link: tool0
-               KDLInvKinChainNR:
-                 class: KDLInvKinChainNRFactory
-                 config:
-                   base_link: base_link
-                   tip_link: tool0)";
+               default: KDLInvKinChainLMA
+               plugins:
+                 KDLInvKinChainLMA:
+                   class: KDLInvKinChainLMAFactory
+                   default: true
+                   config:
+                     base_link: base_link
+                     tip_link: tool0
+                 KDLInvKinChainNR:
+                   class: KDLInvKinChainNRFactory
+                   config:
+                     base_link: base_link
+                     tip_link: tool0)";
 
   std::string yaml_cm_plugins_string =
       R"(contact_manager_plugins:
@@ -620,19 +624,47 @@ TEST(TesseractSRDFUnit, LoadSRDFSaveUnit)  // NOLINT
              - tesseract_collision_bullet_factories
              - tesseract_collision_fcl_factories
            discrete_plugins:
-             BulletDiscreteBVHManager:
-               class: BulletDiscreteBVHManagerFactory
-               default: true
-             BulletDiscreteSimpleManager:
-               class: BulletDiscreteSimpleManagerFactory
-             FCLDiscreteBVHManager:
-               class: FCLDiscreteBVHManagerFactory
+             default: BulletDiscreteBVHManager
+             plugins:
+               BulletDiscreteBVHManager:
+                 class: BulletDiscreteBVHManagerFactory
+                 default: true
+               BulletDiscreteSimpleManager:
+                 class: BulletDiscreteSimpleManagerFactory
+               FCLDiscreteBVHManager:
+                 class: FCLDiscreteBVHManagerFactory
            continuous_plugins:
-             BulletCastBVHManager:
-               class: BulletCastBVHManagerFactory
-               default: true
-             BulletCastSimpleManager:
-               class: BulletCastSimpleManagerFactory)";
+             default: BulletCastBVHManager
+             plugins:
+               BulletCastBVHManager:
+                 class: BulletCastBVHManagerFactory
+                 default: true
+               BulletCastSimpleManager:
+                 class: BulletCastSimpleManagerFactory)";
+
+  std::string yaml_calibration_string =
+      R"(calibration:
+           joints:
+             joint_1:
+               position:
+                 x: 1
+                 y: 2
+                 z: 3
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1
+             joint_2:
+               position:
+                 x: 4
+                 y: 5
+                 z: 6
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1)";
 
   SRDFModel srdf_save;
   srdf_save.initString(*g, xml_string, locator);
@@ -645,6 +677,9 @@ TEST(TesseractSRDFUnit, LoadSRDFSaveUnit)  // NOLINT
   srdf_save.contact_managers_plugin_info =
       contact_managers_plugin_config[ContactManagersPluginInfo::CONFIG_KEY].as<ContactManagersPluginInfo>();
 
+  YAML::Node calibration_config = YAML::Load(yaml_calibration_string);
+  srdf_save.calibration_info = calibration_config[CalibrationInfo::CONFIG_KEY].as<CalibrationInfo>();
+
   std::string save_path = tesseract_common::getTempPath() + "unit_test_save_srdf.srdf";
   EXPECT_TRUE(srdf_save.saveToFile(save_path));
 
@@ -655,8 +690,9 @@ TEST(TesseractSRDFUnit, LoadSRDFSaveUnit)  // NOLINT
   EXPECT_EQ(srdf.version[1], 0);
   EXPECT_EQ(srdf.version[2], 0);
 
-  EXPECT_FALSE(srdf_save.kinematics_information.kinematics_plugin_info.empty());
-  EXPECT_FALSE(srdf_save.contact_managers_plugin_info.empty());
+  EXPECT_FALSE(srdf.kinematics_information.kinematics_plugin_info.empty());
+  EXPECT_FALSE(srdf.contact_managers_plugin_info.empty());
+  EXPECT_FALSE(srdf.calibration_info.empty());
 
   processSRDFAllowedCollisions(*g, srdf);
 
@@ -702,6 +738,39 @@ TEST(TesseractSRDFUnit, LoadSRDFSaveUnit)  // NOLINT
   EXPECT_EQ(srdf.collision_margin_data->getPairCollisionMargins().size(), 2);
   EXPECT_NEAR(srdf.collision_margin_data->getPairCollisionMargin("link_5", "link_6"), 0.01, 1e-6);
   EXPECT_NEAR(srdf.collision_margin_data->getPairCollisionMargin("link_5", "link_4"), 0.015, 1e-6);
+
+  // Calibration failure joint does not exist
+  yaml_calibration_string =
+      R"(calibration:
+           joints:
+             does_not_exist:
+               position:
+                 x: 1
+                 y: 2
+                 z: 3
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1
+             joint_2:
+               position:
+                 x: 4
+                 y: 5
+                 z: 6
+               orientation:
+                 x: 0
+                 y: 0
+                 z: 0
+                 w: 1)";
+  YAML::Node bad_calibration_config = YAML::Load(yaml_calibration_string);
+  srdf_save.calibration_info = bad_calibration_config[CalibrationInfo::CONFIG_KEY].as<CalibrationInfo>();
+
+  save_path = tesseract_common::getTempPath() + "unit_test_save_bad_srdf.srdf";
+  EXPECT_TRUE(srdf_save.saveToFile(save_path));
+
+  SRDFModel bad_srdf;
+  EXPECT_ANY_THROW(bad_srdf.initFile(*g, save_path, locator));  // NOLINT
 }
 
 TEST(TesseractSRDFUnit, LoadSRDFAllowedCollisionMatrixUnit)  // NOLINT

--- a/tesseract_support/urdf/abb_irb2400_calibration.yaml
+++ b/tesseract_support/urdf/abb_irb2400_calibration.yaml
@@ -1,0 +1,22 @@
+calibration:
+  joints:
+    joint_1:
+      position:
+        x: 1
+        y: 2
+        z: 3
+      orientation:
+        x: 0
+        y: 0
+        z: 0
+        w: 1
+    joint_2:
+      position:
+        x: 4
+        y: 5
+        z: 6
+      orientation:
+        x: 0
+        y: 0
+        z: 0
+        w: 1

--- a/tesseract_support/urdf/malformed_config.yaml
+++ b/tesseract_support/urdf/malformed_config.yaml
@@ -1,0 +1,7 @@
+<joint name="joint_2" type="revolute">
+  <origin rpy="0 0 0" xyz="0.1 0 0.615"/>
+  <parent link="link_1"/>
+  <child link="link_2"/>
+  <axis xyz="0 1 0"/>
+  <limit effort="0" lower="-1.7453" upper="1.9199" velocity="2.618"/>
+</joint>


### PR DESCRIPTION
The current calibration config support defining a joint origin in a yaml config file which gets loaded through the srdf. In the environment it will apply these as a `ChangeJointOriginCommand`.

``` yaml
calibration:
  joints:
    joint_1:
      position:
        x: 1
        y: 2
        z: 3
      orientation:
        x: 0
        y: 0
        z: 0
        w: 1
    joint_2:
      position:
        x: 4
        y: 5
        z: 6
      orientation:
        x: 0
        y: 0
        z: 0
        w: 1
```

srdf element:
``` xml
<calibration_config filename="calibration_config.yaml"/>
```
