### PR TITLE
Reduce bullet octomap storage

### DIFF
--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
@@ -199,6 +199,8 @@ public:
 
   void manage(const std::shared_ptr<btCollisionShape>& t) { m_data.push_back(t); }
 
+  void manageReserve(std::size_t s) { m_data.reserve(s); }
+
 protected:
   std::string m_name;                               /**< @brief The name of the collision object */
   int m_type_id{ -1 };                              /**< @brief A user defined type id */


### PR DESCRIPTION
Originally it was creating a new collision shape for each occupied cell when it only need to be creating one for each depth. 