### PR TITLE
Fix benchmark CI along with minor fixes

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -28,7 +28,7 @@ jobs:
              UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release",
              TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release -DTESSERACT_ENABLE_TESTING=OFF -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=ON -DBENCHMARK_ARGS=CI_ONLY",
              DOCKER_RUN_OPTS: '-v ~/work/tesseract/tesseract/benchmarks:/root/benchmarks',
-             AFTER_SCRIPT: 'cp -r $target_ws/build/tesseract_collision/test/benchmarks/*.json /root/benchmarks/ && cp -r $target_ws/build/tesseract_environment/test/benchmarks/*.json /root/benchmarks/'}
+             AFTER_SCRIPT: '$target_ws/src/tesseract/.run_combine_benchmark_results'}
 
     steps:
       - uses: actions/checkout@v2
@@ -51,60 +51,12 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}
 
-      - name: Store Bullet Discrete Simple benchmark result
+      - name: Store Bullet Discrete, FCL Discrete and Environment benchmark result
         uses: rhysd/github-action-benchmark@v1
         with:
           name: Bullet Discrete Simple C++ Benchmark
           tool: 'googlecpp'
-          output-file-path: /home/runner/work/tesseract/tesseract/benchmarks/tesseract_collision_bullet_discrete_simple_benchmarks_results.json
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.GITHUB_TOKEN }} # GitHub API token to make a commit comment
-          auto-push: false
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@mpowelson'
-          max-items-in-chart: 20
-
-      - name: Store Bullet Discrete BVH benchmark result
-        uses: rhysd/github-action-benchmark@v1
-        with:
-          name: Bullet Discrete BVH C++ Benchmark
-          tool: 'googlecpp'
-          output-file-path: /home/runner/work/tesseract/tesseract/benchmarks/tesseract_collision_bullet_discrete_bvh_benchmarks_results.json
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.GITHUB_TOKEN }} # GitHub API token to make a commit comment
-          auto-push: false
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@mpowelson'
-          max-items-in-chart: 20
-
-      - name: Store FCL Discrete BVH benchmark result
-        uses: rhysd/github-action-benchmark@v1
-        with:
-          name: FCL Discrete BVH C++ Benchmark
-          tool: 'googlecpp'
-          output-file-path: /home/runner/work/tesseract/tesseract/benchmarks/tesseract_collision_fcl_discrete_bvh_benchmarks_results.json
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.GITHUB_TOKEN }} # GitHub API token to make a commit comment
-          auto-push: false
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@mpowelson'
-          max-items-in-chart: 20
-
-      - name: Store Environment Clone benchmark result
-        uses: rhysd/github-action-benchmark@v1
-        with:
-          name: Environment Clone C++ Benchmark
-          tool: 'googlecpp'
-          output-file-path: /home/runner/work/tesseract/tesseract/benchmarks/tesseract_environment_clone_benchmark_results.json
+          output-file-path: /home/runner/work/tesseract/tesseract/benchmarks/tesseract-benchmark_result.json
           # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
           github-token: ${{ secrets.GITHUB_TOKEN }} # GitHub API token to make a commit comment
           auto-push: false

