### PR TITLE
Improve manipulability calculcation

### DIFF
--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -310,12 +310,16 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
     Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> sm(m, false);
 
     data.eigen_values = sm.eigenvalues().real();
+    data.volume = 1;
 
-    // Set values near zero to zero
+    // Set eigenvalues near zero to zero. This also implies zero volume
     for (Eigen::Index i = 0; i < data.eigen_values.size(); ++i)
     {
       if (tesseract_common::almostEqualRelativeAndAbs(data.eigen_values[i], 0))
+      {
         data.eigen_values[i] = +0;
+        data.volume = +0;
+      }
     }
 
     // If the minimum eigen value is approximately zero set measure and condition to max double
@@ -330,18 +334,9 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
       data.measure = std::sqrt(data.condition);
     }
 
-    data.volume = 1;
-    for (Eigen::Index i = 0; i < sm.eigenvalues().size(); ++i)
-    {
-      // If an eigen value is approximately zero set the volume to zero and return
-      if (tesseract_common::almostEqualRelativeAndAbs(data.eigen_values[i], 0))
-      {
-        data.volume = +0;
-        break;
-      }
-      data.volume = data.volume * data.eigen_values[i];
-    }
-    data.volume = std::sqrt(data.volume);
+    if (data.volume != 0)  // volume is sqrt of product of eigenvalues
+      data.volume = std::sqrt(data.eigen_values.prod());
+
     return data;
   };
 

--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -307,7 +307,7 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
 
   auto fn = [](const Eigen::MatrixXd& m) {
     ManipulabilityEllipsoid data;
-    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> sm(m, false);
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> sm(m, Eigen::DecompositionOptions::EigenvaluesOnly);
     data.eigen_values = sm.eigenvalues().real();
 
     // Set eigenvalues near zero to zero. This also implies zero volume

--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -308,18 +308,13 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
   auto fn = [](const Eigen::MatrixXd& m) {
     ManipulabilityEllipsoid data;
     Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> sm(m, false);
-
     data.eigen_values = sm.eigenvalues().real();
-    data.volume = 1;
 
     // Set eigenvalues near zero to zero. This also implies zero volume
     for (Eigen::Index i = 0; i < data.eigen_values.size(); ++i)
     {
       if (tesseract_common::almostEqualRelativeAndAbs(data.eigen_values[i], 0))
-      {
         data.eigen_values[i] = +0;
-        data.volume = +0;
-      }
     }
 
     // If the minimum eigen value is approximately zero set measure and condition to max double
@@ -334,8 +329,7 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
       data.measure = std::sqrt(data.condition);
     }
 
-    if (data.volume != 0)  // volume is sqrt of product of eigenvalues
-      data.volume = std::sqrt(data.eigen_values.prod());
+    data.volume = std::sqrt(data.eigen_values.prod());
 
     return data;
   };

--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -326,8 +326,8 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
     }
     else
     {
-      data.measure = std::sqrt(data.eigen_values.maxCoeff()) / std::sqrt(data.eigen_values.minCoeff());
       data.condition = data.eigen_values.maxCoeff() / data.eigen_values.minCoeff();
+      data.measure = std::sqrt(data.condition);
     }
 
     data.volume = 1;

