### PR TITLE
Fix incorrect linking to console_bridge

### DIFF
--- a/tesseract_scene_graph/examples/CMakeLists.txt
+++ b/tesseract_scene_graph/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ target_link_libraries(
   ${PROJECT_NAME}_build_graph_example
   ${PROJECT_NAME}
   tesseract::tesseract_common
-  console_bridge)
+  console_bridge::console_bridge)
 target_compile_options(${PROJECT_NAME}_build_graph_example PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
                                                                    ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_clang_tidy(${PROJECT_NAME}_build_graph_example ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})


### PR DESCRIPTION
This popped up when building against a ROS2 source build. Not sure why it wasn't apparent before.