### PR TITLE
Trajectory Collision Logging

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -534,6 +534,10 @@ struct ContactTrajectoryStepResults
  */
 struct ContactTrajectoryResults
 {
+  // LCOV_EXCL_START
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  // LCOV_EXCL_STOP
+
   ContactTrajectoryResults() = default;
   ContactTrajectoryResults(std::vector<std::string> j_names);
   ContactTrajectoryResults(std::vector<std::string> j_names, int num_steps);

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -469,6 +469,8 @@ struct ContactTrajectorySubstepResults
   ContactTrajectorySubstepResults(int substep, const Eigen::VectorXd& start_state, const Eigen::VectorXd& end_state);
   ContactTrajectorySubstepResults(int substep, const Eigen::VectorXd& state);
 
+  using UPtr = std::unique_ptr<ContactTrajectorySubstepResults>;
+
   int numContacts() const;
 
   tesseract_collision::ContactResultVector worstCollision() const;
@@ -489,6 +491,8 @@ struct ContactTrajectoryStepResults
                                const Eigen::VectorXd& end_state,
                                int num_substeps);
   ContactTrajectoryStepResults(int step_number, const Eigen::VectorXd& state);
+
+  using UPtr = std::unique_ptr<ContactTrajectoryStepResults>;
 
   void resize(int num_substeps);
 
@@ -514,6 +518,8 @@ struct ContactTrajectoryResults
   ContactTrajectoryResults() = default;
   ContactTrajectoryResults(std::vector<std::string> j_names);
   ContactTrajectoryResults(std::vector<std::string> j_names, int num_steps);
+
+  using UPtr = std::unique_ptr<ContactTrajectoryResults>;
 
   void resize(int num_steps);
 

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -460,6 +460,74 @@ struct CollisionCheckConfig
   /** @brief Secifies the mode used when collision checking program/trajectory. Default: ALL */
   CollisionCheckProgramType check_program_mode{ CollisionCheckProgramType::ALL };
 };
+
+struct ContactTrajectorySubstepResults
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ContactTrajectorySubstepResults() = default;
+  ContactTrajectorySubstepResults(const int& substep, Eigen::VectorXd start_state, Eigen::VectorXd end_state);
+  ContactTrajectorySubstepResults(const int& substep, Eigen::VectorXd state);
+
+  int numContacts() const;
+
+  tesseract_collision::ContactResultVector worstCollision() const;
+
+  tesseract_collision::ContactResultMap contacts;
+  int substep = -1;
+  Eigen::VectorXd state0;
+  Eigen::VectorXd state1;
+};
+
+struct ContactTrajectoryStepResults
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  ContactTrajectoryStepResults() = default;
+  ContactTrajectoryStepResults(const int& step_number,
+                               Eigen::VectorXd start_state,
+                               Eigen::VectorXd end_state,
+                               const int& num_substeps);
+  ContactTrajectoryStepResults(const int& step_number, const Eigen::VectorXd& state);
+  int numSubsteps() const;
+
+  int numContacts() const;
+
+  ContactTrajectorySubstepResults worstSubstep() const;
+
+  tesseract_collision::ContactResultVector worstCollision() const;
+
+  ContactTrajectorySubstepResults mostCollisionsSubstep() const;
+
+  std::vector<ContactTrajectorySubstepResults> substeps;
+  int step = -1;
+  Eigen::VectorXd state0;
+  Eigen::VectorXd state1;
+  int total_substeps = 0;
+};
+
+struct ContactTrajectoryResults
+{
+  ContactTrajectoryResults() = default;
+  ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps);
+
+  int numSteps() const;
+
+  int numContacts() const;
+
+  ContactTrajectoryStepResults worstStep() const;
+
+  tesseract_collision::ContactResultVector worstCollision() const;
+
+  ContactTrajectoryStepResults mostCollisionsStep() const;
+
+  std::stringstream trajectoryCollisionResultsTable() const;
+
+  std::vector<ContactTrajectoryStepResults> steps;
+  std::vector<std::string> joint_names;
+  int total_steps = 0;
+};
+
 }  // namespace tesseract_collision
 
 #endif  // TESSERACT_COLLISION_TYPES_H

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -461,6 +461,11 @@ struct CollisionCheckConfig
   CollisionCheckProgramType check_program_mode{ CollisionCheckProgramType::ALL };
 };
 
+/**
+ * @brief The ContactTrajectorySubstepResults struct is the lowest level struct for tracking contacts in a trajectory.
+ * This struct is used for substeps between waypoints in a trajectory when a longest valid segment is used, storing the
+ * relevant states of the substep.
+ */
 struct ContactTrajectorySubstepResults
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -481,6 +486,11 @@ struct ContactTrajectorySubstepResults
   Eigen::VectorXd state1;
 };
 
+/**
+ * @brief The ContactTrajectoryStepResults struct is the second level struct for tracking contacts in a trajectory. This
+ * struct stores all the substep contact information as well as the start and end state of the given step in the
+ * trajectory.
+ */
 struct ContactTrajectoryStepResults
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -513,6 +523,11 @@ struct ContactTrajectoryStepResults
   int total_substeps = 0;
 };
 
+/**
+ * @brief The ContactTrajectoryResults struct is the top level struct for tracking contacts in a trajectory. This struct
+ * stores all the steps and therefore all the contacts in a trajectory. It also exposes a method for returning a contact
+ * summary table as a string for printing to a terminal.
+ */
 struct ContactTrajectoryResults
 {
   ContactTrajectoryResults() = default;

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -489,6 +489,9 @@ struct ContactTrajectoryStepResults
                                Eigen::VectorXd end_state,
                                const int& num_substeps);
   ContactTrajectoryStepResults(const int& step_number, const Eigen::VectorXd& state);
+
+  void resize(const int& num_substeps);
+
   int numSubsteps() const;
 
   int numContacts() const;
@@ -509,7 +512,10 @@ struct ContactTrajectoryStepResults
 struct ContactTrajectoryResults
 {
   ContactTrajectoryResults() = default;
+  ContactTrajectoryResults(std::vector<std::string> j_names);
   ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps);
