### PR TITLE
CI: Drop AFTER_SCRIPT

### DIFF
--- a/.github/workflows/focal_build.yml
+++ b/.github/workflows/focal_build.yml
@@ -95,7 +95,6 @@ jobs:
           BEFORE_RUN_TARGET_TEST_EMBED: "ici_with_unset_variables source $BASEDIR/${PREFIX}target_ws/install/setup.bash"
           UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
           TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTESSERACT_ENABLE_TESTING=ON"
-          AFTER_SCRIPT: 'catkin build -w $target_ws --no-deps --verbose tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_scene_graph tesseract_srdf tesseract_state_solver tesseract_urdf --make-args test'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
 
       - name: Push post-build Docker


### PR DESCRIPTION
Explicit test running via `AFTER_SCRIPT` was required because industrial_test didn't use the correct make target for cmake-only packages. This is fixed with https://github.com/ros-industrial/industrial_ci/pull/785 and thus `AFTER_SCRIPT` is superfluous now.