--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -307,7 +307,7 @@ inline Manipulability calcManipulability(const Eigen::Ref<const Eigen::MatrixXd>
 
   auto fn = [](const Eigen::MatrixXd& m) {
     ManipulabilityEllipsoid data;
-    Eigen::EigenSolver<Eigen::MatrixXd> sm(m, false);
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> sm(m, false);
 
     data.eigen_values = sm.eigenvalues().real();
 

--- a/tesseract_kinematics/test/kinematics_core_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_core_unit.cpp
@@ -183,16 +183,16 @@ TEST(TesseractKinematicsUnit, UtilscalcManipulabilityUnit)  // NOLINT
 
   EXPECT_EQ(m.m_linear.eigen_values.size(), 3);
   EXPECT_NEAR(m.m_linear.eigen_values[0], 0.18153054745434696, 1e-6);
-  EXPECT_NEAR(m.m_linear.eigen_values[1], 1.960719452545653, 1e-6);
-  EXPECT_NEAR(m.m_linear.eigen_values[2], 0.8835999999999999, 1e-6);
+  EXPECT_NEAR(m.m_linear.eigen_values[1], 0.8835999999999999, 1e-6);
+  EXPECT_NEAR(m.m_linear.eigen_values[2], 1.960719452545653, 1e-6);
   EXPECT_NEAR(m.m_linear.condition, 10.801044122002406, 1e-6);
   EXPECT_NEAR(m.m_linear.measure, 3.286494199295414, 1e-6);
   EXPECT_NEAR(m.m_linear.volume, 0.5608031457314142, 1e-6);
 
   EXPECT_EQ(m.m_angular.eigen_values.size(), 3);
-  EXPECT_NEAR(m.m_angular.eigen_values[0], 2.0, 1e-6);
-  EXPECT_NEAR(m.m_angular.eigen_values[1], 3.0, 1e-6);
-  EXPECT_NEAR(m.m_angular.eigen_values[2], 1.0, 1e-6);
+  EXPECT_NEAR(m.m_angular.eigen_values[0], 1.0, 1e-6);
+  EXPECT_NEAR(m.m_angular.eigen_values[1], 2.0, 1e-6);
+  EXPECT_NEAR(m.m_angular.eigen_values[2], 3.0, 1e-6);
   EXPECT_NEAR(m.m_angular.condition, 3.0, 1e-6);
   EXPECT_NEAR(m.m_angular.measure, 1.7320508075688772, 1e-6);
   EXPECT_NEAR(m.m_angular.volume, 2.449489742783178, 1e-6);
@@ -202,16 +202,16 @@ TEST(TesseractKinematicsUnit, UtilscalcManipulabilityUnit)  // NOLINT
   EXPECT_GT(m.m.condition, 1e+20);
 
   EXPECT_EQ(m.f_linear.eigen_values.size(), 3);
-  EXPECT_NEAR(m.f_linear.eigen_values[0], 5.508714726106856, 1e-6);
-  EXPECT_NEAR(m.f_linear.eigen_values[1], 0.5100168709509535, 1e-6);
-  EXPECT_NEAR(m.f_linear.eigen_values[2], 1.1317338162064283, 1e-6);
+  EXPECT_NEAR(m.f_linear.eigen_values[0], 0.5100168709509535, 1e-6);
+  EXPECT_NEAR(m.f_linear.eigen_values[1], 1.1317338162064283, 1e-6);
+  EXPECT_NEAR(m.f_linear.eigen_values[2], 5.508714726106856, 1e-6);
   EXPECT_NEAR(m.f_linear.condition, 10.801044122002406, 1e-6);
   EXPECT_NEAR(m.f_linear.measure, 3.286494199295414, 1e-6);
   EXPECT_NEAR(m.f_linear.volume, 1.783156902045858, 1e-6);
 
   EXPECT_EQ(m.f_angular.eigen_values.size(), 3);
-  EXPECT_NEAR(m.f_angular.eigen_values[0], 0.5, 1e-6);
-  EXPECT_NEAR(m.f_angular.eigen_values[1], 0.3333333333333333, 1e-6);
+  EXPECT_NEAR(m.f_angular.eigen_values[0], 0.3333333333333333, 1e-6);
+  EXPECT_NEAR(m.f_angular.eigen_values[1], 0.5, 1e-6);
   EXPECT_NEAR(m.f_angular.eigen_values[2], 1.0, 1e-6);
   EXPECT_NEAR(m.f_angular.condition, 3.0, 1e-6);
   EXPECT_NEAR(m.f_angular.measure, 1.7320508075688774, 1e-6);


### PR DESCRIPTION
I just came across these minor improvements of the manipulability calculation when inspecting the code, because a student of mine complained that the eigenvalues are not sorted. Please have a look at the individual commit comments for more details.
For reference: [SelfAdjointEigenSolver](http://eigen.tuxfamily.org/dox/classEigen_1_1SelfAdjointEigenSolver.html)

In principle, the calculation of the inverse expressions is redundant:
https://github.com/tesseract-robotics/tesseract/blob/afe92a7ab892dad856a010d3c7864489d7f3489a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h#L355-L360
because eigenvalues(A^-1) = eigenvalues^-1(A). Also, det(A^-1) = 1/det(A).
However, you apply some clipping to the eigenvalues as well...