### PR TITLE
Use windows-2019 for github action

### DIFF
--- a/.github/workflows/windows_noetic_build.yml
+++ b/.github/workflows/windows_noetic_build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   windows_ci:
     name: Noetic
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       ROS_DISTRO: noetic
     steps:


### PR DESCRIPTION
`windows-latest` is defaulting to `windows-2022` for the Windows GitHub CI action. ROS Noetic uses Visual Studio 2019, so change instance to `windows-2019` in `windows_noetic_build.yml`.