### PR TITLE
Fix Boost_VERSION in tesseract_urdf to check for Boost_VERSION_MACRO

### DIFF
--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -94,8 +94,13 @@ target_code_coverage(
 
 # PCL does not support c++11 on Xenial so cannot include point cloud parsing from urdf Boost version number is in XYYYZZ
 # format such that: (BOOST_VERSION % 100) is the sub-minor version ((BOOST_VERSION / 100) % 1000) is the minor version
-# (BOOST_VERSION / 100000) is the major version.
-if(Boost_VERSION VERSION_GREATER "1.60.0")
+# (BOOST_VERSION_MACRO / 100000) is the major version.
+if(Boost_VERSION_MACRO)
+set(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION_MACRO})
+else(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION_MACRO})
+set(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION})
+endif()
+if(TESSERACT_Boost_VERSION_MACRO VERSION_GREATER "106000")
   target_link_libraries(${PROJECT_NAME} PUBLIC ${PCL_LIBRARIES})
   target_compile_definitions(${PROJECT_NAME} PUBLIC TESSERACT_PARSE_POINT_CLOUDS="ON")
   foreach(DEF ${PCL_DEFINITIONS})

--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -96,9 +96,9 @@ target_code_coverage(
 # format such that: (BOOST_VERSION % 100) is the sub-minor version ((BOOST_VERSION / 100) % 1000) is the minor version
 # (BOOST_VERSION_MACRO / 100000) is the major version.
 if(Boost_VERSION_MACRO)
-set(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION_MACRO})
+  set(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION_MACRO})
 else(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION_MACRO})
-set(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION})
+  set(TESSERACT_Boost_VERSION_MACRO ${Boost_VERSION})
 endif()
 if(TESSERACT_Boost_VERSION_MACRO VERSION_GREATER "106000")
   target_link_libraries(${PROJECT_NAME} PUBLIC ${PCL_LIBRARIES})


### PR DESCRIPTION
This PR fixes the problem with #714 by checking for the existence of `Boost_VERSION_MACRO`

> This fix is not going to work with older versions of cmake. FindBoost returns Boost_VERSION in macro format up until cmake version 3.15, then changes to semver and adds Boost_VERSION_MACRO to return the old format. Ubuntu Bionic uses cmake 3.10, so it is going to cause a problem.