+
+  void resize(const int& num_steps);
 
   int numSteps() const;
 

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -468,7 +468,9 @@ struct CollisionCheckConfig
  */
 struct ContactTrajectorySubstepResults
 {
+  // LCOV_EXCL_START
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  // LCOV_EXCL_STOP
 
   ContactTrajectorySubstepResults() = default;
   ContactTrajectorySubstepResults(int substep, const Eigen::VectorXd& start_state, const Eigen::VectorXd& end_state);
@@ -493,7 +495,9 @@ struct ContactTrajectorySubstepResults
  */
 struct ContactTrajectoryStepResults
 {
+  // LCOV_EXCL_START
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  // LCOV_EXCL_STOP
 
   ContactTrajectoryStepResults() = default;
   ContactTrajectoryStepResults(int step_number,

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -466,8 +466,8 @@ struct ContactTrajectorySubstepResults
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   ContactTrajectorySubstepResults() = default;
-  ContactTrajectorySubstepResults(const int& substep, Eigen::VectorXd start_state, Eigen::VectorXd end_state);
-  ContactTrajectorySubstepResults(const int& substep, Eigen::VectorXd state);
+  ContactTrajectorySubstepResults(int substep, const Eigen::VectorXd& start_state, const Eigen::VectorXd& end_state);
+  ContactTrajectorySubstepResults(int substep, const Eigen::VectorXd& state);
 
   int numContacts() const;
 
@@ -484,13 +484,13 @@ struct ContactTrajectoryStepResults
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   ContactTrajectoryStepResults() = default;
-  ContactTrajectoryStepResults(const int& step_number,
-                               Eigen::VectorXd start_state,
-                               Eigen::VectorXd end_state,
-                               const int& num_substeps);
-  ContactTrajectoryStepResults(const int& step_number, const Eigen::VectorXd& state);
+  ContactTrajectoryStepResults(int step_number,
+                               const Eigen::VectorXd& start_state,
+                               const Eigen::VectorXd& end_state,
+                               int num_substeps);
+  ContactTrajectoryStepResults(int step_number, const Eigen::VectorXd& state);
 
-  void resize(const int& num_substeps);
+  void resize(int num_substeps);
 
   int numSubsteps() const;
 
@@ -513,9 +513,9 @@ struct ContactTrajectoryResults
 {
   ContactTrajectoryResults() = default;
   ContactTrajectoryResults(std::vector<std::string> j_names);
-  ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps);
+  ContactTrajectoryResults(std::vector<std::string> j_names, int num_steps);
 
-  void resize(const int& num_steps);
+  void resize(int num_steps);
 
   int numSteps() const;
 

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -304,4 +304,379 @@ CollisionCheckConfig::CollisionCheckConfig(double default_margin,
 {
 }
 
+ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(const int& substep_number,
+                                                                 Eigen::VectorXd start_state,
+                                                                 Eigen::VectorXd end_state)
+  : substep(substep_number), state0(std::move(start_state)), state1(std::move(end_state))
+{
+}
+
+ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(const int& substep_number, Eigen::VectorXd state)
+  : substep(substep_number), state0(std::move(state)), state1(std::move(state))
+{
+}
+
+int ContactTrajectorySubstepResults::numContacts() const { return static_cast<int>(contacts.size()); }
+
+tesseract_collision::ContactResultVector ContactTrajectorySubstepResults::worstCollision() const
+{
+  tesseract_collision::ContactResultVector worst_collision;
+  double worst_distance = std::numeric_limits<double>::max();
+  for (const auto& collision : contacts)
+  {
+    if (collision.second.front().distance < worst_distance)
+    {
+      worst_distance = collision.second.front().distance;
+      worst_collision = collision.second;
+    }
+  }
+  return worst_collision;
+}
+
+ContactTrajectoryStepResults::ContactTrajectoryStepResults(const int& step_number,
+                                                           Eigen::VectorXd start_state,
+                                                           Eigen::VectorXd end_state,
+                                                           const int& num_substeps)
+  : step(step_number), state0(std::move(start_state)), state1(std::move(end_state)), total_substeps(num_substeps)
+{
+  substeps.resize(static_cast<std::size_t>(num_substeps));
+}
+
+ContactTrajectoryStepResults::ContactTrajectoryStepResults(const int& step_number, const Eigen::VectorXd& state)
+  : step(step_number), state0(state), state1(state), total_substeps(1)
+{
+  substeps.resize(static_cast<std::size_t>(1));
+}
+
+int ContactTrajectoryStepResults::numSubsteps() const { return static_cast<int>(substeps.size()); }
+
+int ContactTrajectoryStepResults::numContacts() const
+{
+  int num_contacts = 0;
+  for (const auto& substep : substeps)
+    num_contacts += substep.numContacts();
+  return num_contacts;
+}
+
+ContactTrajectorySubstepResults ContactTrajectoryStepResults::worstSubstep() const
+{
+  ContactTrajectorySubstepResults worst_substep;
+  double worst_distance = std::numeric_limits<double>::max();
+  for (const auto& substep : substeps)
+  {
+    tesseract_collision::ContactResultVector substep_worst_collision = substep.worstCollision();
+    if (substep_worst_collision.front().distance < worst_distance)
+    {
+      worst_distance = substep_worst_collision.front().distance;
+      worst_substep = substep;
+    }
+  }
+  return worst_substep;
+}
+
+tesseract_collision::ContactResultVector ContactTrajectoryStepResults::worstCollision() const
+{
+  tesseract_collision::ContactResultVector worst_collision = worstSubstep().worstCollision();
+  return worst_collision;
+}
+
+ContactTrajectorySubstepResults ContactTrajectoryStepResults::mostCollisionsSubstep() const
+{
+  int most_contacts = 0;
+  ContactTrajectorySubstepResults most_collisions_substep;
+  for (const auto& substep : substeps)
+  {
+    if (substep.numContacts() > most_contacts)
+    {
+      most_contacts = substep.numContacts();
+      most_collisions_substep = substep;
+    }
+  }
+  return most_collisions_substep;
+}
+
+ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps)
+  : joint_names(std::move(j_names)), total_steps(num_steps)
+{
+  steps.resize(static_cast<std::size_t>(num_steps));
+}
+
+int ContactTrajectoryResults::numSteps() const { return static_cast<int>(steps.size()); }
+
+int ContactTrajectoryResults::numContacts() const
+{
+  int num_contacts = 0;
+  for (const auto& step : steps)
+    num_contacts += step.numContacts();
+  return num_contacts;
+}
+
+ContactTrajectoryStepResults ContactTrajectoryResults::worstStep() const
+{
+  ContactTrajectoryStepResults worst_step;
+  double worst_distance = std::numeric_limits<double>::max();
+  for (const auto& step : steps)
+  {
+    tesseract_collision::ContactResultVector step_worst_collision = step.worstCollision();
+    if (step_worst_collision.front().distance < worst_distance)
+    {
+      worst_distance = step_worst_collision.front().distance;
+      worst_step = step;
+    }
+  }
+  return worst_step;
+}
+
+tesseract_collision::ContactResultVector ContactTrajectoryResults::worstCollision() const
+{
+  tesseract_collision::ContactResultVector worst_collision = worstStep().worstCollision();
+  return worst_collision;
+}
+
+ContactTrajectoryStepResults ContactTrajectoryResults::mostCollisionsStep() const
+{
+  int most_contacts = 0;
+  ContactTrajectoryStepResults most_collisions_step;
+  for (const auto& step : steps)
+  {
+    if (step.numContacts() > most_contacts)
+    {
+      most_contacts = step.numContacts();
+      most_collisions_step = step;
+    }
+  }
+  return most_collisions_step;
+}
+std::stringstream ContactTrajectoryResults::trajectoryCollisionResultsTable() const
+{
+  // Possible multiple contacts for every substep
+  // For every contact need to display contact distance, link1, link2
+  // For every substep with a contact need to display substep #/total, all contacts
+  // For every step need to display joint names, state0, state1, all substeps
+  // No seperation between collision lines
+  // Dashed  (---) line seperating substeps
+  // Star (***) line seperating steps
+  std::stringstream ss;
+
+  if (numContacts() == 0)
+  {
+    ss << "No contacts detected" << std::endl;
+    return ss;
+  }
+
+  int step_details_width = 0;
+  int substep_details_width = 0;
+
+  // First need to determine the width of every column, should be a space on either side of each
+  // Step is displayed as (step)/(total number of steps), example: 2/23
+  std::string step_title = "STEP";
+  int longest_steps_width = 2 + static_cast<int>(step_title.size());
+  int number_steps_digits = static_cast<int>(std::log10(steps.back().step)) + 1;
+  // *2 for either side, plus 1 for '/', plus 2 for spaces
+  int width_steps_display = number_steps_digits * 2 + 3;
+  if (width_steps_display > longest_steps_width)
+    longest_steps_width = width_steps_display;
+
+  step_details_width += longest_steps_width;
+
+  // Joint Names can vary widely
+  std::string joint_name_title = "JOINT NAMES";
+  int longest_joint_name_width = static_cast<int>(joint_name_title.size()) + 2;
+  for (const auto& name : joint_names)
+  {
+    if (static_cast<int>(name.size()) + 2 > longest_joint_name_width)
+      longest_joint_name_width = static_cast<int>(name.size()) + 2;
+  }
+
+  step_details_width += longest_joint_name_width;
+
+  // State0 and State1 we will truncate all values to be to 4 decimals of precision,
+  // important to add 1 to the length of negative values to account for the sign
+  std::string state0_title = "STATE0";
+  std::string state1_title = "STATE1";
+  int longest_state0_width = 9;  // Default negative sign, number, decimal point, four places, plus space either side
+  int longest_state1_width = 9;
+  for (const auto& step : steps)
+  {
+    for (int i = 0; i < static_cast<int>(step.state0.size()); i++)
+    {
+      double state0_value = step.state0(i);
+      if (state0_value < 0)
+      {
+        state0_value *= -1;
+      }
+      int state0_number_digits_left_decimal = static_cast<int>(std::log10(state0_value)) + 1;
+      if (state0_number_digits_left_decimal + 7 > longest_state0_width)
+        longest_state0_width =
+            state0_number_digits_left_decimal + 7;  // + 4 after decimal + 2 for spaces either side + 1 for decimal
+
+      double state1_value = step.state1(i);
+      if (state1_value < 0)
+      {
+        state1_value *= -1;
+      }
+      int state1_number_digits_left_decimal = static_cast<int>(std::log10(state1_value)) + 1;
+      if (state1_number_digits_left_decimal + 7 > longest_state1_width)
+        longest_state1_width =
+            state1_number_digits_left_decimal + 7;  // + 4 after decimal + 2 for spaces either side + 1 for decimal
+    }
+  }
+
+  step_details_width += longest_state0_width;
+  step_details_width += longest_state1_width;
+
+  // Substep will almost certainly be the width of substep, but still check
+  std::string substep_title = "SUBSTEP";
+  int longest_substep_width = 2 + static_cast<int>(substep_title.size());
+  for (const auto& step : steps)
+  {
+    // Check to make sure there are value, could be empty if checking for first collision
+    if (step.numSubsteps() == 0)
+      continue;
+
+    // Substep is displayed as (substep)/(total number of substeps), example: 5/7
+    // so length will be 2*(max substep width) + 1
+    int number_digits = static_cast<int>(std::log10(step.substeps.size())) + 1;
+    int width = 2 * number_digits + 3;
+    if (width > longest_substep_width)
+      longest_substep_width = width;
+  }
+
+  substep_details_width += longest_substep_width;
+
+  // Link1 and Link2 will each be the width of the widest link name in that calumn
+  std::string link1_title = "LINK1";
+  std::string link2_title = "LINK2";
+  int longest_link1_width = static_cast<int>(link1_title.size()) + 2;
+  int longest_link2_width = static_cast<int>(link2_title.size()) + 2;
+  for (const auto& step : steps)
+  {
+    for (const auto& substep : step.substeps)
+    {
+      for (const auto& collision : substep.contacts)
+      {
+        std::string link1_name = collision.second.front().link_names[0];
+        if (static_cast<int>(link1_name.size()) + 2 > longest_link1_width)
+          longest_link1_width = static_cast<int>(link1_name.size()) + 2;
+
+        std::string link2_name = collision.second.front().link_names[1];
+        if (static_cast<int>(link2_name.size()) + 2 > longest_link2_width)
+          longest_link2_width = static_cast<int>(link2_name.size()) + 2;
+      }
+    }
+  }
+
+  substep_details_width += longest_link1_width;
+  substep_details_width += longest_link2_width;
+
+  // Distance will also be truncated at 4 decimal points of precision, shouldn't need more
+  // than 0.1 mm of precision
+  // Assumming "DISTANCE" is the widest text, also doesn't matter because this is the last column
+  std::string distance_title = "DISTANCE";
+  int longest_distance_width = static_cast<int>(distance_title.size()) + 2;
+
+  substep_details_width += longest_distance_width;
+
+  // Construct strings for displaying info on a new state and new substate
+  std::string new_step_string(static_cast<std::size_t>(step_details_width), '*');
+  new_step_string += "|";
+  new_step_string += std::string(static_cast<std::size_t>(substep_details_width), '*');
+  std::string new_substep_string(static_cast<std::size_t>(substep_details_width), '-');
+
+  // Start making the table
+  // Start on new line to avoid offset by anythnig on previous line
+  ss << std::endl;
+  // Make the header
+  ss << std::setw(longest_steps_width) << step_title << std::setw(longest_joint_name_width) << joint_name_title
+     << std::setw(longest_state0_width) << state0_title << std::setw(longest_state1_width) << state1_title << "|"
+     << std::setw(longest_substep_width) << substep_title << std::setw(longest_link1_width) << link1_title
+     << std::setw(longest_link2_width) << link2_title << std::setw(longest_distance_width) << distance_title
+     << std::endl;
+
+  ss << new_step_string << std::endl;
+
+  for (const auto& step : steps)
+  {
+    // Check if there are contacts in this step
+    if (step.numContacts() == 0)
+      continue;
+
+    // Create string for stating the step number, repeated on every line of this step. example: 2/23
+    std::string step_number_string = std::to_string(step.step) + "/" + std::to_string(total_steps);
+    int line_number = 0;
+    for (const auto& substep : step.substeps)
+    {
+      // Check if there are contacts in this substep
+      if (substep.numContacts() == 0)
+        continue;
+
+      // Create string for stating the substep number, repeated on every line of this substep
+      std::string substep_string = std::to_string(substep.substep) + "/" + std::to_string(step.total_substeps);
+
+      // Iterate over every collision in this substep
+      for (const auto& collision : substep.contacts)
+      {
+        // Write the current substep string
+        ss << std::setw(longest_steps_width) << step_number_string;
+
+        // Check if we still need to be adding to the joint state information
+        if (line_number < static_cast<int>(joint_names.size()))
+        {
+          ss << std::setprecision(4) << std::fixed;
+          ss << std::setw(longest_joint_name_width) << joint_names[static_cast<std::size_t>(line_number)];
+          ss << std::setw(longest_state0_width) << step.state0(line_number);
+          ss << std::setw(longest_state1_width) << step.state1(line_number);
+        }
+        else
+        {
+          // Add blank spaces once done writing joint states
+          ss << std::setw(longest_joint_name_width) << " " << std::setw(longest_state0_width) << " "
+             << std::setw(longest_state1_width) << " ";
+        }
+        // Add vertical bar
+        ss << "|";
+
+        // Add specific contact information
+        ss << std::setw(longest_substep_width) << substep_string;
+        ss << std::setw(longest_link1_width) << collision.second.front().link_names[0];
+        ss << std::setw(longest_link2_width) << collision.second.front().link_names[1];
+        ss << std::setw(longest_distance_width) << collision.second.front().distance;
+        ss << std::endl;
+        line_number++;
+      }
+
+      // Make new line for seperator between substates
+      ss << std::setw(longest_steps_width) << step_number_string;
+      if (line_number < static_cast<int>(joint_names.size()))
+      {
+        ss << std::setw(longest_joint_name_width) << joint_names[static_cast<std::size_t>(line_number)];
+        ss << std::setw(longest_state0_width) << step.state0(line_number);
+        ss << std::setw(longest_state1_width) << step.state1(line_number);
+      }
+      else
+      {
+        ss << std::setw(longest_joint_name_width) << " " << std::setw(longest_state0_width) << " "
+           << std::setw(longest_state1_width) << " ";
+      }
+      ss << "|";
+      ss << new_substep_string;
+      ss << std::endl;
+      line_number++;
+    }
+
+    // Finish writing joint state if necessary
+    while (line_number < static_cast<int>(joint_names.size()))
+    {
+      ss << std::setw(longest_steps_width) << step_number_string;
+      ss << std::setw(longest_joint_name_width) << joint_names[static_cast<std::size_t>(line_number)];
+      ss << std::setw(longest_state0_width) << step.state0(line_number);
+      ss << std::setw(longest_state1_width) << step.state1(line_number);
+      ss << "|" << std::endl;
+      line_number++;
+    }
+    ss << new_step_string << std::endl;
+  }
+  return ss;
+}
+
 }  // namespace tesseract_collision

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -348,6 +348,12 @@ ContactTrajectoryStepResults::ContactTrajectoryStepResults(const int& step_numbe
   substeps.resize(static_cast<std::size_t>(1));
 }
 
+void ContactTrajectoryStepResults::resize(const int& num_substeps)
+{
+  total_substeps = num_substeps;
+  substeps.resize(static_cast<std::size_t>(num_substeps));
+}
+
 int ContactTrajectoryStepResults::numSubsteps() const { return static_cast<int>(substeps.size()); }
 
 int ContactTrajectoryStepResults::numContacts() const
@@ -395,9 +401,19 @@ ContactTrajectorySubstepResults ContactTrajectoryStepResults::mostCollisionsSubs
   return most_collisions_substep;
 }
 
+ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names)
+  : joint_names(std::move(j_names))
+{}
+
 ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps)
   : joint_names(std::move(j_names)), total_steps(num_steps)
 {
+  steps.resize(static_cast<std::size_t>(num_steps));
+}
+
+void ContactTrajectoryResults::resize(const int& num_steps)
+{
+  total_steps = num_steps;
   steps.resize(static_cast<std::size_t>(num_steps));
 }
 

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -401,9 +401,9 @@ ContactTrajectorySubstepResults ContactTrajectoryStepResults::mostCollisionsSubs
   return most_collisions_substep;
 }
 
-ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names)
-  : joint_names(std::move(j_names))
-{}
+ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names) : joint_names(std::move(j_names))
+{
+}
 
 ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps)
   : joint_names(std::move(j_names)), total_steps(num_steps)

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -304,15 +304,15 @@ CollisionCheckConfig::CollisionCheckConfig(double default_margin,
 {
 }
 
-ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(const int& substep_number,
-                                                                 Eigen::VectorXd start_state,
-                                                                 Eigen::VectorXd end_state)
-  : substep(substep_number), state0(std::move(start_state)), state1(std::move(end_state))
+ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(int substep_number,
+                                                                 const Eigen::VectorXd& start_state, // NOLINT
+                                                                 const Eigen::VectorXd& end_state) // NOLINT
+  : substep(substep_number), state0(start_state), state1(end_state)
 {
 }
 
-ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(const int& substep_number, Eigen::VectorXd state)
-  : substep(substep_number), state0(std::move(state)), state1(std::move(state))
+ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(int substep_number, const Eigen::VectorXd& state)
+  : substep(substep_number), state0(state), state1(state)
 {
 }
 
@@ -333,22 +333,22 @@ tesseract_collision::ContactResultVector ContactTrajectorySubstepResults::worstC
   return worst_collision;
 }
 
-ContactTrajectoryStepResults::ContactTrajectoryStepResults(const int& step_number,
-                                                           Eigen::VectorXd start_state,
-                                                           Eigen::VectorXd end_state,
-                                                           const int& num_substeps)
-  : step(step_number), state0(std::move(start_state)), state1(std::move(end_state)), total_substeps(num_substeps)
+ContactTrajectoryStepResults::ContactTrajectoryStepResults(int step_number,
+                                                           const Eigen::VectorXd& start_state, // NOLINT
+                                                           const Eigen::VectorXd& end_state, // NOLINT
+                                                           int num_substeps)
+  : step(step_number), state0(start_state), state1(end_state), total_substeps(num_substeps)
 {
   substeps.resize(static_cast<std::size_t>(num_substeps));
 }
 
