### PR TITLE
Fix invalid iterator in bullet_cast_simple_manager

### DIFF
--- a/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
@@ -134,9 +134,7 @@ bool BulletCastSimpleManager::removeCollisionObject(const std::string& name)
   auto it = link2cow_.find(name);
   if (it != link2cow_.end())
   {
-    cows_.erase(std::find_if(cows_.begin(), cows_.end(), [&name](const auto& p) {
-      return p->getName() == name;
-    }));
+    cows_.erase(std::find_if(cows_.begin(), cows_.end(), [&name](const auto& p) { return p->getName() == name; }));
     collision_objects_.erase(std::find(collision_objects_.begin(), collision_objects_.end(), name));
     link2cow_.erase(name);
     link2castcow_.erase(name);

--- a/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
@@ -134,7 +134,9 @@ bool BulletCastSimpleManager::removeCollisionObject(const std::string& name)
   auto it = link2cow_.find(name);
   if (it != link2cow_.end())
   {
-    cows_.erase(std::find(cows_.begin(), cows_.end(), it->second));
+    cows_.erase(std::find_if(cows_.begin(), cows_.end(), [&name](const auto& p) {
+      return p->getName() == name;
+    }));
     collision_objects_.erase(std::find(collision_objects_.begin(), collision_objects_.end(), name));
     link2cow_.erase(name);
     link2castcow_.erase(name);


### PR DESCRIPTION
`cows_` in BulletCastSimpleManager sometimes uses `cast_cow` in one of the vectors instead of the uncast `cow`. This mismatch was resulting in a segfault on the lines changed. Search by name directly to avoid this problem.