### PR TITLE
A few fixes that were needed for Windows

### DIFF
--- a/tesseract_collision/bullet/CMakeLists.txt
+++ b/tesseract_collision/bullet/CMakeLists.txt
@@ -12,14 +12,30 @@ if(NOT
     WARNING "Bullet does not appear to be build with double precision, current definitions: ${BULLET_DEFINITIONS}")
 endif()
 
-if(WIN32) # This was required for windows to find things in tesseract_ext before the system which is an issue in ros-win
-  include_directories(BEFORE "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
-  link_directories(BEFORE "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS}")
+# Some Bullet installations (vcpkg) use absolute paths instead of relative to BULLET_ROOT_DIR in the CMake vars
+set(BULLET_INCLUDE_DIRS_ABS "")
+set(BULLET_LIBRARY_DIRS_ABS "")
+if(NOT IS_ABSOLUTE "${BULLET_INCLUDE_DIR}")
+  foreach(dir IN LISTS BULLET_INCLUDE_DIRS)
+    list(APPEND BULLET_INCLUDE_DIRS_ABS "${BULLET_ROOT_DIR}/${dir}")
+  endforeach()
+  foreach(dir IN LISTS BULLET_LIBRARY_DIRS)
+    list(APPEND BULLET_LIBRARY_DIRS_ABS "${BULLET_ROOT_DIR}/${dir}")
+  endforeach()
+else()
+  set(BULLET_INCLUDE_DIRS_ABS ${BULLET_INCLUDE_DIRS})
+  set(BULLET_LIBRARY_DIRS_ABS ${BULLET_LIBRARY_DIRS})
 endif()
 
-find_library(HACD_LIBRARY HACD HINTS ${BULLET_LIBRARY_DIRS})
+if(WIN32) # This was required for windows to find things in tesseract_ext before the system which is an issue in ros-win
+  include_directories(BEFORE "${BULLET_INCLUDE_DIRS_ABS}")
+  link_directories(BEFORE "${BULLET_LIBRARY_DIRS_ABS}")
+endif()
+
+find_library(HACD_LIBRARY HACD HINTS ${BULLET_LIBRARY_DIRS_ABS})
 if(NOT HACD_LIBRARY)
-  message(WARNING "HACD not found! Convex decomposition library will not be built. Install libbullet-extras-dev on Linux.")
+  message(
+    WARNING "HACD not found! Convex decomposition library will not be built. Install libbullet-extras-dev on Linux.")
 endif()
 
 # Create target for Bullet implementation
@@ -57,7 +73,7 @@ target_code_coverage(
   ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 target_include_directories(${PROJECT_NAME}_bullet PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                          "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_bullet SYSTEM PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+target_include_directories(${PROJECT_NAME}_bullet SYSTEM PUBLIC "${BULLET_INCLUDE_DIRS_ABS}")
 
 # Create target for Bullet implementation
 add_library(${PROJECT_NAME}_bullet_factories src/bullet_factories.cpp)
@@ -76,10 +92,10 @@ target_code_coverage(
 target_include_directories(
   ${PROJECT_NAME}_bullet_factories PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                           "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_bullet_factories SYSTEM PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+target_include_directories(${PROJECT_NAME}_bullet_factories SYSTEM PUBLIC "${BULLET_INCLUDE_DIRS_ABS}")
 
 # Convex decomposition libraries
-if (${HACD_LIBRARY})
+if(${HACD_LIBRARY})
   add_library(${PROJECT_NAME}_hacd_convex_decomposition src/convex_decomposition_hacd.cpp)
   target_link_libraries(
     ${PROJECT_NAME}_hacd_convex_decomposition
@@ -103,8 +119,7 @@ if (${HACD_LIBRARY})
   target_include_directories(
     ${PROJECT_NAME}_hacd_convex_decomposition PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                      "$<INSTALL_INTERFACE:include>")
-  target_include_directories(${PROJECT_NAME}_hacd_convex_decomposition SYSTEM
-                             PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+  target_include_directories(${PROJECT_NAME}_hacd_convex_decomposition SYSTEM PUBLIC "${BULLET_INCLUDE_DIRS_ABS}")
   install_targets(TARGETS ${PROJECT_NAME}_hacd_convex_decomposition)
 endif()
 
@@ -148,8 +163,4 @@ install(
   PATTERN "*.inl"
   PATTERN ".svn" EXCLUDE)
 
-install_targets(
-  TARGETS
-  ${PROJECT_NAME}_bullet
-  ${PROJECT_NAME}_bullet_factories
-)
+install_targets(TARGETS ${PROJECT_NAME}_bullet ${PROJECT_NAME}_bullet_factories)

--- a/tesseract_collision/bullet/CMakeLists.txt
+++ b/tesseract_collision/bullet/CMakeLists.txt
@@ -17,14 +17,9 @@ if(WIN32) # This was required for windows to find things in tesseract_ext before
   link_directories(BEFORE "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS}")
 endif()
 
-find_library(CONVEX_DECOMPOSITION_LIBRARY ConvexDecomposition HINTS ${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS})
-if(NOT CONVEX_DECOMPOSITION_LIBRARY)
-  message(FATAL_ERROR "ConvexDecomposition not found! Install libbullet-extras-dev.")
-endif()
-
-find_library(HACD_LIBRARY HACD HINTS ${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS})
+find_library(HACD_LIBRARY HACD HINTS ${BULLET_LIBRARY_DIRS})
 if(NOT HACD_LIBRARY)
-  message(FATAL_ERROR "HACD not found! Install libbullet-extras-dev.")
+  message(WARNING "HACD not found! Convex decomposition library will not be built. Install libbullet-extras-dev on Linux.")
 endif()
 
 # Create target for Bullet implementation
@@ -84,31 +79,34 @@ target_include_directories(
 target_include_directories(${PROJECT_NAME}_bullet_factories SYSTEM PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
 
 # Convex decomposition libraries
-add_library(${PROJECT_NAME}_hacd_convex_decomposition src/convex_decomposition_hacd.cpp)
-target_link_libraries(
-  ${PROJECT_NAME}_hacd_convex_decomposition
-  PUBLIC ${PROJECT_NAME}_bullet
-         Eigen3::Eigen
-         tesseract::tesseract_geometry
-         console_bridge::console_bridge
-         ${BULLET_LIBRARIES}
-         ${HACD_LIBRARY})
-target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
-target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
-target_compile_definitions(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_DEFINITIONS}
-                                                                            ${BULLET_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_hacd_convex_decomposition ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
-target_cxx_version(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC VERSION ${TESSERACT_CXX_VERSION})
-target_code_coverage(
-  ${PROJECT_NAME}_hacd_convex_decomposition
-  ALL
-  EXCLUDE ${COVERAGE_EXCLUDE}
-  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-target_include_directories(
-  ${PROJECT_NAME}_hacd_convex_decomposition PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                                                   "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_hacd_convex_decomposition SYSTEM
-                           PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+if (${HACD_LIBRARY})
+  add_library(${PROJECT_NAME}_hacd_convex_decomposition src/convex_decomposition_hacd.cpp)
+  target_link_libraries(
+    ${PROJECT_NAME}_hacd_convex_decomposition
+    PUBLIC ${PROJECT_NAME}_bullet
+           Eigen3::Eigen
+           tesseract::tesseract_geometry
+           console_bridge::console_bridge
+           ${BULLET_LIBRARIES}
+           ${HACD_LIBRARY})
+  target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
+  target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+  target_compile_definitions(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_DEFINITIONS}
+                                                                              ${BULLET_DEFINITIONS})
+  target_clang_tidy(${PROJECT_NAME}_hacd_convex_decomposition ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+  target_cxx_version(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+  target_code_coverage(
+    ${PROJECT_NAME}_hacd_convex_decomposition
+    ALL
+    EXCLUDE ${COVERAGE_EXCLUDE}
+    ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+  target_include_directories(
+    ${PROJECT_NAME}_hacd_convex_decomposition PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                     "$<INSTALL_INTERFACE:include>")
+  target_include_directories(${PROJECT_NAME}_hacd_convex_decomposition SYSTEM
+                             PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+  install_targets(TARGETS ${PROJECT_NAME}_hacd_convex_decomposition)
+endif()
 
 if(NOT MSVC)
   # Create target for creating convex hulls from meshes
@@ -154,4 +152,4 @@ install_targets(
   TARGETS
   ${PROJECT_NAME}_bullet
   ${PROJECT_NAME}_bullet_factories
-  ${PROJECT_NAME}_hacd_convex_decomposition)
+)

--- a/tesseract_environment/include/tesseract_environment/commands/add_allowed_collision_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/add_allowed_collision_command.h
@@ -29,6 +29,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
+#include <string>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_environment/command.h>


### PR DESCRIPTION
The three commits here:

- Bullet extras are not easily obtained on Windows so this makes building the HACD convex decomposition library optional
- Paths to bullet are specified as `${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}`, e.g., but the include dirs already contains absolute paths. ~Probably this wasn't noticed on Ubuntu since it would already be looking in the system install dirs.~ This is a result of packaging for vcpkg and is different from the version packaged for Ubuntu.
- Had a compile error since a header used but didn't include `std::string`