-ContactTrajectoryStepResults::ContactTrajectoryStepResults(const int& step_number, const Eigen::VectorXd& state)
+ContactTrajectoryStepResults::ContactTrajectoryStepResults(int step_number, const Eigen::VectorXd& state)
   : step(step_number), state0(state), state1(state), total_substeps(1)
 {
   substeps.resize(static_cast<std::size_t>(1));
 }
 
-void ContactTrajectoryStepResults::resize(const int& num_substeps)
+void ContactTrajectoryStepResults::resize(int num_substeps)
 {
   total_substeps = num_substeps;
   substeps.resize(static_cast<std::size_t>(num_substeps));
@@ -405,13 +405,13 @@ ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_na
 {
 }
 
-ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names, const int& num_steps)
+ContactTrajectoryResults::ContactTrajectoryResults(std::vector<std::string> j_names, int num_steps)
   : joint_names(std::move(j_names)), total_steps(num_steps)
 {
   steps.resize(static_cast<std::size_t>(num_steps));
 }
 
-void ContactTrajectoryResults::resize(const int& num_steps)
+void ContactTrajectoryResults::resize(int num_steps)
 {
   total_steps = num_steps;
   steps.resize(static_cast<std::size_t>(num_steps));

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -305,8 +305,8 @@ CollisionCheckConfig::CollisionCheckConfig(double default_margin,
 }
 
 ContactTrajectorySubstepResults::ContactTrajectorySubstepResults(int substep_number,
-                                                                 const Eigen::VectorXd& start_state, // NOLINT
-                                                                 const Eigen::VectorXd& end_state) // NOLINT
+                                                                 const Eigen::VectorXd& start_state,  // NOLINT
+                                                                 const Eigen::VectorXd& end_state)    // NOLINT
   : substep(substep_number), state0(start_state), state1(end_state)
 {
 }
