### PR TITLE
Sort ACM alphabetically when writing

### DIFF
--- a/tesseract_srdf/include/tesseract_srdf/utils.h
+++ b/tesseract_srdf/include/tesseract_srdf/utils.h
@@ -26,6 +26,9 @@
 #ifndef TESSERACT_SRDF_UTILS_H
 #define TESSERACT_SRDF_UTILS_H
 
+#include <functional>
+#include <tesseract_common/allowed_collision_matrix.h>
+#include <tesseract_common/types.h>
 #include <tesseract_scene_graph/graph.h>
 #include <tesseract_srdf/srdf_model.h>
 
@@ -38,5 +41,21 @@ namespace tesseract_srdf
  */
 void processSRDFAllowedCollisions(tesseract_scene_graph::SceneGraph& scene_graph, const SRDFModel& srdf_model);
 
+/**
+ * @brief Used to sort a pair of strings alphabetically - first by the pair.first and then by pair.second
+ * @param pair1 First pair of strings
+ * @param pair2 Second pair of strings
+ * @return True if pair1 should go before pair2 (is closer to A)
+ */
+bool compareLinkPairAlphabetically(std::reference_wrapper<const tesseract_common::LinkNamesPair> pair1,
+                                   std::reference_wrapper<const tesseract_common::LinkNamesPair> pair2);
+
+/**
+ * @brief Returns an alphabetically sorted vector of ACM keys (the link pairs)
+ * @param allowed_collision_entries Entries to be sorted
+ * @return An alphabetically sorted vector of ACM keys (the link pairs)
+ */
+std::vector<std::reference_wrapper<const tesseract_common::LinkNamesPair>>
+getAlphabeticalACMKeys(const tesseract_common::AllowedCollisionEntries& allowed_collision_entries);
 }  // namespace tesseract_srdf
 #endif  // TESSERACT_SRDF_UTILS_H

--- a/tesseract_srdf/src/srdf_model.cpp
+++ b/tesseract_srdf/src/srdf_model.cpp
@@ -44,6 +44,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_srdf/collision_margins.h>
 #include <tesseract_srdf/configs.h>
 #include <tesseract_srdf/srdf_model.h>
+#include <tesseract_srdf/utils.h>
 #include <tesseract_common/utils.h>
 #include <tesseract_common/yaml_utils.h>
 
@@ -357,12 +358,15 @@ bool SRDFModel::saveToFile(const std::string& file_path) const
     xml_root->InsertEndChild(xml_cal_info_entry);
   }
 
-  for (const auto& entry : acm.getAllAllowedCollisions())
+  // Write the ACM
+  const auto allowed_collision_entries = acm.getAllAllowedCollisions();
+  auto acm_keys = getAlphabeticalACMKeys(allowed_collision_entries);
+  for (const auto& key : acm_keys)
   {
     tinyxml2::XMLElement* xml_acm_entry = doc.NewElement("disable_collisions");
-    xml_acm_entry->SetAttribute("link1", entry.first.first.c_str());
-    xml_acm_entry->SetAttribute("link2", entry.first.second.c_str());
-    xml_acm_entry->SetAttribute("reason", entry.second.c_str());
+    xml_acm_entry->SetAttribute("link1", key.get().first.c_str());
+    xml_acm_entry->SetAttribute("link2", key.get().second.c_str());
+    xml_acm_entry->SetAttribute("reason", allowed_collision_entries.at(key.get()).c_str());
     xml_root->InsertEndChild(xml_acm_entry);
   }
 

--- a/tesseract_srdf/src/utils.cpp
+++ b/tesseract_srdf/src/utils.cpp
@@ -33,4 +33,33 @@ void processSRDFAllowedCollisions(tesseract_scene_graph::SceneGraph& scene_graph
     scene_graph.addAllowedCollision(pair.first.first, pair.first.second, pair.second);
 }
 
+bool compareLinkPairAlphabetically(std::reference_wrapper<const tesseract_common::LinkNamesPair> pair1,
+                                   std::reference_wrapper<const tesseract_common::LinkNamesPair> pair2)
+{
+  // Sort first by the first string
+  if (pair1.get().first != pair2.get().first)
+  {
+    return pair1.get().first < pair2.get().first;
+  }
+
+  // Then sort by the second
+  return pair1.get().second < pair2.get().second;
+}
+
+std::vector<std::reference_wrapper<const tesseract_common::LinkNamesPair>>
+getAlphabeticalACMKeys(const tesseract_common::AllowedCollisionEntries& allowed_collision_entries)
+{
+  std::vector<std::reference_wrapper<const tesseract_common::LinkNamesPair>> acm_keys;
+  acm_keys.reserve(allowed_collision_entries.size());
+  for (const auto& acm_pair : allowed_collision_entries)
+  {
+    acm_keys.push_back(std::ref(acm_pair.first));
+  }
+
+  // Sort the keys alphabetically
+  sort(acm_keys.begin(), acm_keys.end(), compareLinkPairAlphabetically);
+
+  return acm_keys;
+}
+
 }  // namespace tesseract_srdf

--- a/tesseract_srdf/test/tesseract_srdf_unit.cpp
+++ b/tesseract_srdf/test/tesseract_srdf_unit.cpp
@@ -427,11 +427,12 @@ TEST(TesseractSRDFUnit, TesseractSRDFModelUnit)  // NOLINT
   // Add disabled collisions
   auto& acm = srdf.acm;
   EXPECT_TRUE(acm.getAllAllowedCollisions().empty());
-  acm.addAllowedCollision("base_link", "link_1", "Adjacent");
+  acm.addAllowedCollision("link_1", "link_3", "Adjacent");
   acm.addAllowedCollision("link_1", "link_2", "Adjacent");
   acm.addAllowedCollision("link_2", "link_3", "Adjacent");
   acm.addAllowedCollision("link_3", "link_4", "Adjacent");
   acm.addAllowedCollision("link_4", "link_5", "Adjacent");
+  acm.addAllowedCollision("base_link", "link_1", "Adjacent");
   EXPECT_FALSE(acm.getAllAllowedCollisions().empty());
   srdf.saveToFile(tesseract_common::getTempPath() + "test.srdf");
 


### PR DESCRIPTION
Sorts the ACM alphabetically when writing it. This is motivated by [this](https://github.com/tesseract-robotics/tesseract_ignition/issues/8) issue. With this change the allowed collisions in the generated SRDF will be sorted alphabetically first by the first link and then by the second link. This does not address that I assume it is possible that which link is the first/second link in the pair could be flipped. We may want to address that in the future too if we want generated SRDFs to be the same run to run. That could be done here, but it might make more sense to do that when we create the pairs.