--- a/.run_combine_benchmark_results
+++ b/.run_combine_benchmark_results
@@ -1,0 +1,8 @@
+#!/bin/bash
+build_dir=$(dirname $0)/../../build
+cp -r $build_dir/tesseract_collision/test/benchmarks/*.json /root/benchmarks/
+cp -r $build_dir/tesseract_environment/test/benchmarks/*.json /root/benchmarks/
+find /root/benchmarks/ -type f -name "*_result.json" -exec cat {} \; > /root/benchmarks/tmp_bench.json
+cat /root/benchmarks/tmp_bench.json | docker run -i --rm itchyny/gojq:0.12.6 -s \
+      '.[0].benchmarks = ([.[].benchmarks] | add) |
+      if .[0].benchmarks == null then null else .[0] end' > /root/benchmarks/tesseract-benchmark_result.json

--- a/tesseract_collision/bullet/CMakeLists.txt
+++ b/tesseract_collision/bullet/CMakeLists.txt
@@ -27,11 +27,6 @@ else()
   set(BULLET_LIBRARY_DIRS_ABS ${BULLET_LIBRARY_DIRS})
 endif()
 
-if(WIN32) # This was required for windows to find things in tesseract_ext before the system which is an issue in ros-win
-  include_directories(BEFORE "${BULLET_INCLUDE_DIRS_ABS}")
-  link_directories(BEFORE "${BULLET_LIBRARY_DIRS_ABS}")
-endif()
-
 find_library(HACD_LIBRARY HACD HINTS ${BULLET_LIBRARY_DIRS_ABS})
 if(NOT HACD_LIBRARY)
   message(

--- a/tesseract_collision/bullet/src/tesseract_compound_compound_collision_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_compound_compound_collision_algorithm.cpp
@@ -133,7 +133,6 @@ struct TesseractCompoundCompoundLeafCallback : btDbvt::ICollide
     , m_sharedManifold(sharedManifold)
     , m_contact_test_data(static_cast<ContactTestData*>(compound1ObjWrap->m_collisionObject->getUserPointer()))
   {
-    btAssert(dynamic_cast<ContactTestData*>(compound1ObjWrap->m_collisionObject->getUserPointer()) != nullptr);
   }
 
   void Process(const btDbvtNode* leaf0, const btDbvtNode* leaf1)  // NOLINT

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/benchmarks/large_dataset_benchmarks.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/benchmarks/large_dataset_benchmarks.hpp
@@ -18,7 +18,7 @@ namespace test_suite
 /** @brief Benchmark that checks collisions between a lot of objects. In this case it is a grid of spheres - each as its
  * own link*/
 static void BM_LARGE_DATASET_MULTILINK(benchmark::State& state,
-                                       DiscreteContactManager::Ptr checker,
+                                       DiscreteContactManager::Ptr checker,  // NOLINT
                                        int edge_size,
                                        tesseract_geometry::GeometryType type)
 {
@@ -85,7 +85,7 @@ static void BM_LARGE_DATASET_MULTILINK(benchmark::State& state,
 
   ContactResultVector result_vector;
 
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     ContactResultMap result;
     result_vector.clear();
@@ -97,7 +97,7 @@ static void BM_LARGE_DATASET_MULTILINK(benchmark::State& state,
 /** @brief Benchmark that checks collisions between a lot of objects. In this case it is a grid of spheres in one link
  * and a single sphere in another link*/
 static void BM_LARGE_DATASET_SINGLELINK(benchmark::State& state,
-                                        DiscreteContactManager::Ptr checker,
+                                        DiscreteContactManager::Ptr checker,  // NOLINT
                                         int edge_size,
                                         tesseract_geometry::GeometryType type)
 {
@@ -152,7 +152,7 @@ static void BM_LARGE_DATASET_SINGLELINK(benchmark::State& state,
       }
     }
   }
-  link_names.push_back("grid_link");
+  link_names.emplace_back("grid_link");
   checker->addCollisionObject(link_names.back(), 0, obj3_shapes, obj3_poses);
 
   // Add Single Sphere Link
@@ -165,7 +165,7 @@ static void BM_LARGE_DATASET_SINGLELINK(benchmark::State& state,
   tesseract_common::VectorIsometry3d single_poses;
   single_shapes.push_back(CollisionShapePtr(sphere->clone()));
   single_poses.push_back(sphere_pose);
-  link_names.push_back("single_link");
+  link_names.emplace_back("single_link");
   checker->addCollisionObject(link_names.back(), 0, single_shapes, single_poses);
 
   // Check if they are in collision
@@ -175,7 +175,7 @@ static void BM_LARGE_DATASET_SINGLELINK(benchmark::State& state,
 
   ContactResultVector result_vector;
 
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     ContactResultMap result;
     result_vector.clear();

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/benchmarks/primatives_benchmarks.hpp
@@ -39,7 +39,7 @@ struct DiscreteBenchmarkInfo
 };
 
 /** @brief Benchmark that checks the clone method in discrete contact managers*/
-static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, std::size_t num_obj)
+static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, std::size_t num_obj)  // NOLINT
 {
   std::vector<std::string> active_obj(num_obj);
   for (std::size_t ind = 0; ind < num_obj; ind++)
@@ -52,14 +52,14 @@ static void BM_CLONE(benchmark::State& state, DiscreteBenchmarkInfo info, std::s
   info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   DiscreteContactManager::Ptr clone;
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     benchmark::DoNotOptimize(clone = info.contact_manager_->clone());
   }
 };
 
 /** @brief Benchmark that checks the contactTest function in discrete contact managers*/
-static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)
+static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)  // NOLINT
 {
   info.contact_manager_->addCollisionObject(std::string("geom1"), 0, info.geom1_, info.obj1_poses);
   info.contact_manager_->addCollisionObject(std::string("geom2"), 0, info.geom2_, info.obj2_poses);
@@ -68,7 +68,7 @@ static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)
   info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   ContactResultMap result;
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     result.clear();
     info.contact_manager_->contactTest(result, ContactRequest(info.contact_test_type_));