@@ -334,8 +334,8 @@ tesseract_collision::ContactResultVector ContactTrajectorySubstepResults::worstC
 }
 
 ContactTrajectoryStepResults::ContactTrajectoryStepResults(int step_number,
-                                                           const Eigen::VectorXd& start_state, // NOLINT
-                                                           const Eigen::VectorXd& end_state, // NOLINT
+                                                           const Eigen::VectorXd& start_state,  // NOLINT
+                                                           const Eigen::VectorXd& end_state,    // NOLINT
                                                            int num_substeps)
   : step(step_number), state0(start_state), state1(end_state), total_substeps(num_substeps)
 {
@@ -569,15 +569,20 @@ std::stringstream ContactTrajectoryResults::trajectoryCollisionResultsTable() co
   {
     for (const auto& substep : step.substeps)
     {
-      for (const auto& collision : substep.contacts)
+      if (!substep.contacts.empty())
       {
-        std::string link1_name = collision.second.front().link_names[0];
-        if (static_cast<int>(link1_name.size()) + 2 > longest_link1_width)
-          longest_link1_width = static_cast<int>(link1_name.size()) + 2;
+        for (const auto& collision : substep.contacts)
+        {
+          if (collision.second.empty())
+            continue;
+          std::string link1_name = collision.second.front().link_names[0];
+          if (static_cast<int>(link1_name.size()) + 2 > longest_link1_width)
+            longest_link1_width = static_cast<int>(link1_name.size()) + 2;
 
-        std::string link2_name = collision.second.front().link_names[1];
-        if (static_cast<int>(link2_name.size()) + 2 > longest_link2_width)
-          longest_link2_width = static_cast<int>(link2_name.size()) + 2;
+          std::string link2_name = collision.second.front().link_names[1];
+          if (static_cast<int>(link2_name.size()) + 2 > longest_link2_width)
+            longest_link2_width = static_cast<int>(link2_name.size()) + 2;
+        }
       }
     }
   }
@@ -622,6 +627,9 @@ std::stringstream ContactTrajectoryResults::trajectoryCollisionResultsTable() co
     int line_number = 0;
     for (const auto& substep : step.substeps)
     {
+      if (substep.contacts.empty())
+        continue;
+
       // Check if there are contacts in this substep
       if (substep.numContacts() == 0)
         continue;
@@ -632,6 +640,8 @@ std::stringstream ContactTrajectoryResults::trajectoryCollisionResultsTable() co
       // Iterate over every collision in this substep
       for (const auto& collision : substep.contacts)
       {
+        if (collision.second.empty())
+          continue;
         // Write the current substep string
         ss << std::setw(longest_steps_width) << step_number_string;
 

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -250,7 +250,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
         {
           step_contacts = tesseract_collision::ContactTrajectoryStepResults(
-              iStep + 1, traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
+              static_cast<int>(iStep + 1), traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
         }
 
         auto sub_segment_last_index = static_cast<int>(subtraj.rows() - 1);
@@ -274,7 +274,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         for (tesseract_common::TrajArray::Index iSubStep = start_idx; iSubStep < end_idx; ++iSubStep)
         {
-          tesseract_collision::ContactTrajectorySubstepResults substep_contacts(iSubStep, subtraj.row(iSubStep));
+          tesseract_collision::ContactTrajectorySubstepResults substep_contacts(static_cast<int>(iSubStep),
+                                                                                subtraj.row(iSubStep));
 
           tesseract_common::TransformMap state0 = state_fn(subtraj.row(iSubStep));
           tesseract_common::TransformMap state1 = state_fn(subtraj.row(iSubStep + 1));
@@ -331,7 +332,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             continue;
         }
 
-        tesseract_collision::ContactTrajectoryStepResults step_contacts(iStep + 1, traj.row(iStep));
+        tesseract_collision::ContactTrajectoryStepResults step_contacts(static_cast<int>(iStep + 1), traj.row(iStep));
         tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
 
         tesseract_common::TransformMap state0 = state_fn(traj.row(iStep));
@@ -373,7 +374,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
     for (tesseract_common::TrajArray::Index iStep = start_idx; iStep < end_idx; ++iStep)
     {
-      tesseract_collision::ContactTrajectoryStepResults step_contacts(iStep + 1, traj.row(iStep));
+      tesseract_collision::ContactTrajectoryStepResults step_contacts(static_cast<int>(iStep + 1), traj.row(iStep));
       tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
 
       tesseract_common::TransformMap state0 = state_fn(traj.row(iStep));
@@ -570,7 +571,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         for (tesseract_common::TrajArray::Index iSubStep = start_idx; iSubStep < end_idx; ++iSubStep)
         {
-          tesseract_collision::ContactTrajectorySubstepResults substep_contacts(iSubStep, subtraj.row(iSubStep));
+          tesseract_collision::ContactTrajectorySubstepResults substep_contacts(static_cast<int>(iSubStep),
+                                                                                subtraj.row(iSubStep));
 
           tesseract_common::TransformMap state = state_fn(subtraj.row(iSubStep));
           tesseract_collision::ContactResultMap sub_state_results;
@@ -760,7 +762,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
     for (tesseract_common::TrajArray::Index iStep = start_idx; iStep < end_idx; ++iStep)
     {
-      tesseract_collision::ContactTrajectoryStepResults step_contacts(iStep + 1, traj.row(iStep));
+      tesseract_collision::ContactTrajectoryStepResults step_contacts(static_cast<int>(iStep + 1), traj.row(iStep));
       tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
 
       tesseract_collision::ContactResultMap state_results;

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -179,8 +179,10 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
   manager.applyContactManagerConfig(config.contact_manager_config);
 
+  bool debug_logging = console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO;
+
   tesseract_collision::ContactTrajectoryResults traj_contacts;
-  if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+  if (debug_logging)
   {
     traj_contacts = tesseract_collision::ContactTrajectoryResults(joint_names, static_cast<int>(traj.rows()));
   }
@@ -202,7 +204,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       // Always use addInterpolatedCollisionResults so cc_type is defined correctly
       state_results.addInterpolatedCollisionResults(
           sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, false);
-      if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+      if (debug_logging)
         printContinuousDebugInfo(joint_names, traj.row(0), traj.row(0), 0, traj.rows() - 1);
     }
 
@@ -223,7 +225,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       // Always use addInterpolatedCollisionResults so cc_type is defined correctly
       state_results.addInterpolatedCollisionResults(
           sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, false);
-      if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+      if (debug_logging)
         printContinuousDebugInfo(joint_names, traj.row(traj.rows() - 1), traj.row(traj.rows() - 1), 0, traj.rows() - 1);
     }
     contacts.push_back(state_results);
@@ -247,7 +249,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         tesseract_collision::ContactTrajectoryStepResults step_contacts;
 
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
         {
           step_contacts = tesseract_collision::ContactTrajectoryStepResults(
               static_cast<int>(iStep + 1), traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
@@ -274,8 +276,12 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         for (tesseract_common::TrajArray::Index iSubStep = start_idx; iSubStep < end_idx; ++iSubStep)
         {
-          tesseract_collision::ContactTrajectorySubstepResults substep_contacts(static_cast<int>(iSubStep),
-                                                                                subtraj.row(iSubStep));
+          tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+          if (debug_logging)
+          {
+            substep_contacts =
+                tesseract_collision::ContactTrajectorySubstepResults(static_cast<int>(iSubStep), subtraj.row(iSubStep));
+          }
 
           tesseract_common::TransformMap state0 = state_fn(subtraj.row(iSubStep));
           tesseract_common::TransformMap state1 = state_fn(subtraj.row(iSubStep + 1));
@@ -285,7 +291,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           {
             found = true;
 
-            if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+            if (debug_logging)
             {
               substep_contacts.contacts = sub_state_results;
               step_contacts.substeps[static_cast<size_t>(iSubStep)] = substep_contacts;
@@ -305,7 +311,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         }
         contacts.push_back(state_results);
 
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
         {
           traj_contacts.steps[static_cast<size_t>(iStep)] = step_contacts;
         }
@@ -332,8 +338,15 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             continue;
         }
 
-        tesseract_collision::ContactTrajectoryStepResults step_contacts(static_cast<int>(iStep + 1), traj.row(iStep));
-        tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
+        tesseract_collision::ContactTrajectoryStepResults step_contacts;
+        tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+
+        if (debug_logging)
+        {
+          step_contacts =
+              tesseract_collision::ContactTrajectoryStepResults(static_cast<int>(iStep + 1), traj.row(iStep));
+          substep_contacts = tesseract_collision::ContactTrajectorySubstepResults(1, traj.row(iStep));
+        }
 
         tesseract_common::TransformMap state0 = state_fn(traj.row(iStep));
         tesseract_common::TransformMap state1 = state_fn(traj.row(iStep + 1));
@@ -343,7 +356,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           found = true;
           // For continuous no lvs addInterpolatedCollisionResults should not be used.
 
-          if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+          if (debug_logging)
           {
             substep_contacts.contacts = state_results;
             step_contacts.substeps[0] = substep_contacts;
@@ -374,8 +387,13 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
     for (tesseract_common::TrajArray::Index iStep = start_idx; iStep < end_idx; ++iStep)
     {
-      tesseract_collision::ContactTrajectoryStepResults step_contacts(static_cast<int>(iStep + 1), traj.row(iStep));
-      tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
+      tesseract_collision::ContactTrajectoryStepResults step_contacts;
+      tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+      if (debug_logging)
+      {
+        step_contacts = tesseract_collision::ContactTrajectoryStepResults(static_cast<int>(iStep + 1), traj.row(iStep));
+        substep_contacts = tesseract_collision::ContactTrajectorySubstepResults(1, traj.row(iStep));
+      }
 
       tesseract_common::TransformMap state0 = state_fn(traj.row(iStep));
       tesseract_common::TransformMap state1 = state_fn(traj.row(iStep + 1));
@@ -387,7 +405,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         found = true;
         // For continuous no lvs addInterpolatedCollisionResults should not be used.
 
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
         {
           substep_contacts.contacts = state_results;
           step_contacts.substeps[0] = substep_contacts;
@@ -401,7 +419,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
     }
   }
 
-  if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+  if (debug_logging)
     std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
 
   return found;
@@ -450,6 +468,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
   manager.applyContactManagerConfig(config.contact_manager_config);
 
+  bool debug_logging = console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO;
+
   tesseract_collision::ContactTrajectoryResults traj_contacts(joint_names, static_cast<int>(traj.rows()));
 
   contacts.clear();
@@ -469,7 +489,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       // Always use addInterpolatedCollisionResults so cc_type is defined correctly
       state_results.addInterpolatedCollisionResults(
           sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, true);
-      if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+      if (debug_logging)
         printDiscreteDebugInfo(joint_names, traj.row(0), 0, traj.rows() - 1);
     }
     contacts.push_back(state_results);
@@ -489,7 +509,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       // Always use addInterpolatedCollisionResults so cc_type is defined correctly
       state_results.addInterpolatedCollisionResults(
           sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, true);
-      if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+      if (debug_logging)
         printDiscreteDebugInfo(joint_names, traj.row(traj.rows() - 1), 0, traj.rows() - 1);
     }
     contacts.push_back(state_results);
@@ -498,8 +518,13 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
   if (traj.rows() == 1)
   {
-    tesseract_collision::ContactTrajectoryStepResults step_contacts(1, traj.row(0));
-    tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(0));
+    tesseract_collision::ContactTrajectoryStepResults step_contacts;
+    tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+    if (debug_logging)
+    {
+      step_contacts = tesseract_collision::ContactTrajectoryStepResults(1, traj.row(0));
+      substep_contacts = tesseract_collision::ContactTrajectorySubstepResults(1, traj.row(0));
+    }
 
     if (config.check_program_mode != tesseract_collision::CollisionCheckProgramType::ALL)
       return true;
@@ -510,7 +535,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
     tesseract_collision::ContactResultMap sub_state_results;
     checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
-    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+    if (debug_logging)
     {
       substep_contacts.contacts = sub_state_results;
       step_contacts.substeps[0] = substep_contacts;
@@ -522,7 +547,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         sub_state_results, 0, sub_segment_last_index, manager.getActiveCollisionObjects(), segment_dt, true);
     contacts.push_back(state_results);
 
-    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+    if (debug_logging)
       std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
 
     return (!state_results.empty());
@@ -544,9 +569,11 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         tesseract_collision::ContactTrajectoryStepResults step_contacts;
 
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
+        {
           step_contacts = tesseract_collision::ContactTrajectoryStepResults(
               iStep + 1, traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
+        }
 
         auto sub_segment_last_index = static_cast<int>(subtraj.rows() - 1);
 
@@ -571,8 +598,12 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         for (tesseract_common::TrajArray::Index iSubStep = start_idx; iSubStep < end_idx; ++iSubStep)
         {
-          tesseract_collision::ContactTrajectorySubstepResults substep_contacts(static_cast<int>(iSubStep),
-                                                                                subtraj.row(iSubStep));
+          tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+          if (debug_logging)
+          {
+            substep_contacts =
+                tesseract_collision::ContactTrajectorySubstepResults(static_cast<int>(iSubStep), subtraj.row(iSubStep));
+          }
 
           tesseract_common::TransformMap state = state_fn(subtraj.row(iSubStep));
           tesseract_collision::ContactResultMap sub_state_results;
@@ -580,7 +611,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           if (!sub_state_results.empty())
           {
             found = true;
-            if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+            if (debug_logging)
             {
               substep_contacts.contacts = sub_state_results;
               step_contacts.substeps[static_cast<size_t>(iSubStep)] = substep_contacts;
@@ -598,12 +629,12 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             break;
         }
 
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
         {
           traj_contacts.steps[static_cast<size_t>(iStep)] = step_contacts;
         }
 
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
         {
           contacts.push_back(state_results);
         }
@@ -614,8 +645,13 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       else
       {
         // Special case when using LVS and only two states
-        tesseract_collision::ContactTrajectoryStepResults step_contacts(iStep + 1, traj.row(iStep));
-        tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
+        tesseract_collision::ContactTrajectoryStepResults step_contacts;
+        tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+        if (debug_logging)
+        {
+          step_contacts = tesseract_collision::ContactTrajectoryStepResults(iStep + 1, traj.row(iStep));
+          substep_contacts = tesseract_collision::ContactTrajectorySubstepResults(1, traj.row(iStep));
+        }
 
         if (iStep == 0 && traj.rows() == 2)
         {
@@ -628,7 +664,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             if (!sub_state_results.empty())
             {
               found = true;
-              if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+              if (debug_logging)
               {
                 substep_contacts.contacts = sub_state_results;
                 step_contacts.substeps[0] = substep_contacts;
@@ -654,7 +690,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             if (!sub_state_results.empty())
             {
               found = true;
-              if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+              if (debug_logging)
               {
                 substep_contacts.contacts = sub_state_results;
                 step_contacts.substeps[0] = substep_contacts;
@@ -691,7 +727,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         if (!sub_state_results.empty())
         {
           found = true;
-          if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+          if (debug_logging)
           {
             substep_contacts.contacts = sub_state_results;
             step_contacts.substeps[0] = substep_contacts;
@@ -723,7 +759,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           if (!sub_state_results.empty())
           {
             found = true;
-            if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+            if (debug_logging)
             {
               substep_contacts.contacts = sub_state_results;
               step_contacts.substeps[0] = substep_contacts;
@@ -762,8 +798,13 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
     for (tesseract_common::TrajArray::Index iStep = start_idx; iStep < end_idx; ++iStep)
     {
-      tesseract_collision::ContactTrajectoryStepResults step_contacts(static_cast<int>(iStep + 1), traj.row(iStep));
-      tesseract_collision::ContactTrajectorySubstepResults substep_contacts(1, traj.row(iStep));
+      tesseract_collision::ContactTrajectoryStepResults step_contacts;
+      tesseract_collision::ContactTrajectorySubstepResults substep_contacts;
+      if (debug_logging)
+      {
+        step_contacts = tesseract_collision::ContactTrajectoryStepResults(static_cast<int>(iStep + 1), traj.row(iStep));
+        substep_contacts = tesseract_collision::ContactTrajectorySubstepResults(1, traj.row(iStep));
+      }
 
       tesseract_collision::ContactResultMap state_results;
 
@@ -773,7 +814,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       if (!sub_state_results.empty())
       {
         found = true;
-        if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+        if (debug_logging)
         {
           substep_contacts.contacts = sub_state_results;
           step_contacts.substeps[0] = substep_contacts;
@@ -789,7 +830,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
     }
   }
 
-  if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
+  if (debug_logging)
     std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
 
   return found;

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -190,12 +190,14 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   contacts.clear();
   contacts.reserve(static_cast<std::size_t>(traj.rows()));
 
+  /** @brief Making this thread_local does not help because it is not called enough during planning */
+  tesseract_collision::ContactResultMap state_results;
+  tesseract_collision::ContactResultMap sub_state_results;
+
   bool found = false;
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::START_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(0));
-    tesseract_collision::ContactResultMap state_results;
-    tesseract_collision::ContactResultMap sub_state_results;
     checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -215,8 +217,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::END_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(traj.rows() - 1));
-    tesseract_collision::ContactResultMap state_results;
-    tesseract_collision::ContactResultMap sub_state_results;
     tesseract_environment::checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -236,7 +236,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   {
     for (tesseract_common::TrajArray::Index iStep = 0; iStep < traj.rows() - 1; ++iStep)
     {
-      tesseract_collision::ContactResultMap state_results;
+      state_results.clear();
 
       double dist = (traj.row(iStep + 1) - traj.row(iStep)).norm();
       if (dist > config.longest_valid_segment_length)
@@ -285,7 +285,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
           tesseract_common::TransformMap state0 = state_fn(subtraj.row(iSubStep));
           tesseract_common::TransformMap state1 = state_fn(subtraj.row(iSubStep + 1));
-          tesseract_collision::ContactResultMap sub_state_results;
+          sub_state_results.clear();
           checkTrajectorySegment(sub_state_results, manager, state0, state1, config.contact_request);
           if (!sub_state_results.empty())
           {
@@ -398,7 +398,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       tesseract_common::TransformMap state0 = state_fn(traj.row(iStep));
       tesseract_common::TransformMap state1 = state_fn(traj.row(iStep + 1));
 
-      tesseract_collision::ContactResultMap state_results;
+      state_results.clear();
       checkTrajectorySegment(state_results, manager, state0, state1, config.contact_request);
       if (!state_results.empty())
       {
@@ -475,12 +475,14 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   contacts.clear();
   contacts.reserve(static_cast<std::size_t>(traj.rows()));
 
+  /** @brief Making this thread_local does not help because it is not called enough during planning */
+  tesseract_collision::ContactResultMap state_results;
+  tesseract_collision::ContactResultMap sub_state_results;
+
   bool found = false;
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::START_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(0));
-    tesseract_collision::ContactResultMap state_results;
-    tesseract_collision::ContactResultMap sub_state_results;
     tesseract_environment::checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -499,8 +501,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::END_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(traj.rows() - 1));
-    tesseract_collision::ContactResultMap state_results;
-    tesseract_collision::ContactResultMap sub_state_results;
     tesseract_environment::checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -530,9 +530,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       return true;
 
     auto sub_segment_last_index = static_cast<int>(traj.rows() - 1);
-    tesseract_collision::ContactResultMap state_results;
     tesseract_common::TransformMap state = state_fn(traj.row(0));
-    tesseract_collision::ContactResultMap sub_state_results;
     checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (debug_logging)
@@ -557,8 +555,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   {
     for (int iStep = 0; iStep < (traj.rows() - 1); ++iStep)
     {
-      tesseract_collision::ContactResultMap state_results;
-
       const double dist = (traj.row(iStep + 1) - traj.row(iStep)).norm();
       if (dist > config.longest_valid_segment_length)
       {
@@ -606,7 +602,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           }
 
           tesseract_common::TransformMap state = state_fn(subtraj.row(iSubStep));
-          tesseract_collision::ContactResultMap sub_state_results;
+          sub_state_results.clear();
           checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
           if (!sub_state_results.empty())
           {
@@ -659,7 +655,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
               config.check_program_mode != tesseract_collision::CollisionCheckProgramType::INTERMEDIATE_ONLY)
           {
             tesseract_common::TransformMap state = state_fn(traj.row(iStep));
-            tesseract_collision::ContactResultMap sub_state_results;
+            sub_state_results.clear();
             checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
             if (!sub_state_results.empty())
             {
@@ -685,7 +681,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
               config.check_program_mode != tesseract_collision::CollisionCheckProgramType::INTERMEDIATE_ONLY)
           {
             tesseract_common::TransformMap state = state_fn(traj.row(iStep + 1));
-            tesseract_collision::ContactResultMap sub_state_results;
+            sub_state_results.clear();
             checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
             if (!sub_state_results.empty())
             {
@@ -722,7 +718,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         }
 
         tesseract_common::TransformMap state = state_fn(traj.row(iStep));
-        tesseract_collision::ContactResultMap sub_state_results;
+        sub_state_results.clear();
         checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
         if (!sub_state_results.empty())
         {
@@ -754,7 +750,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           }
 
           tesseract_common::TransformMap state = state_fn(traj.row(iStep + 1));
-          tesseract_collision::ContactResultMap sub_state_results;
+          sub_state_results.clear();
           checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
           if (!sub_state_results.empty())
           {
@@ -806,10 +802,10 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         substep_contacts = tesseract_collision::ContactTrajectorySubstepResults(1, traj.row(iStep));
       }
 
-      tesseract_collision::ContactResultMap state_results;
+      state_results.clear();
 
       tesseract_common::TransformMap state = state_fn(traj.row(iStep));
-      tesseract_collision::ContactResultMap sub_state_results;
+      sub_state_results.clear();
       checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
       if (!sub_state_results.empty())
       {

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -199,6 +199,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::START_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(0));
+    sub_state_results.clear();
     checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -218,6 +219,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::END_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(traj.rows() - 1));
+    sub_state_results.clear();
     tesseract_environment::checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -490,6 +492,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::START_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(0));
+    sub_state_results.clear();
     tesseract_environment::checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -508,6 +511,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (config.check_program_mode == tesseract_collision::CollisionCheckProgramType::END_ONLY)
   {
     tesseract_common::TransformMap state = state_fn(traj.row(traj.rows() - 1));
+    sub_state_results.clear();
     tesseract_environment::checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (!sub_state_results.empty())
@@ -537,7 +541,9 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       return true;
 
     auto sub_segment_last_index = static_cast<int>(traj.rows() - 1);
+    state_results.clear();
     tesseract_common::TransformMap state = state_fn(traj.row(0));
+    sub_state_results.clear();
     checkTrajectoryState(sub_state_results, manager, state, config.contact_request);
 
     if (debug_logging)
@@ -562,6 +568,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   {
     for (int iStep = 0; iStep < (traj.rows() - 1); ++iStep)
     {
+      state_results.clear();
+
       const double dist = (traj.row(iStep + 1) - traj.row(iStep)).norm();
       if (dist > config.longest_valid_segment_length)
       {
@@ -631,15 +639,11 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
             break;
         }
+        contacts.push_back(state_results);
 
         if (debug_logging)
         {
           traj_contacts->steps[static_cast<size_t>(iStep)] = *step_contacts;
-        }
-
-        if (debug_logging)
-        {
-          contacts.push_back(state_results);
         }
 
         if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -83,24 +83,6 @@ void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_resul
     manager.setCollisionObjectsTransform(link_name, state0.at(link_name), state1.at(link_name));
 
   manager.contactTest(contact_results, contact_request);
-
-  if (!contact_results.empty())
-  {
-    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
-    {
-      for (const auto& collision : contact_results)
-      {
-        if (collision.second.empty())
-          continue;
-
-        std::stringstream ss;
-        ss << "Continuous collision detected between '" << collision.first.first << "' and '" << collision.first.second
-           << "' with distance " << collision.second.front().distance << std::endl;
-
-        CONSOLE_BRIDGE_logDebug(ss.str().c_str());
-      }
-    }
-  }
 }
 
 void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
@@ -121,24 +103,6 @@ void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results
     manager.setCollisionObjectsTransform(link_name, state.at(link_name));
 
   manager.contactTest(contact_results, contact_request);
-
-  if (!contact_results.empty())
-  {
-    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
-    {
-      for (const auto& collision : contact_results)
-      {
-        if (collision.second.empty())
-          continue;
-
-        std::stringstream ss;
-        ss << "Discrete collision detected between '" << collision.first.first << "' and '" << collision.first.second
-           << "' with distance " << collision.second.front().distance << std::endl;
-
-        CONSOLE_BRIDGE_logDebug(ss.str().c_str());
-      }
-    }
-  }
 }
 
 void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
@@ -150,24 +114,6 @@ void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results
     manager.setCollisionObjectsTransform(link_name, state.at(link_name), state.at(link_name));
 
   manager.contactTest(contact_results, contact_request);
-
-  if (!contact_results.empty())
-  {
-    if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
-    {
-      for (const auto& collision : contact_results)
-      {
-        if (collision.second.empty())
-          continue;
-
-        std::stringstream ss;
-        ss << "Discrete collision detected between '" << collision.first.first << "' and '" << collision.first.second
-           << "' with distance " << collision.second.front().distance << std::endl;
-
-        CONSOLE_BRIDGE_logDebug(ss.str().c_str());
-      }
-    }
-  }
 }
 
 void printContinuousDebugInfo(const std::vector<std::string>& joint_names,
@@ -299,13 +245,12 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         for (tesseract_common::TrajArray::Index iVar = 0; iVar < traj.cols(); ++iVar)
           subtraj.col(iVar) = Eigen::VectorXd::LinSpaced(cnt, traj.row(iStep)(iVar), traj.row(iStep + 1)(iVar));
 
-
         tesseract_collision::ContactTrajectoryStepResults step_contacts;
 
         if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
         {
           step_contacts = tesseract_collision::ContactTrajectoryStepResults(
-                iStep + 1, traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
+              iStep + 1, traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
         }
 
         auto sub_segment_last_index = static_cast<int>(subtraj.rows() - 1);
@@ -456,7 +401,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   }
 
   if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
-      std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
+    std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
 
   return found;
 }
@@ -600,7 +545,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
           step_contacts = tesseract_collision::ContactTrajectoryStepResults(
-                iStep + 1, traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
+              iStep + 1, traj.row(iStep), traj.row(iStep + 1), static_cast<int>(subtraj.rows()));
 
         auto sub_segment_last_index = static_cast<int>(subtraj.rows() - 1);
 
@@ -651,7 +596,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             break;
         }
 
-
         if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
         {
           traj_contacts.steps[static_cast<size_t>(iStep)] = step_contacts;
@@ -690,7 +634,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
               }
               state_results.addInterpolatedCollisionResults(
                   sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, true);
-
             }
 
             if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
@@ -717,7 +660,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
               }
               state_results.addInterpolatedCollisionResults(
                   sub_state_results, 1, 1, manager.getActiveCollisionObjects(), 1, true);
-
             }
 
             if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
@@ -755,7 +697,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           }
           state_results.addInterpolatedCollisionResults(
               sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, true);
-
         }
 
         if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
@@ -788,7 +729,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
             }
             state_results.addInterpolatedCollisionResults(
                 sub_state_results, 1, 1, manager.getActiveCollisionObjects(), 1, true);
-
           }
 
           if (found && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
@@ -848,7 +788,7 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   }
 
   if (console_bridge::getLogLevel() > console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO)
-      std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
+    std::cout << traj_contacts.trajectoryCollisionResultsTable().str();
 
   return found;
 }

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -184,7 +184,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   tesseract_collision::ContactTrajectoryResults::UPtr traj_contacts;
   if (debug_logging)
   {
-      traj_contacts = std::make_unique<tesseract_collision::ContactTrajectoryResults>(joint_names, static_cast<int>(traj.rows()));
+    traj_contacts =
+        std::make_unique<tesseract_collision::ContactTrajectoryResults>(joint_names, static_cast<int>(traj.rows()));
   }
 
   contacts.clear();
@@ -279,8 +280,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           tesseract_collision::ContactTrajectorySubstepResults::UPtr substep_contacts;
           if (debug_logging)
           {
-            substep_contacts =
-                std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(static_cast<int>(iSubStep), subtraj.row(iSubStep));
+            substep_contacts = std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(
+                static_cast<int>(iSubStep), subtraj.row(iSubStep));
           }
 
           tesseract_common::TransformMap state0 = state_fn(subtraj.row(iSubStep));
@@ -343,8 +344,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
         if (debug_logging)
         {
-          step_contacts =
-              std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(static_cast<int>(iStep + 1), traj.row(iStep));
+          step_contacts = std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(
+              static_cast<int>(iStep + 1), traj.row(iStep));
           substep_contacts = std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(1, traj.row(iStep));
         }
 
@@ -391,7 +392,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       tesseract_collision::ContactTrajectorySubstepResults::UPtr substep_contacts;
       if (debug_logging)
       {
-        step_contacts = std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(static_cast<int>(iStep + 1), traj.row(iStep));
+        step_contacts = std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(static_cast<int>(iStep + 1),
+                                                                                            traj.row(iStep));
         substep_contacts = std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(1, traj.row(iStep));
       }
 
@@ -473,7 +475,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   tesseract_collision::ContactTrajectoryResults::UPtr traj_contacts;
   if (debug_logging)
   {
-      traj_contacts = std::make_unique<tesseract_collision::ContactTrajectoryResults>(joint_names, static_cast<int>(traj.rows()));
+    traj_contacts =
+        std::make_unique<tesseract_collision::ContactTrajectoryResults>(joint_names, static_cast<int>(traj.rows()));
   }
 
   contacts.clear();
@@ -601,8 +604,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
           tesseract_collision::ContactTrajectorySubstepResults::UPtr substep_contacts;
           if (debug_logging)
           {
-            substep_contacts =
-                std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(static_cast<int>(iSubStep), subtraj.row(iSubStep));
+            substep_contacts = std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(
+                static_cast<int>(iSubStep), subtraj.row(iSubStep));
           }
 
           tesseract_common::TransformMap state = state_fn(subtraj.row(iSubStep));
@@ -649,7 +652,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
         tesseract_collision::ContactTrajectorySubstepResults::UPtr substep_contacts;
         if (debug_logging)
         {
-          step_contacts = std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(iStep + 1, traj.row(iStep));
+          step_contacts =
+              std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(iStep + 1, traj.row(iStep));
           substep_contacts = std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(1, traj.row(iStep));
         }
 
@@ -802,7 +806,8 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
       tesseract_collision::ContactTrajectorySubstepResults::UPtr substep_contacts;
       if (debug_logging)
       {
-        step_contacts = std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(static_cast<int>(iStep + 1), traj.row(iStep));
+        step_contacts = std::make_unique<tesseract_collision::ContactTrajectoryStepResults>(static_cast<int>(iStep + 1),
+                                                                                            traj.row(iStep));
         substep_contacts = std::make_unique<tesseract_collision::ContactTrajectorySubstepResults>(1, traj.row(iStep));
       }
 


### PR DESCRIPTION
The goal of this is to improve the terminal output when performing a collision check on a trajectory. In doing this I also created objects for holding collision information from a trajectory that may be useful elsewhere.

Two examples of partial trajectory outputs from running the unit tests:
![short_traj_output](https://user-images.githubusercontent.com/41449746/170370213-877b0bda-33f5-4a6d-85de-bb05a8122170.png)
![long_traj_output](https://user-images.githubusercontent.com/41449746/170370238-c57affd8-ebc7-4f48-8782-d27c09dc4df2.png)

As compared to the previous output that was much harder to read:
![image](https://user-images.githubusercontent.com/41449746/170370386-ff0e0ec3-29d7-422b-a6bb-36dba350c1f0.png)

The trajectory collision object provides a function that outputs a std::stringstream in the form of the table seen above. All the columns are adjusted to always be a constant width depending on the longest string in that column, so the output should always look clean, similar to what is done with the trajopt iterations.