### PR TITLE
Update triggering of event callbacks to take a shared lock

### DIFF
--- a/tesseract_environment/include/tesseract_environment/environment.h
+++ b/tesseract_environment/include/tesseract_environment/environment.h
@@ -592,6 +592,18 @@ protected:
   /** This will notify the state solver that the environment has changed */
   void environmentChanged();
 
+  /**
+   * @brief @brief Passes a current state changed event to the callbacks
+   * @note This does not take a lock
+   */
+  void triggerCurrentStateChangedCallbacks();
+
+  /**
+   * @brief Passes a environment changed event to the callbacks
+   * @note This does not take a lock
+   */
+  void triggerEnvironmentChangedCallbacks();
+
 private:
   bool removeLinkHelper(const std::string& name);
 


### PR DESCRIPTION
The initial implementation called all of the event callback under a unique lock. This was problematic because you could not call any of the environment method without causing a dead lock. This updated so the event callback are under a shared lock so the environment can be accessed. 