@@ -79,10 +79,10 @@ static void BM_CONTACT_TEST(benchmark::State& state, DiscreteBenchmarkInfo info)
  * benchmarks if that is important*/
 static void BM_SELECT_RANDOM_OBJECT(benchmark::State& state, int num_obj)
 {
-  int selected_link;
-  for (auto _ : state)
+  int selected_link{ 0 };
+  for (auto _ : state)  // NOLINT
   {
-    benchmark::DoNotOptimize(selected_link = rand() % num_obj);
+    benchmark::DoNotOptimize(selected_link = rand() % num_obj);  // NOLINT
   }
 };
 
@@ -103,7 +103,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE(benchmark::State& state,
   info.contact_manager_->setActiveCollisionObjects(active_obj);
   info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     // Including this seems necessary to insure that a distribution of links is used rather than always searching for
     // the same one. Subtract off approximately BM_SELECT_RANDOM_OBJECT if you need absolute numbers rather than
@@ -116,7 +116,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_SINGLE(benchmark::State& state,
 /** @brief Benchmark that checks the setCollisionObjectsTransform(const std::vector<std::string>& names, const
    tesseract_common::VectorIsometry3d& poses) method in discrete contact managers. Moves only a single random link*/
 static void BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR(benchmark::State& state,
-                                                      DiscreteBenchmarkInfo info,
+                                                      DiscreteBenchmarkInfo info,  // NOLINT
                                                       std::size_t num_obj)
 {
   // Setting up collision objects
@@ -131,7 +131,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_VECTOR(benchmark::State& state,
   info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   std::vector<std::string> selected_links(1);
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     // Including this seems necessary to insure that a distribution of links is used rather than always searching for
     // the same one. Subtract off approximately BM_SELECT_RANDOM_OBJECT if you need absolute numbers rather than
@@ -159,7 +159,7 @@ static void BM_SET_COLLISION_OBJECTS_TRANSFORM_MAP(benchmark::State& state,
   info.contact_manager_->setCollisionMarginData(CollisionMarginData(0.5));
 
   tesseract_common::TransformMap selected_link;
-  for (auto _ : state)
+  for (auto _ : state)  // NOLINT
   {
     // Including this seems necessary to insure that a distribution of links is used rather than always searching for
     // the same one. It might be worth it to manually time these as well if it's really important

--- a/tesseract_collision/fcl/CMakeLists.txt
+++ b/tesseract_collision/fcl/CMakeLists.txt
@@ -1,10 +1,5 @@
 find_package(fcl 0.6 REQUIRED)
 
-if(WIN32) # This was required for windows to find things in tesseract_ext before the system which is an issue in ros-win
-  include_directories(BEFORE ${FCL_INCLUDE_DIRS})
-  link_directories(BEFORE ${FCL_LIBRARY_DIRS})
-endif()
-
 # Create target for FCL implementation
 add_library(${PROJECT_NAME}_fcl src/fcl_discrete_managers.cpp src/fcl_utils.cpp src/fcl_collision_object_wrapper.cpp)
 target_link_libraries(

--- a/tesseract_collision/test/benchmarks/CMakeLists.txt
+++ b/tesseract_collision/test/benchmarks/CMakeLists.txt
@@ -24,7 +24,6 @@ macro(add_benchmark benchmark_name benchmark_file)
     octomath
     ${LIBFCL_LIBRARIES})
   target_include_directories(${benchmark_name} PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
-  target_include_directories(${benchmark_name} SYSTEM PRIVATE "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
   add_dependencies(
     ${benchmark_name}
     ${PROJECT_NAME}_test_suite_benchmarks

--- a/tesseract_collision/test/benchmarks/bullet_discrete_bvh_benchmarks.cpp
+++ b/tesseract_collision/test/benchmarks/bullet_discrete_bvh_benchmarks.cpp
@@ -217,7 +217,7 @@ int main(int argc, char** argv)
   //////////////////////////////////////
   // Large Dataset contactTest
   //////////////////////////////////////
-  if (std::string(BENCHMARK_ARGS).compare("CI_ONLY") != 0)
+  if (std::string(BENCHMARK_ARGS) != "CI_ONLY")
   {
     std::function<void(benchmark::State&, DiscreteContactManager::Ptr, int, tesseract_geometry::GeometryType)>
         BM_LARGE_DATASET_MULTILINK_FUNC = BM_LARGE_DATASET_MULTILINK;

--- a/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
+++ b/tesseract_collision/test/benchmarks/bullet_discrete_simple_benchmarks.cpp
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
   //////////////////////////////////////
   // Large Dataset contactTest
   //////////////////////////////////////
-  if (std::string(BENCHMARK_ARGS).compare("CI_ONLY") != 0)
+  if (std::string(BENCHMARK_ARGS) != "CI_ONLY")
   {
     std::function<void(benchmark::State&, DiscreteContactManager::Ptr, int, tesseract_geometry::GeometryType)>
         BM_LARGE_DATASET_MULTILINK_FUNC = BM_LARGE_DATASET_MULTILINK;

--- a/tesseract_collision/test/benchmarks/fcl_discrete_bvh_benchmarks.cpp
+++ b/tesseract_collision/test/benchmarks/fcl_discrete_bvh_benchmarks.cpp
@@ -226,7 +226,7 @@ int main(int argc, char** argv)
   //////////////////////////////////////
   // Large Dataset contactTest
   //////////////////////////////////////
-  if (std::string(BENCHMARK_ARGS).compare("CI_ONLY") != 0)
+  if (std::string(BENCHMARK_ARGS) != "CI_ONLY")
   {
     std::function<void(benchmark::State&, DiscreteContactManager::Ptr, int, tesseract_geometry::GeometryType)>
         BM_LARGE_DATASET_MULTILINK_FUNC = BM_LARGE_DATASET_MULTILINK;

--- a/tesseract_collision/vhacd/CMakeLists.txt
+++ b/tesseract_collision/vhacd/CMakeLists.txt
@@ -12,9 +12,19 @@ if(NOT
     WARNING "Bullet does not appear to be build with double precision, current definitions: ${BULLET_DEFINITIONS}")
 endif()
 
-if(WIN32) # This was required for windows to find things in tesseract_ext before the system which is an issue in ros-win
-  include_directories(BEFORE "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
-  link_directories(BEFORE "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS}")
+# Some Bullet installations (vcpkg) use absolute paths instead of relative to BULLET_ROOT_DIR in the CMake vars
+set(BULLET_INCLUDE_DIRS_ABS "")
+set(BULLET_LIBRARY_DIRS_ABS "")
+if(NOT IS_ABSOLUTE "${BULLET_INCLUDE_DIR}")
+  foreach(dir IN LISTS BULLET_INCLUDE_DIRS)
+    list(APPEND BULLET_INCLUDE_DIRS_ABS "${BULLET_ROOT_DIR}/${dir}")
+  endforeach()
+  foreach(dir IN LISTS BULLET_LIBRARY_DIRS)
+    list(APPEND BULLET_LIBRARY_DIRS_ABS "${BULLET_ROOT_DIR}/${dir}")
+  endforeach()
+else()
+  set(BULLET_INCLUDE_DIRS_ABS ${BULLET_INCLUDE_DIRS})
+  set(BULLET_LIBRARY_DIRS_ABS ${BULLET_LIBRARY_DIRS})
 endif()
 
 # Third party vhacd
@@ -64,7 +74,7 @@ target_link_libraries(
          ${BULLET_LIBRARIES})
 target_include_directories(${PROJECT_NAME}_vhacd PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                         "$<INSTALL_INTERFACE:include>")
-target_include_directories(${PROJECT_NAME}_vhacd SYSTEM PUBLIC "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}")
+target_include_directories(${PROJECT_NAME}_vhacd SYSTEM PUBLIC "${BULLET_INCLUDE_DIRS_ABS}")
 
 # Convex decomposition libraries
 add_library(${PROJECT_NAME}_vhacd_convex_decomposition src/convex_decomposition_vhacd.cpp)


### PR DESCRIPTION
- Remove no longer needed 
``` cmake
  include_directories(BEFORE "${BULLET_INCLUDE_DIRS_ABS}")
  link_directories(BEFORE "${BULLET_LIBRARY_DIRS_ABS}")
```
- Remove invalid dynamic cast in bullet
