### PR TITLE
Make limits utility functions templates

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,8 @@ Checks: >
     clang-analyzer-*,
     -clang-analyzer-cplusplus*,
     bugprone-*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-exception-escape,
     cppcoreguidelines-*,
     -cppcoreguidelines-macro-usage,
     -cppcoreguidelines-pro-type-static-cast-downcast,
@@ -28,7 +30,10 @@ Checks: >
     -readability-named-parameter,
     -readability-magic-numbers,
     -readability-isolate-declaration,
-    -readability-function-cognitive-complexity
+    -readability-function-cognitive-complexity,
+    -readability-use-anyofallof,
+    -readability-identifier-length,
+    -readability-suspicious-call-argument
 WarningsAsErrors: >
     -*,
     clang-diagnostic-*,
@@ -36,6 +41,8 @@ WarningsAsErrors: >
     clang-analyzer-*,
     -clang-analyzer-cplusplus*,
     bugprone-*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-exception-escape,
     cppcoreguidelines-*,
     -cppcoreguidelines-macro-usage,
     -cppcoreguidelines-pro-type-static-cast-downcast,
@@ -59,6 +66,9 @@ WarningsAsErrors: >
     -readability-magic-numbers,
     -readability-isolate-declaration,
     -readability-function-cognitive-complexity
+    -readability-use-anyofallof,
+    -readability-identifier-length,
+    -readability-suspicious-call-argument
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
@@ -68,5 +78,7 @@ CheckOptions:
   - key:             cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
     value:           '1'
   - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           '1'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
     value:           '1'
 ...

--- a/tesseract_collision/bullet/CMakeLists.txt
+++ b/tesseract_collision/bullet/CMakeLists.txt
@@ -59,8 +59,8 @@ target_link_libraries(${PROJECT_NAME}_bullet PUBLIC ${BULLET_LIBRARIES})
 target_compile_options(${PROJECT_NAME}_bullet PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME}_bullet PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_bullet PUBLIC ${TESSERACT_COMPILE_DEFINITIONS} ${BULLET_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_bullet ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_bullet PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_bullet ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_bullet
   PRIVATE
@@ -78,8 +78,8 @@ target_compile_options(${PROJECT_NAME}_bullet_factories PRIVATE ${TESSERACT_COMP
 target_compile_options(${PROJECT_NAME}_bullet_factories PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_bullet_factories PUBLIC ${TESSERACT_COMPILE_DEFINITIONS}
                                                                    ${BULLET_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_bullet_factories ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_bullet_factories PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_bullet_factories ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_bullet_factories
   PRIVATE
@@ -106,8 +106,8 @@ if(${HACD_LIBRARY})
   target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
   target_compile_definitions(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_DEFINITIONS}
                                                                               ${BULLET_DEFINITIONS})
-  target_clang_tidy(${PROJECT_NAME}_hacd_convex_decomposition ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_cxx_version(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+  target_clang_tidy(${PROJECT_NAME}_hacd_convex_decomposition ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_code_coverage(
     ${PROJECT_NAME}_hacd_convex_decomposition
     PRIVATE
@@ -139,8 +139,8 @@ if(NOT MSVC)
   target_compile_options(create_convex_hull PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
                                                     ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
   target_compile_definitions(create_convex_hull PRIVATE ${TESSERACT_COMPILE_DEFINITIONS})
-  target_clang_tidy(create_convex_hull ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_cxx_version(create_convex_hull PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+  target_clang_tidy(create_convex_hull ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_include_directories(create_convex_hull PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
 
   list(APPEND PACKAGE_LIBRARIES create_convex_hull)

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
@@ -49,9 +49,7 @@
 %shared_ptr(tesseract_collision::tesseract_collision_bullet::BulletCastBVHManager)
 #endif  // SWIG
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /** @brief A BVH implementation of a tesseract contact manager */
 class BulletCastBVHManager : public ContinuousContactManager
@@ -169,7 +167,6 @@ private:
   /** @brief This function will update internal data when margin data has changed */
   void onCollisionMarginDataChanged();
 };
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 
 #endif  // TESSERACT_COLLISION_BULLET_CAST_BVH_MANAGERS_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
@@ -49,9 +49,7 @@
 %shared_ptr(tesseract_collision::tesseract_collision_bullet::BulletCastSimpleManager)
 #endif  // SWIG
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /** @brief A simple implementation of a tesseract manager which does not use BHV */
 class BulletCastSimpleManager : public ContinuousContactManager
@@ -167,7 +165,6 @@ private:
   void onCollisionMarginDataChanged();
 };
 
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 
 #endif  // TESSERACT_COLLISION_BULLET_CAST_SIMPLE_MANAGERS_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
@@ -49,9 +49,7 @@
 %shared_ptr(tesseract_collision::tesseract_collision_bullet::BulletDiscreteBVHManager)
 #endif  // SWIG
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /** @brief A BVH implementation of a bullet manager */
 class BulletDiscreteBVHManager : public DiscreteContactManager
@@ -158,6 +156,5 @@ private:
   void onCollisionMarginDataChanged();
 };
 
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 #endif  // TESSERACT_COLLISION_BULLET_DISCRETE_BVH_MANAGERS_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
@@ -49,9 +49,7 @@
 %shared_ptr(tesseract_collision::tesseract_collision_bullet::BulletDiscreteSimpleManager)
 #endif  // SWIG
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /** @brief A simple implementation of a bullet manager which does not use BHV */
 class BulletDiscreteSimpleManager : public DiscreteContactManager
@@ -155,6 +153,5 @@ private:
   void onCollisionMarginDataChanged();
 };
 
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 #endif  // TESSERACT_COLLISION_BULLET_DISCRETE_SIMPLE_MANAGERS_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
@@ -54,9 +54,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/types.h>
 #include <tesseract_collision/core/common.h>
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 #define METERS
 
@@ -67,56 +65,19 @@ const btScalar BULLET_EPSILON = btScalar(1e-3);
 const btScalar BULLET_DEFAULT_CONTACT_DISTANCE = btScalar(0.05);
 const bool BULLET_COMPOUND_USE_DYNAMIC_AABB = true;
 
-inline btVector3 convertEigenToBt(const Eigen::Vector3d& v)
-{
-  return btVector3{ static_cast<btScalar>(v[0]), static_cast<btScalar>(v[1]), static_cast<btScalar>(v[2]) };
-}
+btVector3 convertEigenToBt(const Eigen::Vector3d& v);
 
-inline Eigen::Vector3d convertBtToEigen(const btVector3& v)
-{
-  return Eigen::Vector3d{ static_cast<double>(v.x()), static_cast<double>(v.y()), static_cast<double>(v.z()) };
-}
+Eigen::Vector3d convertBtToEigen(const btVector3& v);
 
-inline btQuaternion convertEigenToBt(const Eigen::Quaterniond& q)
-{
-  return btQuaternion{ static_cast<btScalar>(q.x()),
-                       static_cast<btScalar>(q.y()),
-                       static_cast<btScalar>(q.z()),
-                       static_cast<btScalar>(q.w()) };
-}
+btQuaternion convertEigenToBt(const Eigen::Quaterniond& q);
 
-inline btMatrix3x3 convertEigenToBt(const Eigen::Matrix3d& r)
-{
-  return btMatrix3x3{ static_cast<btScalar>(r(0, 0)), static_cast<btScalar>(r(0, 1)), static_cast<btScalar>(r(0, 2)),
-                      static_cast<btScalar>(r(1, 0)), static_cast<btScalar>(r(1, 1)), static_cast<btScalar>(r(1, 2)),
-                      static_cast<btScalar>(r(2, 0)), static_cast<btScalar>(r(2, 1)), static_cast<btScalar>(r(2, 2)) };
-}
+btMatrix3x3 convertEigenToBt(const Eigen::Matrix3d& r);
 
-inline Eigen::Matrix3d convertBtToEigen(const btMatrix3x3& r)
-{
-  Eigen::Matrix3d m;
-  m << static_cast<double>(r[0][0]), static_cast<double>(r[0][1]), static_cast<double>(r[0][2]),
-      static_cast<double>(r[1][0]), static_cast<double>(r[1][1]), static_cast<double>(r[1][2]),
-      static_cast<double>(r[2][0]), static_cast<double>(r[2][1]), static_cast<double>(r[2][2]);
-  return m;
-}
+Eigen::Matrix3d convertBtToEigen(const btMatrix3x3& r);
 
-inline btTransform convertEigenToBt(const Eigen::Isometry3d& t)
-{
-  const Eigen::Matrix3d& rot = t.matrix().block<3, 3>(0, 0);
-  const Eigen::Vector3d& tran = t.translation();
+btTransform convertEigenToBt(const Eigen::Isometry3d& t);
 
-  return btTransform{ convertEigenToBt(rot), convertEigenToBt(tran) };
-}
-
-inline Eigen::Isometry3d convertBtToEigen(const btTransform& t)
-{
-  Eigen::Isometry3d i = Eigen::Isometry3d::Identity();
-  i.linear() = convertBtToEigen(t.getBasis());
-  i.translation() = convertBtToEigen(t.getOrigin());
-
-  return i;
-}
+Eigen::Isometry3d convertBtToEigen(const btTransform& t);
 
 /**
  * @brief This is a tesseract bullet collsion object.
@@ -143,72 +104,44 @@ public:
   bool m_enabled{ true };
 
   /** @brief Get the collision object name */
-  const std::string& getName() const { return m_name; }
+  const std::string& getName() const;
   /** @brief Get a user defined type */
-  const int& getTypeID() const { return m_type_id; }
+  const int& getTypeID() const;
   /** \brief Check if two CollisionObjectWrapper objects point to the same source object */
-  bool sameObject(const CollisionObjectWrapper& other) const
-  {
-    return m_name == other.m_name && m_type_id == other.m_type_id && m_shapes.size() == other.m_shapes.size() &&
-           m_shape_poses.size() == other.m_shape_poses.size() &&
-           std::equal(m_shapes.begin(), m_shapes.end(), other.m_shapes.begin()) &&
-           std::equal(m_shape_poses.begin(),
-                      m_shape_poses.end(),
-                      other.m_shape_poses.begin(),
-                      [](const Eigen::Isometry3d& t1, const Eigen::Isometry3d& t2) { return t1.isApprox(t2); });
-  }
+  bool sameObject(const CollisionObjectWrapper& other) const;
 
-  const CollisionShapesConst& getCollisionGeometries() const { return m_shapes; }
+  const CollisionShapesConst& getCollisionGeometries() const;
 
-  const tesseract_common::VectorIsometry3d& getCollisionGeometriesTransforms() const { return m_shape_poses; }
+  const tesseract_common::VectorIsometry3d& getCollisionGeometriesTransforms() const;
 
   /**
    * @brief Get the collision objects axis aligned bounding box
    * @param aabb_min The minimum point
    * @param aabb_max The maximum point
    */
-  void getAABB(btVector3& aabb_min, btVector3& aabb_max) const
-  {
-    getCollisionShape()->getAabb(getWorldTransform(), aabb_min, aabb_max);
-    const btScalar& d = getContactProcessingThreshold();
-    btVector3 contactThreshold(d, d, d);
-    aabb_min -= contactThreshold;
-    aabb_max += contactThreshold;
-  }
+  void getAABB(btVector3& aabb_min, btVector3& aabb_max) const;
 
   /**
    * @brief This clones the collision objects but not the collision shape wich is const.
    * @return Shared Pointer to the cloned collision object
    */
-  std::shared_ptr<CollisionObjectWrapper> clone()
-  {
-    auto clone_cow = std::make_shared<CollisionObjectWrapper>();
-    clone_cow->m_name = m_name;
-    clone_cow->m_type_id = m_type_id;
-    clone_cow->m_shapes = m_shapes;
-    clone_cow->m_shape_poses = m_shape_poses;
-    clone_cow->m_data = m_data;
-    clone_cow->setCollisionShape(getCollisionShape());
-    clone_cow->setWorldTransform(getWorldTransform());
-    clone_cow->m_collisionFilterGroup = m_collisionFilterGroup;
-    clone_cow->m_collisionFilterMask = m_collisionFilterMask;
-    clone_cow->m_enabled = m_enabled;
-    clone_cow->setBroadphaseHandle(nullptr);
-    return clone_cow;
-  }
+  std::shared_ptr<CollisionObjectWrapper> clone();
 
-  void manage(const std::shared_ptr<btCollisionShape>& t) { m_data.push_back(t); }
+  void manage(const std::shared_ptr<btCollisionShape>& t);
 
-  void manageReserve(std::size_t s) { m_data.reserve(s); }
+  void manageReserve(std::size_t s);
 
 protected:
-  std::string m_name;                               /**< @brief The name of the collision object */
-  int m_type_id{ -1 };                              /**< @brief A user defined type id */
-  CollisionShapesConst m_shapes;                    /**< @brief The shapes that define the collison object */
-  tesseract_common::VectorIsometry3d m_shape_poses; /**< @brief The shpaes poses information */
-
+  /** @brief The name of the collision object */
+  std::string m_name;
+  /** @brief A user defined type id */
+  int m_type_id{ -1 };
+  /* @brief The shapes that define the collision object */
+  CollisionShapesConst m_shapes{};
+  /**< @brief The shapes poses information */
+  tesseract_common::VectorIsometry3d m_shape_poses{};
   /** @brief This manages the collision shape pointer so they get destroyed */
-  std::vector<std::shared_ptr<btCollisionShape>> m_data;
+  std::vector<std::shared_ptr<btCollisionShape>> m_data{};
 };
 
 using COW = CollisionObjectWrapper;
@@ -222,133 +155,45 @@ public:
   btConvexShape* m_shape;
   btTransform m_t01;
 
-  CastHullShape(btConvexShape* shape, const btTransform& t01) : m_shape(shape), m_t01(t01)
-  {
-    m_shapeType = CUSTOM_CONVEX_SHAPE_TYPE;
-    setUserIndex(m_shape->getUserIndex());
-  }
+  CastHullShape(btConvexShape* shape, const btTransform& t01);
 
-  void updateCastTransform(const btTransform& t01) { m_t01 = t01; }
-  btVector3 localGetSupportingVertex(const btVector3& vec) const override
-  {
-    btVector3 sv0 = m_shape->localGetSupportingVertex(vec);
-    btVector3 sv1 = m_t01 * m_shape->localGetSupportingVertex(vec * m_t01.getBasis());
-    return (vec.dot(sv0) > vec.dot(sv1)) ? sv0 : sv1;
-  }
+  void updateCastTransform(const btTransform& t01);
+  btVector3 localGetSupportingVertex(const btVector3& vec) const override;
 
   /// getAabb's default implementation is brute force, expected derived classes to implement a fast dedicated version
-  void getAabb(const btTransform& t_w0, btVector3& aabbMin, btVector3& aabbMax) const override
-  {
-    m_shape->getAabb(t_w0, aabbMin, aabbMax);
-    btVector3 min1, max1;
-    m_shape->getAabb(t_w0 * m_t01, min1, max1);
-    aabbMin.setMin(min1);
-    aabbMax.setMax(max1);
-  }
+  void getAabb(const btTransform& t_w0, btVector3& aabbMin, btVector3& aabbMax) const override;
 
-  const char* getName() const override { return "CastHull"; }
-  btVector3 localGetSupportingVertexWithoutMargin(const btVector3& v) const override
-  {
-    return localGetSupportingVertex(v);
-  }
+  const char* getName() const override;
+  btVector3 localGetSupportingVertexWithoutMargin(const btVector3& v) const override;
 
   // LCOV_EXCL_START
   // notice that the vectors should be unit length
-  void batchedUnitVectorGetSupportingVertexWithoutMargin(const btVector3* /*vectors*/,
-                                                         btVector3* /*supportVerticesOut*/,
-                                                         int /*numVectors*/) const override
-  {
-    throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
-                             "a debugger and inspect the call stack to find the function in Bullet calling this "
-                             "function, then review commit history to determine what change.");
-  }
+  void batchedUnitVectorGetSupportingVertexWithoutMargin(const btVector3* vectors,
+                                                         btVector3* supportVerticesOut,
+                                                         int numVectors) const override;
 
-  void getAabbSlow(const btTransform& /*t*/, btVector3& /*aabbMin*/, btVector3& /*aabbMax*/) const override
-  {
-    throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
-                             "a debugger and inspect the call stack to find the function in Bullet calling this "
-                             "function, then review commit history to determine what change.");
-  }
+  void getAabbSlow(const btTransform& t, btVector3& aabbMin, btVector3& aabbMax) const override;
 
-  void setLocalScaling(const btVector3& /*scaling*/) override
-  {
-    throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
-                             "a debugger and inspect the call stack to find the function in Bullet calling this "
-                             "function, then review commit history to determine what change.");
-  }
+  void setLocalScaling(const btVector3& scaling) override;
 
-  const btVector3& getLocalScaling() const override
-  {
-    static btVector3 out(1, 1, 1);
-    return out;
-  }
+  const btVector3& getLocalScaling() const override;
 
-  void setMargin(btScalar /*margin*/) override {}
+  void setMargin(btScalar margin) override;
 
-  btScalar getMargin() const override { return 0; }
+  btScalar getMargin() const override;
 
-  int getNumPreferredPenetrationDirections() const override { return 0; }
+  int getNumPreferredPenetrationDirections() const override;
 
-  void getPreferredPenetrationDirection(int /*index*/, btVector3& /*penetrationVector*/) const override
-  {
-    throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
-                             "a debugger and inspect the call stack to find the function in Bullet calling this "
-                             "function, then review commit history to determine what change.");
-  }
+  void getPreferredPenetrationDirection(int index, btVector3& penetrationVector) const override;
 
-  void calculateLocalInertia(btScalar, btVector3&) const override
-  {
-    throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
-                             "a debugger and inspect the call stack to find the function in Bullet calling this "
-                             "function, then review commit history to determine what change.");
-  }
+  void calculateLocalInertia(btScalar, btVector3&) const override;
   // LCOV_EXCL_STOP
 };
 
-inline void
-GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, btScalar& outsupport, btVector3& outpt)
-{
-  btVector3 ptSum(0, 0, 0);
-  btScalar ptCount = 0;
-  btScalar maxSupport = -1000;
-
-  const auto* pshape = dynamic_cast<const btPolyhedralConvexShape*>(shape);
-  if (pshape != nullptr)
-  {
-    int nPts = pshape->getNumVertices();
-
-    for (int i = 0; i < nPts; ++i)
-    {
-      btVector3 pt;
-      pshape->getVertex(i, pt);
-
-      btScalar sup = pt.dot(localNormal);
-      if (sup > maxSupport + BULLET_EPSILON)
-      {
-        ptCount = 1;
-        ptSum = pt;
-        maxSupport = sup;
-      }
-      else if (sup < maxSupport - BULLET_EPSILON)
-      {
-      }
-      else
-      {
-        ptCount += 1;
-        ptSum += pt;
-      }
-    }
-    outsupport = maxSupport;
-    outpt = ptSum / ptCount;
-  }
-  else
-  {
-    // The margins are set to zero for most shapes, but for a sphere the margin is used so must use
-    // localGetSupportingVertex instead of localGetSupportingVertexWithoutMargin.
-    outpt = shape->localGetSupportingVertex(localNormal);
-    outsupport = localNormal.dot(outpt);
-  }
-}
+void GetAverageSupport(const btConvexShape* shape,
+                       const btVector3& localNormal,
+                       btScalar& outsupport,
+                       btVector3& outpt);
 
 /**
  * @brief This transversus the parent tree to find the base object and return its world transform
@@ -356,21 +201,7 @@ GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, btSc
  * @param cow Bullet collision object wrapper.
  * @return Transform of link in world coordinates
  */
-inline btTransform getLinkTransformFromCOW(const btCollisionObjectWrapper* cow)
-{
-  if (cow->m_parent != nullptr)
-  {
-    if (cow->m_parent->m_parent != nullptr)
-    {
-      assert(cow->m_parent->m_parent->m_parent == nullptr);
-      return cow->m_parent->m_parent->getWorldTransform();
-    }
-
-    return cow->m_parent->getWorldTransform();
-  }
-
-  return cow->getWorldTransform();
-}
+btTransform getLinkTransformFromCOW(const btCollisionObjectWrapper* cow);
 
 /**
  * @brief This is used to check if a collision check is required between the provided two collision objects
@@ -380,65 +211,12 @@ inline btTransform getLinkTransformFromCOW(const btCollisionObjectWrapper* cow)
  * @param verbose Indicate if verbose information should be printed to the terminal
  * @return True if the two collision objects should be checked for collision, otherwise false
  */
-inline bool needsCollisionCheck(const COW& cow1, const COW& cow2, const IsContactAllowedFn& acm, bool verbose = false)
-{
-  return cow1.m_enabled && cow2.m_enabled && (cow2.m_collisionFilterGroup & cow1.m_collisionFilterMask) &&  // NOLINT
-         (cow1.m_collisionFilterGroup & cow2.m_collisionFilterMask) &&                                      // NOLINT
-         !isContactAllowed(cow1.getName(), cow2.getName(), acm, verbose);
-}
+bool needsCollisionCheck(const COW& cow1, const COW& cow2, const IsContactAllowedFn& acm, bool verbose = false);
 
-inline btScalar addDiscreteSingleResult(btManifoldPoint& cp,
-                                        const btCollisionObjectWrapper* colObj0Wrap,
-                                        const btCollisionObjectWrapper* colObj1Wrap,
-                                        ContactTestData& collisions)
-{
-  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject()) != nullptr);
-  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject()) != nullptr);
-  const auto* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());  // NOLINT
-  const auto* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());  // NOLINT
-
-  ObjectPairKey pc = getObjectPairKey(cd0->getName(), cd1->getName());
-
-  const auto& it = collisions.res->find(pc);
-  bool found = (it != collisions.res->end());
-
-  //    size_t l = 0;
-  //    if (found)
-  //    {
-  //      l = it->second.size();
-  //      if (m_collisions.req->type == DistanceRequestType::LIMITED && l >= m_collisions.req->max_contacts_per_body)
-  //          return 0;
-
-  //    }
-
-  btTransform tf0 = getLinkTransformFromCOW(colObj0Wrap);
-  btTransform tf1 = getLinkTransformFromCOW(colObj1Wrap);
-  btTransform tf0_inv = tf0.inverse();
-  btTransform tf1_inv = tf1.inverse();
-
-  ContactResult contact;
-  contact.link_names[0] = cd0->getName();
-  contact.link_names[1] = cd1->getName();
-  contact.shape_id[0] = colObj0Wrap->getCollisionShape()->getUserIndex();
-  contact.shape_id[1] = colObj1Wrap->getCollisionShape()->getUserIndex();
-  contact.subshape_id[0] = colObj0Wrap->m_index;
-  contact.subshape_id[1] = colObj1Wrap->m_index;
-  contact.nearest_points[0] = convertBtToEigen(cp.m_positionWorldOnA);
-  contact.nearest_points[1] = convertBtToEigen(cp.m_positionWorldOnB);
-  contact.nearest_points_local[0] = convertBtToEigen(tf0_inv * cp.m_positionWorldOnA);
-  contact.nearest_points_local[1] = convertBtToEigen(tf1_inv * cp.m_positionWorldOnB);
-  contact.transform[0] = convertBtToEigen(tf0);
-  contact.transform[1] = convertBtToEigen(tf1);
-  contact.type_id[0] = cd0->getTypeID();
-  contact.type_id[1] = cd1->getTypeID();
-  contact.distance = static_cast<double>(cp.m_distance1);
-  contact.normal = convertBtToEigen(-1 * cp.m_normalWorldOnB);
-
-  if (processResult(collisions, contact, pc, found) == nullptr)
-    return 0;
-
-  return 1;
-}
+btScalar addDiscreteSingleResult(btManifoldPoint& cp,
+                                 const btCollisionObjectWrapper* colObj0Wrap,
+                                 const btCollisionObjectWrapper* colObj1Wrap,
+                                 ContactTestData& collisions);
 
 /**
  * @brief Calculate the continuous contact data for casted collision shape
@@ -449,166 +227,19 @@ inline btScalar addDiscreteSingleResult(btManifoldPoint& cp,
  * @param link_tf_inv The links world transform inverse
  * @param link_index The link index in teh ContactResults the shape is associated with
  */
-inline void calculateContinuousData(ContactResult* col,
-                                    const btCollisionObjectWrapper* cow,
-                                    const btVector3& pt_world,
-                                    const btVector3& normal_world,
-                                    const btTransform& link_tf_inv,
-                                    size_t link_index)
-{
-  assert(dynamic_cast<const CastHullShape*>(cow->getCollisionShape()) != nullptr);
-  const auto* shape = static_cast<const CastHullShape*>(cow->getCollisionShape());
-  assert(shape != nullptr);
+void calculateContinuousData(ContactResult* col,
+                             const btCollisionObjectWrapper* cow,
+                             const btVector3& pt_world,
+                             const btVector3& normal_world,
+                             const btTransform& link_tf_inv,
+                             size_t link_index);
 
-  // Get the start and final location of the shape
-  btTransform shape_tfWorld0 = cow->getWorldTransform();
-  btTransform shape_tfWorld1 = cow->getWorldTransform() * shape->m_t01;
-
-  // Given the shapes final location calculate the links transform at the final location
-  Eigen::Isometry3d s = col->transform[link_index].inverse() * convertBtToEigen(shape_tfWorld0);
-  col->cc_transform[link_index] = convertBtToEigen(shape_tfWorld1) * s.inverse();
-
-  // Get the normal in the local shapes coordinate system at start and final location
-  btVector3 shape_normalLocal0 = normal_world * shape_tfWorld0.getBasis();
-  btVector3 shape_normalLocal1 = normal_world * shape_tfWorld1.getBasis();
-
-  // Calculate the contact point at the start location using the casted normal vector in thapes local coordinate system
-  btVector3 shape_ptLocal0;
-  btScalar shape_localsup0{ std::numeric_limits<btScalar>::max() };
-  GetAverageSupport(shape->m_shape, shape_normalLocal0, shape_localsup0, shape_ptLocal0);
-  btVector3 shape_ptWorld0 = shape_tfWorld0 * shape_ptLocal0;
-
-  // Calculate the contact point at the final location using the casted normal vector in thapes local coordinate system
-  btVector3 shape_ptLocal1;
-  btScalar shape_localsup1{ std::numeric_limits<btScalar>::max() };
-  GetAverageSupport(shape->m_shape, shape_normalLocal1, shape_localsup1, shape_ptLocal1);
-  btVector3 shape_ptWorld1 = shape_tfWorld1 * shape_ptLocal1;
-
-  btScalar shape_sup0 = normal_world.dot(shape_ptWorld0);
-  btScalar shape_sup1 = normal_world.dot(shape_ptWorld1);
-
-  // TODO: this section is potentially problematic. think hard about the math
-  if (shape_sup0 - shape_sup1 > BULLET_SUPPORT_FUNC_TOLERANCE)
-  {
-    // LCOV_EXCL_START
-    col->cc_time[link_index] = 0;
-    col->cc_type[link_index] = ContinuousCollisionType::CCType_Time0;
-    // LCOV_EXCL_STOP
-  }
-  else if (shape_sup1 - shape_sup0 > BULLET_SUPPORT_FUNC_TOLERANCE)
-  {
-    // LCOV_EXCL_START
-    col->cc_time[link_index] = 1;
-    col->cc_type[link_index] = ContinuousCollisionType::CCType_Time1;
-    // LCOV_EXCL_STOP
-  }
-  else
-  {
-    // Given the contact point at the start and final location along with the casted contact point
-    // the time between 0 and 1 can be calculated along the path between the start and final location contact occurs.
-    btScalar l0c = (pt_world - shape_ptWorld0).length();
-    btScalar l1c = (pt_world - shape_ptWorld1).length();
-
-    col->nearest_points_local[link_index] =
-        convertBtToEigen(link_tf_inv * (shape_tfWorld0 * ((shape_ptLocal0 + shape_ptLocal1) / 2.0)));
-    col->cc_type[link_index] = ContinuousCollisionType::CCType_Between;
-
-    if (l0c + l1c < BULLET_LENGTH_TOLERANCE)
-    {
-      col->cc_time[link_index] = .5;  // LCOV_EXCL_LINE
-    }
-    else
-    {
-      col->cc_time[link_index] = static_cast<double>(l0c / (l0c + l1c));
-    }
-  }
-}
-
-inline btScalar addCastSingleResult(btManifoldPoint& cp,
-                                    const btCollisionObjectWrapper* colObj0Wrap,
-                                    int /*index0*/,
-                                    const btCollisionObjectWrapper* colObj1Wrap,
-                                    int /*index1*/,
-                                    ContactTestData& collisions)
-{
-  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject()) != nullptr);
-  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject()) != nullptr);
-  const auto* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());  // NOLINT
-  const auto* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());  // NOLINT
-
-  const std::pair<std::string, std::string>& pc = cd0->getName() < cd1->getName() ?
-                                                      std::make_pair(cd0->getName(), cd1->getName()) :
-                                                      std::make_pair(cd1->getName(), cd0->getName());
-
-  auto it = collisions.res->find(pc);
-  bool found = it != collisions.res->end();
-
-  //    size_t l = 0;
-  //    if (found)
-  //    {
-  //      l = it->second.size();
-  //      if (m_collisions.req->type == DistanceRequestType::LIMITED && l >= m_collisions.req->max_contacts_per_body)
-  //          return 0;
-  //    }
-
-  btTransform tf0 = getLinkTransformFromCOW(colObj0Wrap);
-  btTransform tf1 = getLinkTransformFromCOW(colObj1Wrap);
-  btTransform tf0_inv = tf0.inverse();
-  btTransform tf1_inv = tf1.inverse();
-
-  ContactResult contact;
-  contact.link_names[0] = cd0->getName();
-  contact.link_names[1] = cd1->getName();
-  contact.shape_id[0] = colObj0Wrap->getCollisionShape()->getUserIndex();
-  contact.shape_id[1] = colObj1Wrap->getCollisionShape()->getUserIndex();
-  contact.subshape_id[0] = colObj0Wrap->m_index;
-  contact.subshape_id[1] = colObj1Wrap->m_index;
-  contact.nearest_points[0] = convertBtToEigen(cp.m_positionWorldOnA);
-  contact.nearest_points[1] = convertBtToEigen(cp.m_positionWorldOnB);
-  contact.nearest_points_local[0] = convertBtToEigen(tf0_inv * cp.m_positionWorldOnA);
-  contact.nearest_points_local[1] = convertBtToEigen(tf1_inv * cp.m_positionWorldOnB);
-  contact.transform[0] = convertBtToEigen(tf0);
-  contact.transform[1] = convertBtToEigen(tf1);
-  contact.type_id[0] = cd0->getTypeID();
-  contact.type_id[1] = cd1->getTypeID();
-  contact.distance = static_cast<double>(cp.m_distance1);
-  contact.normal = convertBtToEigen(-1 * cp.m_normalWorldOnB);
-
-  ContactResult* col = processResult(collisions, contact, pc, found);
-  if (col == nullptr)
-    return 0;
-
-  if (cd0->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter &&
-      cd1->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
-  {
-    calculateContinuousData(col, colObj0Wrap, cp.m_positionWorldOnA, -1 * cp.m_normalWorldOnB, tf0_inv, 0);
-    calculateContinuousData(col, colObj1Wrap, cp.m_positionWorldOnB, cp.m_normalWorldOnB, tf1_inv, 1);
-  }
-  else
-  {
-    bool castShapeIsFirst = (cd0->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter);
-    btVector3 normalWorldFromCast = -(castShapeIsFirst ? 1 : -1) * cp.m_normalWorldOnB;
-    const btCollisionObjectWrapper* firstColObjWrap = (castShapeIsFirst ? colObj0Wrap : colObj1Wrap);
-    const btTransform& first_tf_inv = (castShapeIsFirst ? tf0_inv : tf1_inv);
-    const btVector3& ptOnCast = castShapeIsFirst ? cp.m_positionWorldOnA : cp.m_positionWorldOnB;
-
-    if (castShapeIsFirst)
-    {
-      std::swap(col->nearest_points[0], col->nearest_points[1]);
-      std::swap(col->nearest_points_local[0], col->nearest_points_local[1]);
-      std::swap(col->transform[0], col->transform[1]);
-      std::swap(col->link_names[0], col->link_names[1]);
-      std::swap(col->type_id[0], col->type_id[1]);
-      std::swap(col->shape_id[0], col->shape_id[1]);
-      std::swap(col->subshape_id[0], col->subshape_id[1]);
-      col->normal *= -1;
-    }
-
-    calculateContinuousData(col, firstColObjWrap, ptOnCast, normalWorldFromCast, first_tf_inv, 1);
-  }
-
-  return 1;
-}
+btScalar addCastSingleResult(btManifoldPoint& cp,
+                             const btCollisionObjectWrapper* colObj0Wrap,
+                             int index0,
+                             const btCollisionObjectWrapper* colObj1Wrap,
+                             int index1,
+                             ContactTestData& collisions);
 
 /** @brief This is copied directly out of BulletWorld */
 struct TesseractBridgedManifoldResult : public btManifoldResult
@@ -617,54 +248,9 @@ struct TesseractBridgedManifoldResult : public btManifoldResult
 
   TesseractBridgedManifoldResult(const btCollisionObjectWrapper* obj0Wrap,
                                  const btCollisionObjectWrapper* obj1Wrap,
-                                 btCollisionWorld::ContactResultCallback& resultCallback)
-    : btManifoldResult(obj0Wrap, obj1Wrap), m_resultCallback(resultCallback)
-  {
-  }
+                                 btCollisionWorld::ContactResultCallback& resultCallback);
 
-  void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth) override
-  {
-    bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
-    btVector3 pointA = pointInWorld + normalOnBInWorld * depth;
-    btVector3 localA;
-    btVector3 localB;
-    if (isSwapped)
-    {
-      localA = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
-      localB = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
-    }
-    else
-    {
-      localA = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
-      localB = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
-    }
-
-    btManifoldPoint newPt(localA, localB, normalOnBInWorld, depth);
-    newPt.m_positionWorldOnA = pointA;
-    newPt.m_positionWorldOnB = pointInWorld;
-
-    // BP mod, store contact triangles.
-    if (isSwapped)
-    {
-      newPt.m_partId0 = m_partId1;
-      newPt.m_partId1 = m_partId0;
-      newPt.m_index0 = m_index1;
-      newPt.m_index1 = m_index0;
-    }
-    else
-    {
-      newPt.m_partId0 = m_partId0;
-      newPt.m_partId1 = m_partId1;
-      newPt.m_index0 = m_index0;
-      newPt.m_index1 = m_index1;
-    }
-
-    // experimental feature info, for per-triangle material etc.
-    const btCollisionObjectWrapper* obj0Wrap = isSwapped ? m_body1Wrap : m_body0Wrap;
-    const btCollisionObjectWrapper* obj1Wrap = isSwapped ? m_body0Wrap : m_body1Wrap;
-    m_resultCallback.addSingleResult(
-        newPt, obj0Wrap, newPt.m_partId0, newPt.m_index0, obj1Wrap, newPt.m_partId1, newPt.m_index1);
-  }
+  void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth) override;
 };
 
 /** @brief The BroadphaseContactResultCallback is used to report contact points */
@@ -674,10 +260,7 @@ struct BroadphaseContactResultCallback
   double contact_distance_;
   bool verbose_;
 
-  BroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false)
-    : collisions_(collisions), contact_distance_(contact_distance), verbose_(verbose)
-  {
-  }
+  BroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false);
 
   virtual ~BroadphaseContactResultCallback() = default;
   BroadphaseContactResultCallback(const BroadphaseContactResultCallback&) = default;
@@ -685,10 +268,7 @@ struct BroadphaseContactResultCallback
   BroadphaseContactResultCallback(BroadphaseContactResultCallback&&) = default;
   BroadphaseContactResultCallback& operator=(BroadphaseContactResultCallback&&) = delete;
 
-  virtual bool needsCollision(const CollisionObjectWrapper* cow0, const CollisionObjectWrapper* cow1) const
-  {
-    return !collisions_.done && needsCollisionCheck(*cow0, *cow1, collisions_.fn, verbose_);
-  }
+  virtual bool needsCollision(const CollisionObjectWrapper* cow0, const CollisionObjectWrapper* cow1) const;
 
   virtual btScalar addSingleResult(btManifoldPoint& cp,
                                    const btCollisionObjectWrapper* colObj0Wrap,
@@ -701,46 +281,28 @@ struct BroadphaseContactResultCallback
 
 struct DiscreteBroadphaseContactResultCallback : public BroadphaseContactResultCallback
 {
-  DiscreteBroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false)
-    : BroadphaseContactResultCallback(collisions, contact_distance, verbose)
-  {
-  }
+  DiscreteBroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false);
 
   btScalar addSingleResult(btManifoldPoint& cp,
                            const btCollisionObjectWrapper* colObj0Wrap,
-                           int /*partId0*/,
-                           int /*index0*/,
+                           int partId0,
+                           int index0,
                            const btCollisionObjectWrapper* colObj1Wrap,
-                           int /*partId1*/,
-                           int /*index1*/) override
-  {
-    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
-      return 0;
-
-    return addDiscreteSingleResult(cp, colObj0Wrap, colObj1Wrap, collisions_);
-  }
+                           int partId1,
+                           int index1) override;
 };
 
 struct CastBroadphaseContactResultCallback : public BroadphaseContactResultCallback
 {
-  CastBroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false)
-    : BroadphaseContactResultCallback(collisions, contact_distance, verbose)
-  {
-  }
+  CastBroadphaseContactResultCallback(ContactTestData& collisions, double contact_distance, bool verbose = false);
 
   btScalar addSingleResult(btManifoldPoint& cp,
                            const btCollisionObjectWrapper* colObj0Wrap,
-                           int /*partId0*/,
+                           int partId0,
                            int index0,
                            const btCollisionObjectWrapper* colObj1Wrap,
-                           int /*partId1*/,
-                           int index1) override
-  {
-    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
-      return 0;
-
-    return addCastSingleResult(cp, colObj0Wrap, index0, colObj1Wrap, index1, collisions_);
-  }
+                           int partId1,
+                           int index1) override;
 };
 
 struct TesseractBroadphaseBridgedManifoldResult : public btManifoldResult
@@ -749,57 +311,9 @@ struct TesseractBroadphaseBridgedManifoldResult : public btManifoldResult
 
   TesseractBroadphaseBridgedManifoldResult(const btCollisionObjectWrapper* obj0Wrap,
                                            const btCollisionObjectWrapper* obj1Wrap,
-                                           BroadphaseContactResultCallback& result_callback)
-    : btManifoldResult(obj0Wrap, obj1Wrap), result_callback_(result_callback)
-  {
-  }
+                                           BroadphaseContactResultCallback& result_callback);
 
-  void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth) override
-  {
-    if (result_callback_.collisions_.done || depth > static_cast<btScalar>(result_callback_.contact_distance_))
-      return;
-
-    bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
-    btVector3 pointA = pointInWorld + normalOnBInWorld * depth;
-    btVector3 localA;
-    btVector3 localB;
-    if (isSwapped)
-    {
-      localA = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
-      localB = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
-    }
-    else
-    {
-      localA = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
-      localB = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
-    }
-
-    btManifoldPoint newPt(localA, localB, normalOnBInWorld, depth);
-    newPt.m_positionWorldOnA = pointA;
-    newPt.m_positionWorldOnB = pointInWorld;
-
-    // BP mod, store contact triangles.
-    if (isSwapped)
-    {
-      newPt.m_partId0 = m_partId1;
-      newPt.m_partId1 = m_partId0;
-      newPt.m_index0 = m_index1;
-      newPt.m_index1 = m_index0;
-    }
-    else
-    {
-      newPt.m_partId0 = m_partId0;
-      newPt.m_partId1 = m_partId1;
-      newPt.m_index0 = m_index0;
-      newPt.m_index1 = m_index1;
-    }
-
-    // experimental feature info, for per-triangle material etc.
-    const btCollisionObjectWrapper* obj0Wrap = isSwapped ? m_body1Wrap : m_body0Wrap;
-    const btCollisionObjectWrapper* obj1Wrap = isSwapped ? m_body0Wrap : m_body1Wrap;
-    result_callback_.addSingleResult(
-        newPt, obj0Wrap, newPt.m_partId0, newPt.m_index0, obj1Wrap, newPt.m_partId1, newPt.m_index1);
-  }
+  void addContactPoint(const btVector3& normalOnBInWorld, const btVector3& pointInWorld, btScalar depth) override;
 };
 
 /**
@@ -817,10 +331,7 @@ class TesseractCollisionPairCallback : public btOverlapCallback
 public:
   TesseractCollisionPairCallback(const btDispatcherInfo& dispatchInfo,
                                  btCollisionDispatcher* dispatcher,
-                                 BroadphaseContactResultCallback& results_callback)
-    : dispatch_info_(dispatchInfo), dispatcher_(dispatcher), results_callback_(results_callback)
-  {
-  }
+                                 BroadphaseContactResultCallback& results_callback);
 
   ~TesseractCollisionPairCallback() override = default;
   TesseractCollisionPairCallback(const TesseractCollisionPairCallback&) = default;
@@ -828,53 +339,16 @@ public:
   TesseractCollisionPairCallback(TesseractCollisionPairCallback&&) = default;
   TesseractCollisionPairCallback& operator=(TesseractCollisionPairCallback&&) = delete;
 
-  bool processOverlap(btBroadphasePair& pair) override
-  {
-    if (results_callback_.collisions_.done)
-      return false;
-
-    const auto* cow0 = static_cast<const CollisionObjectWrapper*>(pair.m_pProxy0->m_clientObject);
-    const auto* cow1 = static_cast<const CollisionObjectWrapper*>(pair.m_pProxy1->m_clientObject);
-
-    if (results_callback_.needsCollision(cow0, cow1))
-    {
-      btCollisionObjectWrapper obj0Wrap(nullptr, cow0->getCollisionShape(), cow0, cow0->getWorldTransform(), -1, -1);
-      btCollisionObjectWrapper obj1Wrap(nullptr, cow1->getCollisionShape(), cow1, cow1->getWorldTransform(), -1, -1);
-
-      // dispatcher will keep algorithms persistent in the collision pair
-      if (pair.m_algorithm == nullptr)
-      {
-        pair.m_algorithm = dispatcher_->findAlgorithm(&obj0Wrap, &obj1Wrap, nullptr, BT_CLOSEST_POINT_ALGORITHMS);
-      }
-
-      if (pair.m_algorithm != nullptr)
-      {
-        TesseractBroadphaseBridgedManifoldResult contactPointResult(&obj0Wrap, &obj1Wrap, results_callback_);
-        contactPointResult.m_closestPointDistanceThreshold = static_cast<btScalar>(results_callback_.contact_distance_);
-
-        // discrete collision detection query
-        pair.m_algorithm->processCollision(&obj0Wrap, &obj1Wrap, dispatch_info_, &contactPointResult);
-      }
-    }
-    return false;
-  }
+  bool processOverlap(btBroadphasePair& pair) override;
 };
 
 /** @brief This class is used to filter broadphase */
 class TesseractOverlapFilterCallback : public btOverlapFilterCallback
 {
 public:
-  TesseractOverlapFilterCallback(bool verbose = false) : verbose_(verbose) {}
+  TesseractOverlapFilterCallback(bool verbose = false);
 
-  bool needBroadphaseCollision(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1) const override
-  {
-    // Note: We do not pass the allowed collision matrix because if it changes we do not know and this function only
-    // gets called under certain cases and it could cause overlapping pairs to not be processed.
-    return needsCollisionCheck(*(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)),
-                               *(static_cast<CollisionObjectWrapper*>(proxy1->m_clientObject)),
-                               nullptr,
-                               verbose_);
-  }
+  bool needBroadphaseCollision(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1) const override;
 
 private:
   bool verbose_{ false };
@@ -897,46 +371,13 @@ std::shared_ptr<btCollisionShape> createShapePrimitive(const CollisionShapeConst
  * @param active A list of active collision objects
  * @param cow The collision object to update.
  */
-inline void updateCollisionObjectFilters(const std::vector<std::string>& active, const COW::Ptr& cow)
-{
-  cow->m_collisionFilterGroup = btBroadphaseProxy::KinematicFilter;
+void updateCollisionObjectFilters(const std::vector<std::string>& active, const COW::Ptr& cow);
 
-  if (!isLinkActive(active, cow->getName()))
-  {
-    cow->m_collisionFilterGroup = btBroadphaseProxy::StaticFilter;
-  }
-
-  if (cow->m_collisionFilterGroup == btBroadphaseProxy::StaticFilter)
-  {
-    cow->m_collisionFilterMask = btBroadphaseProxy::KinematicFilter;
-  }
-  else
-  {
-    cow->m_collisionFilterMask = btBroadphaseProxy::StaticFilter | btBroadphaseProxy::KinematicFilter;
-  }
-}
-
-inline COW::Ptr createCollisionObject(const std::string& name,
-                                      const int& type_id,
-                                      const CollisionShapesConst& shapes,
-                                      const tesseract_common::VectorIsometry3d& shape_poses,
-                                      bool enabled = true)
-{
-  // dont add object that does not have geometry
-  if (shapes.empty() || shape_poses.empty() || (shapes.size() != shape_poses.size()))
-  {
-    CONSOLE_BRIDGE_logDebug("ignoring link %s", name.c_str());
-    return nullptr;
-  }
-
-  auto new_cow = std::make_shared<COW>(name, type_id, shapes, shape_poses);
-
-  new_cow->m_enabled = enabled;
-  new_cow->setContactProcessingThreshold(BULLET_DEFAULT_CONTACT_DISTANCE);
-
-  CONSOLE_BRIDGE_logDebug("Created collision object for link %s", new_cow->getName().c_str());
-  return new_cow;
-}
+COW::Ptr createCollisionObject(const std::string& name,
+                               const int& type_id,
+                               const CollisionShapesConst& shapes,
+                               const tesseract_common::VectorIsometry3d& shape_poses,
+                               bool enabled = true);
 
 struct DiscreteCollisionCollector : public btCollisionWorld::ContactResultCallback
 {
@@ -945,34 +386,20 @@ struct DiscreteCollisionCollector : public btCollisionWorld::ContactResultCallba
   double contact_distance_;
   bool verbose_;
 
-  DiscreteCollisionCollector(ContactTestData& collisions, COW::Ptr cow, btScalar contact_distance, bool verbose = false)
-    : collisions_(collisions), cow_(std::move(cow)), contact_distance_(contact_distance), verbose_(verbose)
-  {
-    m_closestDistanceThreshold = contact_distance;
-    m_collisionFilterGroup = cow_->m_collisionFilterGroup;
-    m_collisionFilterMask = cow_->m_collisionFilterMask;
-  }
+  DiscreteCollisionCollector(ContactTestData& collisions,
+                             COW::Ptr cow,
+                             btScalar contact_distance,
+                             bool verbose = false);
 
   btScalar addSingleResult(btManifoldPoint& cp,
                            const btCollisionObjectWrapper* colObj0Wrap,
-                           int /*partId0*/,
-                           int /*index0*/,
+                           int partId0,
+                           int index0,
                            const btCollisionObjectWrapper* colObj1Wrap,
-                           int /*partId1*/,
-                           int /*index1*/) override
-  {
-    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
-      return 0;
+                           int partId1,
+                           int index1) override;
 
-    return addDiscreteSingleResult(cp, colObj0Wrap, colObj1Wrap, collisions_);
-  }
-
-  bool needsCollision(btBroadphaseProxy* proxy0) const override
-  {
-    return !collisions_.done &&
-           needsCollisionCheck(
-               *cow_, *(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)), collisions_.fn, verbose_);
-  }
+  bool needsCollision(btBroadphaseProxy* proxy0) const override;
 };
 
 struct CastCollisionCollector : public btCollisionWorld::ContactResultCallback
@@ -982,133 +409,20 @@ struct CastCollisionCollector : public btCollisionWorld::ContactResultCallback
   double contact_distance_;
   bool verbose_;
 
-  CastCollisionCollector(ContactTestData& collisions, COW::Ptr cow, double contact_distance, bool verbose = false)
-    : collisions_(collisions), cow_(std::move(cow)), contact_distance_(contact_distance), verbose_(verbose)
-  {
-    m_closestDistanceThreshold = static_cast<btScalar>(contact_distance);
-    m_collisionFilterGroup = cow_->m_collisionFilterGroup;
-    m_collisionFilterMask = cow_->m_collisionFilterMask;
-  }
+  CastCollisionCollector(ContactTestData& collisions, COW::Ptr cow, double contact_distance, bool verbose = false);
 
   btScalar addSingleResult(btManifoldPoint& cp,
                            const btCollisionObjectWrapper* colObj0Wrap,
-                           int /*partId0*/,
+                           int partId0,
                            int index0,
                            const btCollisionObjectWrapper* colObj1Wrap,
-                           int /*partId1*/,
-                           int index1) override
-  {
-    if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
-      return 0;
+                           int partId1,
+                           int index1) override;
 
-    return addCastSingleResult(cp, colObj0Wrap, index0, colObj1Wrap, index1, collisions_);
-  }
-
-  bool needsCollision(btBroadphaseProxy* proxy0) const override
-  {
-    return !collisions_.done &&
-           needsCollisionCheck(
-               *cow_, *(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)), collisions_.fn, verbose_);
-  }
+  bool needsCollision(btBroadphaseProxy* proxy0) const override;
 };
 
-inline COW::Ptr makeCastCollisionObject(const COW::Ptr& cow)
-{
-  COW::Ptr new_cow = cow->clone();
-
-  btTransform tf;
-  tf.setIdentity();
-
-  if (btBroadphaseProxy::isConvex(new_cow->getCollisionShape()->getShapeType()))
-  {
-    assert(dynamic_cast<btConvexShape*>(new_cow->getCollisionShape()) != nullptr);
-    auto* convex = static_cast<btConvexShape*>(new_cow->getCollisionShape());  // NOLINT
-    assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if the collision object is already a
-                                                                 // cast collision object
-
-    auto shape = std::make_shared<CastHullShape>(convex, tf);
-    assert(shape != nullptr);
-
-    new_cow->manage(shape);
-    new_cow->setCollisionShape(shape.get());
-  }
-  else if (btBroadphaseProxy::isCompound(new_cow->getCollisionShape()->getShapeType()))
-  {
-    assert(dynamic_cast<btCompoundShape*>(new_cow->getCollisionShape()) != nullptr);
-    auto* compound = static_cast<btCompoundShape*>(new_cow->getCollisionShape());  // NOLINT
-    auto new_compound =
-        std::make_shared<btCompoundShape>(BULLET_COMPOUND_USE_DYNAMIC_AABB, compound->getNumChildShapes());
-
-    for (int i = 0; i < compound->getNumChildShapes(); ++i)
-    {
-      if (btBroadphaseProxy::isConvex(compound->getChildShape(i)->getShapeType()))
-      {
-        auto* convex = static_cast<btConvexShape*>(compound->getChildShape(i));  // NOLINT
-        assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if already a cast collision object
-
-        btTransform geomTrans = compound->getChildTransform(i);
-
-        auto subshape = std::make_shared<CastHullShape>(convex, tf);
-        assert(subshape != nullptr);
-
-        new_cow->manage(subshape);
-        subshape->setMargin(BULLET_MARGIN);
-        new_compound->addChildShape(geomTrans, subshape.get());
-      }
-      else if (btBroadphaseProxy::isCompound(compound->getChildShape(i)->getShapeType()))
-      {
-        auto* second_compound = static_cast<btCompoundShape*>(compound->getChildShape(i));  // NOLINT
-        auto new_second_compound =
-            std::make_shared<btCompoundShape>(BULLET_COMPOUND_USE_DYNAMIC_AABB, second_compound->getNumChildShapes());
-        for (int j = 0; j < second_compound->getNumChildShapes(); ++j)
-        {
-          assert(!btBroadphaseProxy::isCompound(second_compound->getChildShape(j)->getShapeType()));
-          assert(dynamic_cast<btConvexShape*>(second_compound->getChildShape(j)) != nullptr);
-
-          auto* convex = static_cast<btConvexShape*>(second_compound->getChildShape(j));  // NOLINT
-          assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if already a cast collision object
-
-          btTransform geomTrans = second_compound->getChildTransform(j);
-
-          auto subshape = std::make_shared<CastHullShape>(convex, tf);
-          assert(subshape != nullptr);
-
-          new_cow->manage(subshape);
-          subshape->setMargin(BULLET_MARGIN);
-          new_second_compound->addChildShape(geomTrans, subshape.get());
-        }
-
-        btTransform geomTrans = compound->getChildTransform(i);
-
-        new_cow->manage(new_second_compound);
-        new_second_compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to
-                                                        // have no effect when positive
-                                                        // but has an effect when
-                                                        // negative
-
-        new_compound->addChildShape(geomTrans, new_second_compound.get());
-      }
-      else
-      {
-        throw std::runtime_error("I can only collision check convex shapes and compound shapes made of convex shapes");
-      }
-    }
-
-    new_compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to
-                                             // have no effect when positive
-                                             // but has an effect when
-                                             // negative
-    new_cow->manage(new_compound);
-    new_cow->setCollisionShape(new_compound.get());
-    new_cow->setWorldTransform(cow->getWorldTransform());
-  }
-  else
-  {
-    throw std::runtime_error("I can only collision check convex shapes and compound shapes made of convex shapes");
-  }
-
-  return new_cow;
-}
+COW::Ptr makeCastCollisionObject(const COW::Ptr& cow);
 
 /**
  * @brief Update the Broadphase AABB for the input collision object
@@ -1116,18 +430,9 @@ inline COW::Ptr makeCastCollisionObject(const COW::Ptr& cow)
  * @param broadphase The bullet broadphase interface
  * @param dispatcher The bullet collision dispatcher
  */
-inline void updateBroadphaseAABB(const COW::Ptr& cow,
-                                 const std::unique_ptr<btBroadphaseInterface>& broadphase,
-                                 const std::unique_ptr<btCollisionDispatcher>& dispatcher)
-{
-  // Calculate the aabb
-  btVector3 aabb_min, aabb_max;
-  cow->getAABB(aabb_min, aabb_max);
-
-  // Update the broadphase aabb
-  assert(cow->getBroadphaseHandle() != nullptr);
-  broadphase->setAabb(cow->getBroadphaseHandle(), aabb_min, aabb_max, dispatcher.get());
-}
+void updateBroadphaseAABB(const COW::Ptr& cow,
+                          const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                          const std::unique_ptr<btCollisionDispatcher>& dispatcher);
 
 /**
  * @brief Remove the collision object from broadphase
@@ -1135,19 +440,9 @@ inline void updateBroadphaseAABB(const COW::Ptr& cow,
  * @param broadphase The bullet broadphase interface
  * @param dispatcher The bullet collision dispatcher
  */
-inline void removeCollisionObjectFromBroadphase(const COW::Ptr& cow,
-                                                const std::unique_ptr<btBroadphaseInterface>& broadphase,
-                                                const std::unique_ptr<btCollisionDispatcher>& dispatcher)
-{
-  btBroadphaseProxy* bp = cow->getBroadphaseHandle();
-  if (bp != nullptr)
-  {
-    // only clear the cached algorithms
-    broadphase->getOverlappingPairCache()->cleanProxyFromPairs(bp, dispatcher.get());
-    broadphase->destroyProxy(bp, dispatcher.get());
-    cow->setBroadphaseHandle(nullptr);
-  }
-}
+void removeCollisionObjectFromBroadphase(const COW::Ptr& cow,
+                                         const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                         const std::unique_ptr<btCollisionDispatcher>& dispatcher);
 
 /**
  * @brief Add the collision object to broadphase
@@ -1155,18 +450,9 @@ inline void removeCollisionObjectFromBroadphase(const COW::Ptr& cow,
  * @param broadphase The bullet broadphase interface
  * @param dispatcher The bullet collision dispatcher
  */
-inline void addCollisionObjectToBroadphase(const COW::Ptr& cow,
-                                           const std::unique_ptr<btBroadphaseInterface>& broadphase,
-                                           const std::unique_ptr<btCollisionDispatcher>& dispatcher)
-{
-  btVector3 aabb_min, aabb_max;
-  cow->getAABB(aabb_min, aabb_max);
-
-  // Add the active collision object to the broadphase
-  int type = cow->getCollisionShape()->getShapeType();
-  cow->setBroadphaseHandle(broadphase->createProxy(
-      aabb_min, aabb_max, type, cow.get(), cow->m_collisionFilterGroup, cow->m_collisionFilterMask, dispatcher.get()));
-}
+void addCollisionObjectToBroadphase(const COW::Ptr& cow,
+                                    const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                    const std::unique_ptr<btCollisionDispatcher>& dispatcher);
 
 /**
  * @brief Update a collision objects filters for broadphase
@@ -1175,18 +461,10 @@ inline void addCollisionObjectToBroadphase(const COW::Ptr& cow,
  * @param broadphase The collision object to update.
  * @param dispatcher The collision object to update.
  */
-inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
-                                         const COW::Ptr& cow,
-                                         const std::unique_ptr<btBroadphaseInterface>& broadphase,
-                                         const std::unique_ptr<btCollisionDispatcher>& dispatcher)
-{
-  updateCollisionObjectFilters(active, cow);
-
-  // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
-  // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
-  // this must be called or contacts between shapes will be missed.
-  broadphase->getOverlappingPairCache()->cleanProxyFromPairs(cow->getBroadphaseHandle(), dispatcher.get());
-}
+void updateCollisionObjectFilters(const std::vector<std::string>& active,
+                                  const COW::Ptr& cow,
+                                  const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                  const std::unique_ptr<btCollisionDispatcher>& dispatcher);
 
 /**
  * @brief Refresh the broadphase data structure
@@ -1197,29 +475,8 @@ inline void updateCollisionObjectFilters(const std::vector<std::string>& active,
  * @param broadphase The broadphase to update.
  * @param dispatcher The dispatcher.
  */
-inline void refreshBroadphaseProxy(const COW::Ptr& cow,
-                                   const std::unique_ptr<btBroadphaseInterface>& broadphase,
-                                   const std::unique_ptr<btCollisionDispatcher>& dispatcher)
-{
-  if (cow->getBroadphaseHandle() != nullptr)
-  {
-    broadphase->destroyProxy(cow->getBroadphaseHandle(), dispatcher.get());
-
-    btVector3 aabb_min, aabb_max;
-    cow->getAABB(aabb_min, aabb_max);
-
-    // Add the active collision object to the broadphase
-    int type = cow->getCollisionShape()->getShapeType();
-    cow->setBroadphaseHandle(broadphase->createProxy(aabb_min,
-                                                     aabb_max,
-                                                     type,
-                                                     cow.get(),
-                                                     cow->m_collisionFilterGroup,
-                                                     cow->m_collisionFilterMask,
-                                                     dispatcher.get()));
-  }
-}
-
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+void refreshBroadphaseProxy(const COW::Ptr& cow,
+                            const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                            const std::unique_ptr<btCollisionDispatcher>& dispatcher);
+}  // namespace tesseract_collision::tesseract_collision_bullet
 #endif  // TESSERACT_COLLISION_BULLET_UTILS_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_collision_configuration.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_collision_configuration.h
@@ -46,9 +46,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /**
  * @brief This is a modified configuration that included the modified Bullet algorithms.
@@ -64,6 +62,5 @@ public:
   TesseractCollisionConfiguration(
       const btDefaultCollisionConstructionInfo& constructionInfo = btDefaultCollisionConstructionInfo());
 };
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 #endif  // TESSERACT_COLLISION_TESSERACT_COLLISION_CONFIGURATION_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_compound_collision_algorithm.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_compound_collision_algorithm.h
@@ -35,9 +35,7 @@ class btCollisionObject;
 class btCollisionShape;
 
 // LCOV_EXCL_START
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /**
  * @brief Supports collision between CompoundCollisionShapes and other collision shapes
@@ -61,7 +59,7 @@ protected:
   bool m_isSwapped;
 
   class btPersistentManifold* m_sharedManifold;
-  bool m_ownsManifold;
+  bool m_ownsManifold{ false };
 
   int m_compoundShapeRevision;  // to keep track of changes, so that childAlgorithm array can be updated
 
@@ -124,7 +122,6 @@ public:
     }
   };
 };
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 // LCOV_EXCL_STOP
 #endif  // TESSERACT_COLLISION_TESSERACT_COMPOUND_COLLISION_ALGORITHM_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_compound_compound_collision_algorithm.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_compound_compound_collision_algorithm.h
@@ -38,9 +38,7 @@ class btCollisionObject;
 class btCollisionShape;
 
 // LCOV_EXCL_START
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /**
  * @brief Supports collision between two btCompoundCollisionShape shapes
@@ -110,7 +108,6 @@ public:
     }
   };
 };
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 // LCOV_EXCL_STOP
 #endif  // TESSERACT_COLLISION_TESSERACT_COMPOUND_COMPOUND_COLLISION_ALGORITHM_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_convex_convex_algorithm.h
@@ -36,9 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 class btConvexPenetrationDepthSolver;
 
 // LCOV_EXCL_START
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /// Enabling USE_SEPDISTANCE_UTIL2 requires 100% reliable distance computation. However, when using large size ratios
 /// GJK can be imprecise so the distance is not conservative. In that case, enabling this USE_SEPDISTANCE_UTIL2 would
@@ -74,9 +72,9 @@ class TesseractConvexConvexAlgorithm : public btActivatingCollisionAlgorithm
   btVertexArray worldVertsB1;
   btVertexArray worldVertsB2;
 
-  bool m_ownManifold;
+  bool m_ownManifold{ false };
   btPersistentManifold* m_manifoldPtr;
-  bool m_lowLevelOfDetail;
+  bool m_lowLevelOfDetail{ false };
 
   int m_numPerturbationIterations;
   int m_minimumPointsPerturbationThreshold;
@@ -124,8 +122,8 @@ public:
   struct CreateFunc : public btCollisionAlgorithmCreateFunc
   {
     btConvexPenetrationDepthSolver* m_pdSolver;
-    int m_numPerturbationIterations;
-    int m_minimumPointsPerturbationThreshold;
+    int m_numPerturbationIterations{ 0 };
+    int m_minimumPointsPerturbationThreshold{ 3 };
 
     CreateFunc(btConvexPenetrationDepthSolver* pdSolver);
 
@@ -145,7 +143,6 @@ public:
   };
 };
 
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 // LCOV_EXCL_STOP
 #endif  // TESSERACT_COLLISION_TESSERACT_CONVEX_CONVEX_ALGORITHM_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/tesseract_gjk_pair_detector.h
@@ -33,9 +33,7 @@ class btConvexPenetrationDepthSolver;
 
 #include <tesseract_collision/core/types.h>
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_bullet
+namespace tesseract_collision::tesseract_collision_bullet
 {
 /**
  * @brief This is a modifed Convex to Convex collision algorithm
@@ -113,6 +111,5 @@ public:
   /// don't use setIgnoreMargin, it's for Bullet's internal use
   void setIgnoreMargin(bool ignoreMargin) { m_ignoreMargin = ignoreMargin; }
 };
-}  // namespace tesseract_collision_bullet
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_bullet
 #endif  // TESSERACT_COLLISION_TESSERACT_GJK_PAIR_DETECTOR_H

--- a/tesseract_collision/bullet/src/bullet_utils.cpp
+++ b/tesseract_collision/bullet/src/bullet_utils.cpp
@@ -55,6 +55,57 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_collision::tesseract_collision_bullet
 {
+btVector3 convertEigenToBt(const Eigen::Vector3d& v)
+{
+  return btVector3{ static_cast<btScalar>(v[0]), static_cast<btScalar>(v[1]), static_cast<btScalar>(v[2]) };
+}
+
+Eigen::Vector3d convertBtToEigen(const btVector3& v)
+{
+  return Eigen::Vector3d{ static_cast<double>(v.x()), static_cast<double>(v.y()), static_cast<double>(v.z()) };
+}
+
+btQuaternion convertEigenToBt(const Eigen::Quaterniond& q)
+{
+  return btQuaternion{ static_cast<btScalar>(q.x()),
+                       static_cast<btScalar>(q.y()),
+                       static_cast<btScalar>(q.z()),
+                       static_cast<btScalar>(q.w()) };
+}
+
+btMatrix3x3 convertEigenToBt(const Eigen::Matrix3d& r)
+{
+  return btMatrix3x3{ static_cast<btScalar>(r(0, 0)), static_cast<btScalar>(r(0, 1)), static_cast<btScalar>(r(0, 2)),
+                      static_cast<btScalar>(r(1, 0)), static_cast<btScalar>(r(1, 1)), static_cast<btScalar>(r(1, 2)),
+                      static_cast<btScalar>(r(2, 0)), static_cast<btScalar>(r(2, 1)), static_cast<btScalar>(r(2, 2)) };
+}
+
+Eigen::Matrix3d convertBtToEigen(const btMatrix3x3& r)
+{
+  Eigen::Matrix3d m;
+  m << static_cast<double>(r[0][0]), static_cast<double>(r[0][1]), static_cast<double>(r[0][2]),
+      static_cast<double>(r[1][0]), static_cast<double>(r[1][1]), static_cast<double>(r[1][2]),
+      static_cast<double>(r[2][0]), static_cast<double>(r[2][1]), static_cast<double>(r[2][2]);
+  return m;
+}
+
+btTransform convertEigenToBt(const Eigen::Isometry3d& t)
+{
+  const Eigen::Matrix3d& rot = t.matrix().block<3, 3>(0, 0);
+  const Eigen::Vector3d& tran = t.translation();
+
+  return btTransform{ convertEigenToBt(rot), convertEigenToBt(tran) };
+}
+
+Eigen::Isometry3d convertBtToEigen(const btTransform& t)
+{
+  Eigen::Isometry3d i = Eigen::Isometry3d::Identity();
+  i.linear() = convertBtToEigen(t.getBasis());
+  i.translation() = convertBtToEigen(t.getOrigin());
+
+  return i;
+}
+
 std::shared_ptr<btCollisionShape> createShapePrimitive(const tesseract_geometry::Box::ConstPtr& geom)
 {
   auto a = static_cast<btScalar>(geom->getX() / 2);
@@ -110,7 +161,7 @@ std::shared_ptr<btCollisionShape> createShapePrimitive(const tesseract_geometry:
     for (int i = 0; i < triangle_count; ++i)
     {
       btVector3 v[3];  // NOLINT
-      assert(triangles[4 * i] == 3);
+      assert(triangles[4L * i] == 3);
       for (unsigned x = 0; x < 3; ++x)
       {
         // Note: triangles structure is number of vertices that represent the triangle followed by vertex indexes
@@ -357,6 +408,25 @@ std::shared_ptr<btCollisionShape> createShapePrimitive(const CollisionShapeConst
   return shape;
 }
 
+void updateCollisionObjectFilters(const std::vector<std::string>& active, const COW::Ptr& cow)
+{
+  cow->m_collisionFilterGroup = btBroadphaseProxy::KinematicFilter;
+
+  if (!isLinkActive(active, cow->getName()))
+  {
+    cow->m_collisionFilterGroup = btBroadphaseProxy::StaticFilter;
+  }
+
+  if (cow->m_collisionFilterGroup == btBroadphaseProxy::StaticFilter)
+  {
+    cow->m_collisionFilterMask = btBroadphaseProxy::KinematicFilter;
+  }
+  else
+  {
+    cow->m_collisionFilterMask = btBroadphaseProxy::StaticFilter | btBroadphaseProxy::KinematicFilter;
+  }
+}
+
 CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
                                                const int& type_id,
                                                CollisionShapesConst shapes,
@@ -404,4 +474,894 @@ CollisionObjectWrapper::CollisionObjectWrapper(std::string name,
   setWorldTransform(trans);
 }
 
+const std::string& CollisionObjectWrapper::getName() const { return m_name; }
+
+const int& CollisionObjectWrapper::getTypeID() const { return m_type_id; }
+
+bool CollisionObjectWrapper::sameObject(const CollisionObjectWrapper& other) const
+{
+  return m_name == other.m_name && m_type_id == other.m_type_id && m_shapes.size() == other.m_shapes.size() &&
+         m_shape_poses.size() == other.m_shape_poses.size() &&
+         std::equal(m_shapes.begin(), m_shapes.end(), other.m_shapes.begin()) &&
+         std::equal(m_shape_poses.begin(),
+                    m_shape_poses.end(),
+                    other.m_shape_poses.begin(),
+                    [](const Eigen::Isometry3d& t1, const Eigen::Isometry3d& t2) { return t1.isApprox(t2); });
+}
+
+const CollisionShapesConst& CollisionObjectWrapper::getCollisionGeometries() const { return m_shapes; }
+
+const tesseract_common::VectorIsometry3d& CollisionObjectWrapper::getCollisionGeometriesTransforms() const
+{
+  return m_shape_poses;
+}
+
+void CollisionObjectWrapper::getAABB(btVector3& aabb_min, btVector3& aabb_max) const
+{
+  getCollisionShape()->getAabb(getWorldTransform(), aabb_min, aabb_max);
+  const btScalar& d = getContactProcessingThreshold();
+  btVector3 contactThreshold(d, d, d);
+  aabb_min -= contactThreshold;
+  aabb_max += contactThreshold;
+}
+
+std::shared_ptr<CollisionObjectWrapper> CollisionObjectWrapper::clone()
+{
+  auto clone_cow = std::make_shared<CollisionObjectWrapper>();
+  clone_cow->m_name = m_name;
+  clone_cow->m_type_id = m_type_id;
+  clone_cow->m_shapes = m_shapes;
+  clone_cow->m_shape_poses = m_shape_poses;
+  clone_cow->m_data = m_data;
+  clone_cow->setCollisionShape(getCollisionShape());
+  clone_cow->setWorldTransform(getWorldTransform());
+  clone_cow->m_collisionFilterGroup = m_collisionFilterGroup;
+  clone_cow->m_collisionFilterMask = m_collisionFilterMask;
+  clone_cow->m_enabled = m_enabled;
+  clone_cow->setBroadphaseHandle(nullptr);
+  return clone_cow;
+}
+
+void CollisionObjectWrapper::manage(const std::shared_ptr<btCollisionShape>& t) { m_data.push_back(t); }
+
+void CollisionObjectWrapper::manageReserve(std::size_t s) { m_data.reserve(s); }
+
+CastHullShape::CastHullShape(btConvexShape* shape, const btTransform& t01) : m_shape(shape), m_t01(t01)
+{
+  m_shapeType = CUSTOM_CONVEX_SHAPE_TYPE;
+  setUserIndex(m_shape->getUserIndex());
+}
+
+void CastHullShape::updateCastTransform(const btTransform& t01) { m_t01 = t01; }
+btVector3 CastHullShape::localGetSupportingVertex(const btVector3& vec) const
+{
+  btVector3 sv0 = m_shape->localGetSupportingVertex(vec);
+  btVector3 sv1 = m_t01 * m_shape->localGetSupportingVertex(vec * m_t01.getBasis());
+  return (vec.dot(sv0) > vec.dot(sv1)) ? sv0 : sv1;
+}
+
+/// getAabb's default implementation is brute force, expected derived classes to implement a fast dedicated version
+void CastHullShape::getAabb(const btTransform& t_w0, btVector3& aabbMin, btVector3& aabbMax) const
+{
+  m_shape->getAabb(t_w0, aabbMin, aabbMax);
+  btVector3 min1, max1;
+  m_shape->getAabb(t_w0 * m_t01, min1, max1);
+  aabbMin.setMin(min1);
+  aabbMax.setMax(max1);
+}
+
+const char* CastHullShape::getName() const { return "CastHull"; }
+btVector3 CastHullShape::localGetSupportingVertexWithoutMargin(const btVector3& v) const
+{
+  return localGetSupportingVertex(v);
+}
+
+// LCOV_EXCL_START
+// notice that the vectors should be unit length
+void CastHullShape::batchedUnitVectorGetSupportingVertexWithoutMargin(const btVector3* /*vectors*/,
+                                                                      btVector3* /*supportVerticesOut*/,
+                                                                      int /*numVectors*/) const
+{
+  throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
+                           "a debugger and inspect the call stack to find the function in Bullet calling this "
+                           "function, then review commit history to determine what change.");
+}
+
+void CastHullShape::getAabbSlow(const btTransform& /*t*/, btVector3& /*aabbMin*/, btVector3& /*aabbMax*/) const
+{
+  throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
+                           "a debugger and inspect the call stack to find the function in Bullet calling this "
+                           "function, then review commit history to determine what change.");
+}
+
+void CastHullShape::setLocalScaling(const btVector3& /*scaling*/)
+{
+  throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
+                           "a debugger and inspect the call stack to find the function in Bullet calling this "
+                           "function, then review commit history to determine what change.");
+}
+
+const btVector3& CastHullShape::getLocalScaling() const
+{
+  static btVector3 out(1, 1, 1);
+  return out;
+}
+
+void CastHullShape::setMargin(btScalar /*margin*/) {}
+
+btScalar CastHullShape::getMargin() const { return 0; }
+
+int CastHullShape::getNumPreferredPenetrationDirections() const { return 0; }
+
+void CastHullShape::getPreferredPenetrationDirection(int /*index*/, btVector3& /*penetrationVector*/) const
+{
+  throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
+                           "a debugger and inspect the call stack to find the function in Bullet calling this "
+                           "function, then review commit history to determine what change.");
+}
+
+void CastHullShape::calculateLocalInertia(btScalar, btVector3&) const
+{
+  throw std::runtime_error("If you are seeing this error message then something in Bullet must have changed. Attach "
+                           "a debugger and inspect the call stack to find the function in Bullet calling this "
+                           "function, then review commit history to determine what change.");
+}
+
+void GetAverageSupport(const btConvexShape* shape, const btVector3& localNormal, btScalar& outsupport, btVector3& outpt)
+{
+  btVector3 ptSum(0, 0, 0);
+  btScalar ptCount = 0;
+  btScalar maxSupport = -1000;
+
+  const auto* pshape = dynamic_cast<const btPolyhedralConvexShape*>(shape);
+  if (pshape != nullptr)
+  {
+    int nPts = pshape->getNumVertices();
+
+    for (int i = 0; i < nPts; ++i)
+    {
+      btVector3 pt;
+      pshape->getVertex(i, pt);
+
+      btScalar sup = pt.dot(localNormal);
+      if (sup > maxSupport + BULLET_EPSILON)
+      {
+        ptCount = 1;
+        ptSum = pt;
+        maxSupport = sup;
+      }
+      else if (sup < maxSupport - BULLET_EPSILON)
+      {
+      }
+      else
+      {
+        ptCount += 1;
+        ptSum += pt;
+      }
+    }
+    outsupport = maxSupport;
+    outpt = ptSum / ptCount;
+  }
+  else
+  {
+    // The margins are set to zero for most shapes, but for a sphere the margin is used so must use
+    // localGetSupportingVertex instead of localGetSupportingVertexWithoutMargin.
+    outpt = shape->localGetSupportingVertex(localNormal);  // NOLINT
+    outsupport = localNormal.dot(outpt);
+  }
+}
+
+btTransform getLinkTransformFromCOW(const btCollisionObjectWrapper* cow)
+{
+  if (cow->m_parent != nullptr)
+  {
+    if (cow->m_parent->m_parent != nullptr)
+    {
+      assert(cow->m_parent->m_parent->m_parent == nullptr);
+      return cow->m_parent->m_parent->getWorldTransform();
+    }
+
+    return cow->m_parent->getWorldTransform();
+  }
+
+  return cow->getWorldTransform();
+}
+
+bool needsCollisionCheck(const COW& cow1, const COW& cow2, const IsContactAllowedFn& acm, bool verbose)
+{
+  return cow1.m_enabled && cow2.m_enabled && (cow2.m_collisionFilterGroup & cow1.m_collisionFilterMask) &&  // NOLINT
+         (cow1.m_collisionFilterGroup & cow2.m_collisionFilterMask) &&                                      // NOLINT
+         !isContactAllowed(cow1.getName(), cow2.getName(), acm, verbose);
+}
+
+btScalar addDiscreteSingleResult(btManifoldPoint& cp,
+                                 const btCollisionObjectWrapper* colObj0Wrap,
+                                 const btCollisionObjectWrapper* colObj1Wrap,
+                                 ContactTestData& collisions)
+{
+  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject()) != nullptr);
+  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject()) != nullptr);
+  const auto* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());  // NOLINT
+  const auto* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());  // NOLINT
+
+  ObjectPairKey pc = getObjectPairKey(cd0->getName(), cd1->getName());
+
+  const auto& it = collisions.res->find(pc);
+  bool found = (it != collisions.res->end());
+
+  //    size_t l = 0;
+  //    if (found)
+  //    {
+  //      l = it->second.size();
+  //      if (m_collisions.req->type == DistanceRequestType::LIMITED && l >= m_collisions.req->max_contacts_per_body)
+  //          return 0;
+
+  //    }
+
+  btTransform tf0 = getLinkTransformFromCOW(colObj0Wrap);
+  btTransform tf1 = getLinkTransformFromCOW(colObj1Wrap);
+  btTransform tf0_inv = tf0.inverse();
+  btTransform tf1_inv = tf1.inverse();
+
+  ContactResult contact;
+  contact.link_names[0] = cd0->getName();
+  contact.link_names[1] = cd1->getName();
+  contact.shape_id[0] = colObj0Wrap->getCollisionShape()->getUserIndex();
+  contact.shape_id[1] = colObj1Wrap->getCollisionShape()->getUserIndex();
+  contact.subshape_id[0] = colObj0Wrap->m_index;
+  contact.subshape_id[1] = colObj1Wrap->m_index;
+  contact.nearest_points[0] = convertBtToEigen(cp.m_positionWorldOnA);
+  contact.nearest_points[1] = convertBtToEigen(cp.m_positionWorldOnB);
+  contact.nearest_points_local[0] = convertBtToEigen(tf0_inv * cp.m_positionWorldOnA);
+  contact.nearest_points_local[1] = convertBtToEigen(tf1_inv * cp.m_positionWorldOnB);
+  contact.transform[0] = convertBtToEigen(tf0);
+  contact.transform[1] = convertBtToEigen(tf1);
+  contact.type_id[0] = cd0->getTypeID();
+  contact.type_id[1] = cd1->getTypeID();
+  contact.distance = static_cast<double>(cp.m_distance1);
+  contact.normal = convertBtToEigen(-1 * cp.m_normalWorldOnB);
+
+  if (processResult(collisions, contact, pc, found) == nullptr)
+    return 0;
+
+  return 1;
+}
+
+void calculateContinuousData(ContactResult* col,
+                             const btCollisionObjectWrapper* cow,
+                             const btVector3& pt_world,
+                             const btVector3& normal_world,
+                             const btTransform& link_tf_inv,
+                             size_t link_index)
+{
+  assert(dynamic_cast<const CastHullShape*>(cow->getCollisionShape()) != nullptr);
+  const auto* shape = static_cast<const CastHullShape*>(cow->getCollisionShape());
+  assert(shape != nullptr);
+
+  // Get the start and final location of the shape
+  btTransform shape_tfWorld0 = cow->getWorldTransform();
+  btTransform shape_tfWorld1 = cow->getWorldTransform() * shape->m_t01;
+
+  // Given the shapes final location calculate the links transform at the final location
+  // NOLINTNEXTLINE
+  Eigen::Isometry3d s = col->transform[link_index].inverse() * convertBtToEigen(shape_tfWorld0);
+  col->cc_transform[link_index] = convertBtToEigen(shape_tfWorld1) * s.inverse();
+
+  // Get the normal in the local shapes coordinate system at start and final location
+  btVector3 shape_normalLocal0 = normal_world * shape_tfWorld0.getBasis();
+  btVector3 shape_normalLocal1 = normal_world * shape_tfWorld1.getBasis();
+
+  // Calculate the contact point at the start location using the casted normal vector in thapes local coordinate system
+  btVector3 shape_ptLocal0;
+  btScalar shape_localsup0{ std::numeric_limits<btScalar>::max() };
+  GetAverageSupport(shape->m_shape, shape_normalLocal0, shape_localsup0, shape_ptLocal0);
+  btVector3 shape_ptWorld0 = shape_tfWorld0 * shape_ptLocal0;
+
+  // Calculate the contact point at the final location using the casted normal vector in thapes local coordinate system
+  btVector3 shape_ptLocal1;
+  btScalar shape_localsup1{ std::numeric_limits<btScalar>::max() };
+  GetAverageSupport(shape->m_shape, shape_normalLocal1, shape_localsup1, shape_ptLocal1);
+  btVector3 shape_ptWorld1 = shape_tfWorld1 * shape_ptLocal1;
+
+  btScalar shape_sup0 = normal_world.dot(shape_ptWorld0);
+  btScalar shape_sup1 = normal_world.dot(shape_ptWorld1);
+
+  // TODO: this section is potentially problematic. think hard about the math
+  if (shape_sup0 - shape_sup1 > BULLET_SUPPORT_FUNC_TOLERANCE)
+  {
+    // LCOV_EXCL_START
+    col->cc_time[link_index] = 0;
+    col->cc_type[link_index] = ContinuousCollisionType::CCType_Time0;
+    // LCOV_EXCL_STOP
+  }
+  else if (shape_sup1 - shape_sup0 > BULLET_SUPPORT_FUNC_TOLERANCE)
+  {
+    // LCOV_EXCL_START
+    col->cc_time[link_index] = 1;
+    col->cc_type[link_index] = ContinuousCollisionType::CCType_Time1;
+    // LCOV_EXCL_STOP
+  }
+  else
+  {
+    // Given the contact point at the start and final location along with the casted contact point
+    // the time between 0 and 1 can be calculated along the path between the start and final location contact occurs.
+    btScalar l0c = (pt_world - shape_ptWorld0).length();
+    btScalar l1c = (pt_world - shape_ptWorld1).length();
+
+    col->nearest_points_local[link_index] =
+        convertBtToEigen(link_tf_inv * (shape_tfWorld0 * ((shape_ptLocal0 + shape_ptLocal1) / 2.0)));
+    col->cc_type[link_index] = ContinuousCollisionType::CCType_Between;
+
+    if (l0c + l1c < BULLET_LENGTH_TOLERANCE)
+    {
+      col->cc_time[link_index] = .5;  // LCOV_EXCL_LINE
+    }
+    else
+    {
+      col->cc_time[link_index] = static_cast<double>(l0c / (l0c + l1c));
+    }
+  }
+}
+
+btScalar addCastSingleResult(btManifoldPoint& cp,
+                             const btCollisionObjectWrapper* colObj0Wrap,
+                             int /*index0*/,
+                             const btCollisionObjectWrapper* colObj1Wrap,
+                             int /*index1*/,
+                             ContactTestData& collisions)
+{
+  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject()) != nullptr);
+  assert(dynamic_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject()) != nullptr);
+  const auto* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());  // NOLINT
+  const auto* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());  // NOLINT
+
+  const std::pair<std::string, std::string>& pc = cd0->getName() < cd1->getName() ?
+                                                      std::make_pair(cd0->getName(), cd1->getName()) :
+                                                      std::make_pair(cd1->getName(), cd0->getName());
+
+  auto it = collisions.res->find(pc);
+  bool found = it != collisions.res->end();
+
+  //    size_t l = 0;
+  //    if (found)
+  //    {
+  //      l = it->second.size();
+  //      if (m_collisions.req->type == DistanceRequestType::LIMITED && l >= m_collisions.req->max_contacts_per_body)
+  //          return 0;
+  //    }
+
+  btTransform tf0 = getLinkTransformFromCOW(colObj0Wrap);
+  btTransform tf1 = getLinkTransformFromCOW(colObj1Wrap);
+  btTransform tf0_inv = tf0.inverse();
+  btTransform tf1_inv = tf1.inverse();
+
+  ContactResult contact;
+  contact.link_names[0] = cd0->getName();
+  contact.link_names[1] = cd1->getName();
+  contact.shape_id[0] = colObj0Wrap->getCollisionShape()->getUserIndex();
+  contact.shape_id[1] = colObj1Wrap->getCollisionShape()->getUserIndex();
+  contact.subshape_id[0] = colObj0Wrap->m_index;
+  contact.subshape_id[1] = colObj1Wrap->m_index;
+  contact.nearest_points[0] = convertBtToEigen(cp.m_positionWorldOnA);
+  contact.nearest_points[1] = convertBtToEigen(cp.m_positionWorldOnB);
+  contact.nearest_points_local[0] = convertBtToEigen(tf0_inv * cp.m_positionWorldOnA);
+  contact.nearest_points_local[1] = convertBtToEigen(tf1_inv * cp.m_positionWorldOnB);
+  contact.transform[0] = convertBtToEigen(tf0);
+  contact.transform[1] = convertBtToEigen(tf1);
+  contact.type_id[0] = cd0->getTypeID();
+  contact.type_id[1] = cd1->getTypeID();
+  contact.distance = static_cast<double>(cp.m_distance1);
+  contact.normal = convertBtToEigen(-1 * cp.m_normalWorldOnB);
+
+  ContactResult* col = processResult(collisions, contact, pc, found);
+  if (col == nullptr)
+    return 0;
+
+  if (cd0->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter &&
+      cd1->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter)
+  {
+    calculateContinuousData(col, colObj0Wrap, cp.m_positionWorldOnA, -1 * cp.m_normalWorldOnB, tf0_inv, 0);
+    calculateContinuousData(col, colObj1Wrap, cp.m_positionWorldOnB, cp.m_normalWorldOnB, tf1_inv, 1);
+  }
+  else
+  {
+    bool castShapeIsFirst = (cd0->m_collisionFilterGroup == btBroadphaseProxy::KinematicFilter);
+    btVector3 normalWorldFromCast = -(castShapeIsFirst ? 1 : -1) * cp.m_normalWorldOnB;
+    const btCollisionObjectWrapper* firstColObjWrap = (castShapeIsFirst ? colObj0Wrap : colObj1Wrap);
+    const btTransform& first_tf_inv = (castShapeIsFirst ? tf0_inv : tf1_inv);
+    const btVector3& ptOnCast = castShapeIsFirst ? cp.m_positionWorldOnA : cp.m_positionWorldOnB;
+
+    if (castShapeIsFirst)
+    {
+      std::swap(col->nearest_points[0], col->nearest_points[1]);
+      std::swap(col->nearest_points_local[0], col->nearest_points_local[1]);
+      std::swap(col->transform[0], col->transform[1]);
+      std::swap(col->link_names[0], col->link_names[1]);
+      std::swap(col->type_id[0], col->type_id[1]);
+      std::swap(col->shape_id[0], col->shape_id[1]);
+      std::swap(col->subshape_id[0], col->subshape_id[1]);
+      col->normal *= -1;
+    }
+
+    calculateContinuousData(col, firstColObjWrap, ptOnCast, normalWorldFromCast, first_tf_inv, 1);
+  }
+
+  return 1;
+}
+
+TesseractBridgedManifoldResult::TesseractBridgedManifoldResult(const btCollisionObjectWrapper* obj0Wrap,
+                                                               const btCollisionObjectWrapper* obj1Wrap,
+                                                               btCollisionWorld::ContactResultCallback& resultCallback)
+  : btManifoldResult(obj0Wrap, obj1Wrap), m_resultCallback(resultCallback)
+{
+}
+
+void TesseractBridgedManifoldResult::addContactPoint(const btVector3& normalOnBInWorld,
+                                                     const btVector3& pointInWorld,
+                                                     btScalar depth)
+{
+  bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
+  btVector3 pointA = pointInWorld + normalOnBInWorld * depth;
+  btVector3 localA;
+  btVector3 localB;
+  if (isSwapped)
+  {
+    localA = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+    localB = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+  }
+  else
+  {
+    localA = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+    localB = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+  }
+
+  btManifoldPoint newPt(localA, localB, normalOnBInWorld, depth);
+  newPt.m_positionWorldOnA = pointA;
+  newPt.m_positionWorldOnB = pointInWorld;
+
+  // BP mod, store contact triangles.
+  if (isSwapped)
+  {
+    newPt.m_partId0 = m_partId1;
+    newPt.m_partId1 = m_partId0;
+    newPt.m_index0 = m_index1;
+    newPt.m_index1 = m_index0;
+  }
+  else
+  {
+    newPt.m_partId0 = m_partId0;
+    newPt.m_partId1 = m_partId1;
+    newPt.m_index0 = m_index0;
+    newPt.m_index1 = m_index1;
+  }
+
+  // experimental feature info, for per-triangle material etc.
+  const btCollisionObjectWrapper* obj0Wrap = isSwapped ? m_body1Wrap : m_body0Wrap;
+  const btCollisionObjectWrapper* obj1Wrap = isSwapped ? m_body0Wrap : m_body1Wrap;
+  m_resultCallback.addSingleResult(
+      newPt, obj0Wrap, newPt.m_partId0, newPt.m_index0, obj1Wrap, newPt.m_partId1, newPt.m_index1);
+}
+
+BroadphaseContactResultCallback::BroadphaseContactResultCallback(ContactTestData& collisions,
+                                                                 double contact_distance,
+                                                                 bool verbose)
+  : collisions_(collisions), contact_distance_(contact_distance), verbose_(verbose)
+{
+}
+
+bool BroadphaseContactResultCallback::needsCollision(const CollisionObjectWrapper* cow0,
+                                                     const CollisionObjectWrapper* cow1) const
+{
+  return !collisions_.done && needsCollisionCheck(*cow0, *cow1, collisions_.fn, verbose_);
+}
+
+DiscreteBroadphaseContactResultCallback::DiscreteBroadphaseContactResultCallback(ContactTestData& collisions,
+                                                                                 double contact_distance,
+                                                                                 bool verbose)
+  : BroadphaseContactResultCallback(collisions, contact_distance, verbose)
+{
+}
+
+btScalar DiscreteBroadphaseContactResultCallback::addSingleResult(btManifoldPoint& cp,
+                                                                  const btCollisionObjectWrapper* colObj0Wrap,
+                                                                  int /*partId0*/,
+                                                                  int /*index0*/,
+                                                                  const btCollisionObjectWrapper* colObj1Wrap,
+                                                                  int /*partId1*/,
+                                                                  int /*index1*/)
+{
+  if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+    return 0;
+
+  return addDiscreteSingleResult(cp, colObj0Wrap, colObj1Wrap, collisions_);
+}
+
+CastBroadphaseContactResultCallback::CastBroadphaseContactResultCallback(ContactTestData& collisions,
+                                                                         double contact_distance,
+                                                                         bool verbose)
+  : BroadphaseContactResultCallback(collisions, contact_distance, verbose)
+{
+}
+
+btScalar CastBroadphaseContactResultCallback::addSingleResult(btManifoldPoint& cp,
+                                                              const btCollisionObjectWrapper* colObj0Wrap,
+                                                              int /*partId0*/,
+                                                              int index0,
+                                                              const btCollisionObjectWrapper* colObj1Wrap,
+                                                              int /*partId1*/,
+                                                              int index1)
+{
+  if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+    return 0;
+
+  return addCastSingleResult(cp, colObj0Wrap, index0, colObj1Wrap, index1, collisions_);
+}
+
+TesseractBroadphaseBridgedManifoldResult::TesseractBroadphaseBridgedManifoldResult(
+    const btCollisionObjectWrapper* obj0Wrap,
+    const btCollisionObjectWrapper* obj1Wrap,
+    BroadphaseContactResultCallback& result_callback)
+  : btManifoldResult(obj0Wrap, obj1Wrap), result_callback_(result_callback)
+{
+}
+
+void TesseractBroadphaseBridgedManifoldResult::addContactPoint(const btVector3& normalOnBInWorld,
+                                                               const btVector3& pointInWorld,
+                                                               btScalar depth)
+{
+  if (result_callback_.collisions_.done || depth > static_cast<btScalar>(result_callback_.contact_distance_))
+    return;
+
+  bool isSwapped = m_manifoldPtr->getBody0() != m_body0Wrap->getCollisionObject();
+  btVector3 pointA = pointInWorld + normalOnBInWorld * depth;
+  btVector3 localA;
+  btVector3 localB;
+  if (isSwapped)
+  {
+    localA = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+    localB = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+  }
+  else
+  {
+    localA = m_body0Wrap->getCollisionObject()->getWorldTransform().invXform(pointA);
+    localB = m_body1Wrap->getCollisionObject()->getWorldTransform().invXform(pointInWorld);
+  }
+
+  btManifoldPoint newPt(localA, localB, normalOnBInWorld, depth);
+  newPt.m_positionWorldOnA = pointA;
+  newPt.m_positionWorldOnB = pointInWorld;
+
+  // BP mod, store contact triangles.
+  if (isSwapped)
+  {
+    newPt.m_partId0 = m_partId1;
+    newPt.m_partId1 = m_partId0;
+    newPt.m_index0 = m_index1;
+    newPt.m_index1 = m_index0;
+  }
+  else
+  {
+    newPt.m_partId0 = m_partId0;
+    newPt.m_partId1 = m_partId1;
+    newPt.m_index0 = m_index0;
+    newPt.m_index1 = m_index1;
+  }
+
+  // experimental feature info, for per-triangle material etc.
+  const btCollisionObjectWrapper* obj0Wrap = isSwapped ? m_body1Wrap : m_body0Wrap;
+  const btCollisionObjectWrapper* obj1Wrap = isSwapped ? m_body0Wrap : m_body1Wrap;
+  result_callback_.addSingleResult(
+      newPt, obj0Wrap, newPt.m_partId0, newPt.m_index0, obj1Wrap, newPt.m_partId1, newPt.m_index1);
+}
+
+TesseractCollisionPairCallback::TesseractCollisionPairCallback(const btDispatcherInfo& dispatchInfo,
+                                                               btCollisionDispatcher* dispatcher,
+                                                               BroadphaseContactResultCallback& results_callback)
+  : dispatch_info_(dispatchInfo), dispatcher_(dispatcher), results_callback_(results_callback)
+{
+}
+
+bool TesseractCollisionPairCallback::processOverlap(btBroadphasePair& pair)
+{
+  if (results_callback_.collisions_.done)
+    return false;
+
+  const auto* cow0 = static_cast<const CollisionObjectWrapper*>(pair.m_pProxy0->m_clientObject);
+  const auto* cow1 = static_cast<const CollisionObjectWrapper*>(pair.m_pProxy1->m_clientObject);
+
+  if (results_callback_.needsCollision(cow0, cow1))
+  {
+    btCollisionObjectWrapper obj0Wrap(nullptr, cow0->getCollisionShape(), cow0, cow0->getWorldTransform(), -1, -1);
+    btCollisionObjectWrapper obj1Wrap(nullptr, cow1->getCollisionShape(), cow1, cow1->getWorldTransform(), -1, -1);
+
+    // dispatcher will keep algorithms persistent in the collision pair
+    if (pair.m_algorithm == nullptr)
+    {
+      pair.m_algorithm = dispatcher_->findAlgorithm(&obj0Wrap, &obj1Wrap, nullptr, BT_CLOSEST_POINT_ALGORITHMS);
+    }
+
+    if (pair.m_algorithm != nullptr)
+    {
+      TesseractBroadphaseBridgedManifoldResult contactPointResult(&obj0Wrap, &obj1Wrap, results_callback_);
+      contactPointResult.m_closestPointDistanceThreshold = static_cast<btScalar>(results_callback_.contact_distance_);
+
+      // discrete collision detection query
+      pair.m_algorithm->processCollision(&obj0Wrap, &obj1Wrap, dispatch_info_, &contactPointResult);
+    }
+  }
+  return false;
+}
+
+TesseractOverlapFilterCallback::TesseractOverlapFilterCallback(bool verbose) : verbose_(verbose) {}
+
+bool TesseractOverlapFilterCallback::needBroadphaseCollision(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1) const
+{
+  // Note: We do not pass the allowed collision matrix because if it changes we do not know and this function only
+  // gets called under certain cases and it could cause overlapping pairs to not be processed.
+  return needsCollisionCheck(*(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)),
+                             *(static_cast<CollisionObjectWrapper*>(proxy1->m_clientObject)),
+                             nullptr,
+                             verbose_);
+}
+
+COW::Ptr createCollisionObject(const std::string& name,
+                               const int& type_id,
+                               const CollisionShapesConst& shapes,
+                               const tesseract_common::VectorIsometry3d& shape_poses,
+                               bool enabled)
+{
+  // dont add object that does not have geometry
+  if (shapes.empty() || shape_poses.empty() || (shapes.size() != shape_poses.size()))
+  {
+    CONSOLE_BRIDGE_logDebug("ignoring link %s", name.c_str());
+    return nullptr;
+  }
+
+  auto new_cow = std::make_shared<COW>(name, type_id, shapes, shape_poses);
+
+  new_cow->m_enabled = enabled;
+  new_cow->setContactProcessingThreshold(BULLET_DEFAULT_CONTACT_DISTANCE);
+
+  CONSOLE_BRIDGE_logDebug("Created collision object for link %s", new_cow->getName().c_str());
+  return new_cow;
+}
+
+DiscreteCollisionCollector::DiscreteCollisionCollector(ContactTestData& collisions,
+                                                       COW::Ptr cow,
+                                                       btScalar contact_distance,
+                                                       bool verbose)
+  : collisions_(collisions), cow_(std::move(cow)), contact_distance_(contact_distance), verbose_(verbose)
+{
+  m_closestDistanceThreshold = contact_distance;
+  m_collisionFilterGroup = cow_->m_collisionFilterGroup;
+  m_collisionFilterMask = cow_->m_collisionFilterMask;
+}
+
+btScalar DiscreteCollisionCollector::addSingleResult(btManifoldPoint& cp,
+                                                     const btCollisionObjectWrapper* colObj0Wrap,
+                                                     int /*partId0*/,
+                                                     int /*index0*/,
+                                                     const btCollisionObjectWrapper* colObj1Wrap,
+                                                     int /*partId1*/,
+                                                     int /*index1*/)
+{
+  if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+    return 0;
+
+  return addDiscreteSingleResult(cp, colObj0Wrap, colObj1Wrap, collisions_);
+}
+
+bool DiscreteCollisionCollector::needsCollision(btBroadphaseProxy* proxy0) const
+{
+  return !collisions_.done &&
+         needsCollisionCheck(
+             *cow_, *(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)), collisions_.fn, verbose_);
+}
+
+CastCollisionCollector::CastCollisionCollector(ContactTestData& collisions,
+                                               COW::Ptr cow,
+                                               double contact_distance,
+                                               bool verbose)
+  : collisions_(collisions), cow_(std::move(cow)), contact_distance_(contact_distance), verbose_(verbose)
+{
+  m_closestDistanceThreshold = static_cast<btScalar>(contact_distance);
+  m_collisionFilterGroup = cow_->m_collisionFilterGroup;
+  m_collisionFilterMask = cow_->m_collisionFilterMask;
+}
+
+btScalar CastCollisionCollector::addSingleResult(btManifoldPoint& cp,
+                                                 const btCollisionObjectWrapper* colObj0Wrap,
+                                                 int /*partId0*/,
+                                                 int index0,
+                                                 const btCollisionObjectWrapper* colObj1Wrap,
+                                                 int /*partId1*/,
+                                                 int index1)
+{
+  // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
+  if (cp.m_distance1 > static_cast<btScalar>(contact_distance_))
+    return 0;
+
+  return addCastSingleResult(cp, colObj0Wrap, index0, colObj1Wrap, index1, collisions_);
+}
+
+bool CastCollisionCollector::needsCollision(btBroadphaseProxy* proxy0) const
+{
+  return !collisions_.done &&
+         needsCollisionCheck(
+             *cow_, *(static_cast<CollisionObjectWrapper*>(proxy0->m_clientObject)), collisions_.fn, verbose_);
+}
+
+COW::Ptr makeCastCollisionObject(const COW::Ptr& cow)
+{
+  COW::Ptr new_cow = cow->clone();
+
+  btTransform tf;
+  tf.setIdentity();
+
+  if (btBroadphaseProxy::isConvex(new_cow->getCollisionShape()->getShapeType()))
+  {
+    assert(dynamic_cast<btConvexShape*>(new_cow->getCollisionShape()) != nullptr);
+    auto* convex = static_cast<btConvexShape*>(new_cow->getCollisionShape());  // NOLINT
+    assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if the collision object is already a
+                                                                 // cast collision object
+
+    auto shape = std::make_shared<CastHullShape>(convex, tf);
+    assert(shape != nullptr);
+
+    new_cow->manage(shape);
+    new_cow->setCollisionShape(shape.get());
+  }
+  else if (btBroadphaseProxy::isCompound(new_cow->getCollisionShape()->getShapeType()))
+  {
+    assert(dynamic_cast<btCompoundShape*>(new_cow->getCollisionShape()) != nullptr);
+    auto* compound = static_cast<btCompoundShape*>(new_cow->getCollisionShape());  // NOLINT
+    auto new_compound =
+        std::make_shared<btCompoundShape>(BULLET_COMPOUND_USE_DYNAMIC_AABB, compound->getNumChildShapes());
+
+    for (int i = 0; i < compound->getNumChildShapes(); ++i)
+    {
+      if (btBroadphaseProxy::isConvex(compound->getChildShape(i)->getShapeType()))
+      {
+        auto* convex = static_cast<btConvexShape*>(compound->getChildShape(i));  // NOLINT
+        assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if already a cast collision object
+
+        btTransform geomTrans = compound->getChildTransform(i);
+
+        auto subshape = std::make_shared<CastHullShape>(convex, tf);
+        assert(subshape != nullptr);
+
+        new_cow->manage(subshape);
+        subshape->setMargin(BULLET_MARGIN);
+        new_compound->addChildShape(geomTrans, subshape.get());
+      }
+      else if (btBroadphaseProxy::isCompound(compound->getChildShape(i)->getShapeType()))
+      {
+        auto* second_compound = static_cast<btCompoundShape*>(compound->getChildShape(i));  // NOLINT
+        auto new_second_compound =
+            std::make_shared<btCompoundShape>(BULLET_COMPOUND_USE_DYNAMIC_AABB, second_compound->getNumChildShapes());
+        for (int j = 0; j < second_compound->getNumChildShapes(); ++j)
+        {
+          assert(!btBroadphaseProxy::isCompound(second_compound->getChildShape(j)->getShapeType()));
+          assert(dynamic_cast<btConvexShape*>(second_compound->getChildShape(j)) != nullptr);
+
+          auto* convex = static_cast<btConvexShape*>(second_compound->getChildShape(j));  // NOLINT
+          assert(convex->getShapeType() != CUSTOM_CONVEX_SHAPE_TYPE);  // This checks if already a cast collision object
+
+          btTransform geomTrans = second_compound->getChildTransform(j);
+
+          auto subshape = std::make_shared<CastHullShape>(convex, tf);
+          assert(subshape != nullptr);
+
+          new_cow->manage(subshape);
+          subshape->setMargin(BULLET_MARGIN);
+          new_second_compound->addChildShape(geomTrans, subshape.get());
+        }
+
+        btTransform geomTrans = compound->getChildTransform(i);
+
+        new_cow->manage(new_second_compound);
+        new_second_compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to
+                                                        // have no effect when positive
+                                                        // but has an effect when
+                                                        // negative
+
+        new_compound->addChildShape(geomTrans, new_second_compound.get());
+      }
+      else
+      {
+        throw std::runtime_error("I can only collision check convex shapes and compound shapes made of convex shapes");
+      }
+    }
+
+    new_compound->setMargin(BULLET_MARGIN);  // margin: compound. seems to
+                                             // have no effect when positive
+                                             // but has an effect when
+                                             // negative
+    new_cow->manage(new_compound);
+    new_cow->setCollisionShape(new_compound.get());
+    new_cow->setWorldTransform(cow->getWorldTransform());
+  }
+  else
+  {
+    throw std::runtime_error("I can only collision check convex shapes and compound shapes made of convex shapes");
+  }
+
+  return new_cow;
+}
+
+void updateBroadphaseAABB(const COW::Ptr& cow,
+                          const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                          const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  // Calculate the aabb
+  btVector3 aabb_min, aabb_max;
+  cow->getAABB(aabb_min, aabb_max);
+
+  // Update the broadphase aabb
+  assert(cow->getBroadphaseHandle() != nullptr);
+  broadphase->setAabb(cow->getBroadphaseHandle(), aabb_min, aabb_max, dispatcher.get());
+}
+
+void removeCollisionObjectFromBroadphase(const COW::Ptr& cow,
+                                         const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                         const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  btBroadphaseProxy* bp = cow->getBroadphaseHandle();
+  if (bp != nullptr)
+  {
+    // only clear the cached algorithms
+    broadphase->getOverlappingPairCache()->cleanProxyFromPairs(bp, dispatcher.get());
+    broadphase->destroyProxy(bp, dispatcher.get());
+    cow->setBroadphaseHandle(nullptr);
+  }
+}
+
+void addCollisionObjectToBroadphase(const COW::Ptr& cow,
+                                    const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                    const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  btVector3 aabb_min, aabb_max;
+  cow->getAABB(aabb_min, aabb_max);
+
+  // Add the active collision object to the broadphase
+  int type{ cow->getCollisionShape()->getShapeType() };
+  cow->setBroadphaseHandle(broadphase->createProxy(
+      aabb_min, aabb_max, type, cow.get(), cow->m_collisionFilterGroup, cow->m_collisionFilterMask, dispatcher.get()));
+}
+
+void updateCollisionObjectFilters(const std::vector<std::string>& active,
+                                  const COW::Ptr& cow,
+                                  const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                                  const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  updateCollisionObjectFilters(active, cow);
+
+  // Need to clean the proxy from broadphase cache so BroadPhaseFilter gets called again.
+  // The BroadPhaseFilter only gets called once, so if you change when two objects can be in collision, like filters
+  // this must be called or contacts between shapes will be missed.
+  broadphase->getOverlappingPairCache()->cleanProxyFromPairs(cow->getBroadphaseHandle(), dispatcher.get());
+}
+
+void refreshBroadphaseProxy(const COW::Ptr& cow,
+                            const std::unique_ptr<btBroadphaseInterface>& broadphase,
+                            const std::unique_ptr<btCollisionDispatcher>& dispatcher)
+{
+  if (cow->getBroadphaseHandle() != nullptr)
+  {
+    broadphase->destroyProxy(cow->getBroadphaseHandle(), dispatcher.get());
+
+    btVector3 aabb_min, aabb_max;
+    cow->getAABB(aabb_min, aabb_max);
+
+    // Add the active collision object to the broadphase
+    int type{ cow->getCollisionShape()->getShapeType() };
+    cow->setBroadphaseHandle(broadphase->createProxy(aabb_min,
+                                                     aabb_max,
+                                                     type,
+                                                     cow.get(),
+                                                     cow->m_collisionFilterGroup,
+                                                     cow->m_collisionFilterMask,
+                                                     dispatcher.get()));
+  }
+}
 }  // namespace tesseract_collision::tesseract_collision_bullet

--- a/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
@@ -41,8 +41,6 @@ TesseractCompoundCollisionAlgorithm::TesseractCompoundCollisionAlgorithm(const b
                                                                          bool isSwapped)
   : btActivatingCollisionAlgorithm(ci, body0Wrap, body1Wrap), m_isSwapped(isSwapped), m_sharedManifold(ci.m_manifold)
 {
-  m_ownsManifold = false;
-
   const btCollisionObjectWrapper* colObjWrap = m_isSwapped ? body1Wrap : body0Wrap;
   btAssert(colObjWrap->getCollisionShape()->isCompound());
 

--- a/tesseract_collision/bullet/src/tesseract_compound_compound_collision_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_compound_compound_collision_algorithm.cpp
@@ -102,7 +102,7 @@ void TesseractCompoundCompoundCollisionAlgorithm::removeChildAlgorithms()
 
 struct TesseractCompoundCompoundLeafCallback : btDbvt::ICollide
 {
-  int m_numOverlapPairs;
+  int m_numOverlapPairs{ 0 };
 
   const btCollisionObjectWrapper* m_compound0ColObjWrap;
   const btCollisionObjectWrapper* m_compound1ColObjWrap;
@@ -123,8 +123,7 @@ struct TesseractCompoundCompoundLeafCallback : btDbvt::ICollide
                                         btManifoldResult* resultOut,
                                         btHashedSimplePairCache* childAlgorithmsCache,
                                         btPersistentManifold* sharedManifold)
-    : m_numOverlapPairs(0)
-    , m_compound0ColObjWrap(compound1ObjWrap)
+    : m_compound0ColObjWrap(compound1ObjWrap)
     , m_compound1ColObjWrap(compound0ObjWrap)
     , m_dispatcher(dispatcher)
     , m_dispatchInfo(dispatchInfo)

--- a/tesseract_collision/bullet/src/tesseract_convex_convex_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_convex_convex_algorithm.cpp
@@ -181,11 +181,8 @@ static SIMD_FORCE_INLINE btScalar capsuleCapsuleDistance(btVector3& normalOnB,
 
 //////////
 
-TesseractConvexConvexAlgorithm::CreateFunc::CreateFunc(btConvexPenetrationDepthSolver* pdSolver)
+TesseractConvexConvexAlgorithm::CreateFunc::CreateFunc(btConvexPenetrationDepthSolver* pdSolver) : m_pdSolver(pdSolver)
 {
-  m_numPerturbationIterations = 0;
-  m_minimumPointsPerturbationThreshold = 3;
-  m_pdSolver = pdSolver;
 }
 
 TesseractConvexConvexAlgorithm::TesseractConvexConvexAlgorithm(btPersistentManifold* mf,
@@ -197,9 +194,7 @@ TesseractConvexConvexAlgorithm::TesseractConvexConvexAlgorithm(btPersistentManif
                                                                int minimumPointsPerturbationThreshold)
   : btActivatingCollisionAlgorithm(ci, body0Wrap, body1Wrap)
   , m_pdSolver(pdSolver)
-  , m_ownManifold(false)
   , m_manifoldPtr(mf)
-  , m_lowLevelOfDetail(false)
   ,
 #ifdef USE_SEPDISTANCE_UTIL2
   m_sepDistance((static_cast<btConvexShape*>(body0->getCollisionShape()))->getAngularMotionDisc(),
@@ -485,11 +480,11 @@ void TesseractConvexConvexAlgorithm::processCollision(const btCollisionObjectWra
         btScalar m_marginOnB;
         btScalar m_reportedDistance{ 0 };
 
-        bool m_foundResult;
+        bool m_foundResult{ false };
         btWithoutMarginResult(btDiscreteCollisionDetectorInterface::Result* result,
                               btScalar marginOnA,
                               btScalar marginOnB)
-          : m_originalResult(result), m_marginOnA(marginOnA), m_marginOnB(marginOnB), m_foundResult(false)
+          : m_originalResult(result), m_marginOnA(marginOnA), m_marginOnB(marginOnB)
         {
         }
 

--- a/tesseract_collision/core/CMakeLists.txt
+++ b/tesseract_collision/core/CMakeLists.txt
@@ -20,8 +20,8 @@ target_compile_options(${PROJECT_NAME}_core PUBLIC ${TESSERACT_COMPILE_OPTIONS_P
 target_compile_definitions(${PROJECT_NAME}_core PUBLIC ${TESSERACT_COMPILE_DEFINITIONS})
 target_compile_definitions(${PROJECT_NAME}_core
                            PRIVATE TESSERACT_CONTACT_MANAGERS_PLUGIN_PATH="${TESSERACT_CONTACT_MANAGERS_PLUGIN_PATH}")
-target_clang_tidy(${PROJECT_NAME}_core ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_core PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_core ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_core
   PRIVATE
@@ -41,8 +41,8 @@ target_link_libraries(
             ${PROJECT_NAME}_core)
 target_compile_options(${PROJECT_NAME}_test_suite INTERFACE ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_test_suite INTERFACE ${TESSERACT_COMPILE_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_test_suite ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_test_suite INTERFACE VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_test_suite ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_test_suite
   INTERFACE
@@ -57,8 +57,8 @@ add_library(${PROJECT_NAME}_test_suite_benchmarks INTERFACE)
 target_link_libraries(${PROJECT_NAME}_test_suite_benchmarks INTERFACE Eigen3::Eigen tesseract::tesseract_support
                                                                       tesseract::tesseract_geometry)
 target_compile_options(${PROJECT_NAME}_test_suite_benchmarks INTERFACE ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
-target_clang_tidy(${PROJECT_NAME}_test_suite_benchmarks ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_test_suite_benchmarks INTERFACE VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_test_suite_benchmarks ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_test_suite_benchmarks
   INTERFACE

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -284,7 +284,7 @@ struct ContactManagerConfig
 
 /**
  * @brief This is a high level structure containing common information that collision checking utilities need. The goal
- * of this config is to allow all collision checking utilities and planners to use the same datastructure
+ * of this config is to allow all collision checking utilities and planners to use the same data structure
  */
 struct CollisionCheckConfig
 {

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
@@ -4,9 +4,7 @@
 #include <tesseract_collision/core/continuous_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -173,7 +171,6 @@ inline void runTest(ContinuousContactManager& checker)
     EXPECT_NEAR(p1[2], 0.0, 0.001);
   }
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 
 #endif  // TESSERACT_COLLISION_COLLISION_BOX_BOX_CAST_UNIT_H

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -7,9 +7,7 @@
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -311,6 +309,5 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
   detail::runTestTyped(checker, ContactTestType::ALL);
 }
 
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // COLLISION_BOX_BOX_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
@@ -4,9 +4,7 @@
 #include <tesseract_collision/core/discrete_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -204,7 +202,6 @@ inline void runTest(DiscreteContactManager& checker)
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 1.0, 0.0011);  // FCL Required the bump in tolerance
 }
 
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 
 #endif  // TESSERACT_COLLISION_COLLISION_BOX_CAPSULE_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
@@ -4,9 +4,7 @@
 #include <tesseract_collision/core/discrete_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -219,6 +217,5 @@ inline void runTest(DiscreteContactManager& checker)
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_BOX_CONE_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
@@ -4,9 +4,7 @@
 #include <tesseract_collision/core/discrete_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -207,6 +205,5 @@ inline void runTest(DiscreteContactManager& checker)
   EXPECT_NEAR(result_vector[0].normal[1], idx[2] * 0.0, 0.001);
   EXPECT_NEAR(result_vector[0].normal[2], idx[2] * 0.0, 0.001);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_BOX_CYLINDER_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
@@ -6,9 +6,7 @@
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -344,6 +342,5 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
     detail::runTestPrimitive(checker);
 }
 
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_BOX_SPHERE_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_clone_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_clone_unit.hpp
@@ -4,9 +4,7 @@
 #include <tesseract_collision/core/discrete_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -179,6 +177,5 @@ runTest(DiscreteContactManager& checker, double dist_tol = 0.001, double nearest
   EXPECT_NEAR(result_vector[0].normal[1] * idx[2], cloned_result_vector[0].normal[1] * cloned_idx[2], normal_tol);
   EXPECT_NEAR(result_vector[0].normal[2] * idx[2], cloned_result_vector[0].normal[2] * cloned_idx[2], normal_tol);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_CLONE_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
@@ -10,9 +10,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/continuous_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -149,6 +147,5 @@ inline void runTest(DiscreteContactManager& checker)
   DiscreteContactManager::Ptr cloned_checker = checker.clone();
   detail::runTestCompound(*cloned_checker);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_COMPOUND_COMPOUND_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
@@ -12,9 +12,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = false, int num_interations = 10)
 {
@@ -96,6 +94,5 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
 
   CONSOLE_BRIDGE_logInform("DT: %f ms", std::chrono::duration<double, std::milli>(end_time - start_time).count());
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_LARGE_DATASET_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
@@ -5,9 +5,7 @@
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -213,6 +211,5 @@ inline void runTest(DiscreteContactManager& checker)
   EXPECT_GT((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(0, 1, 0)), 0.0);
   EXPECT_LT(std::abs(std::acos((idx[2] * result_vector[0].normal).dot(Eigen::Vector3d(0, 1, 0)))), 0.00001);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_MESH_MESH_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
@@ -12,9 +12,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = false)
 {
@@ -135,7 +133,6 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
     EXPECT_TRUE(result_vector[static_cast<std::size_t>(i)].size() == 2700);
   }
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 
 #endif  // TESSERACT_COLLISION_COLLISION_MULTI_THREADED_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
@@ -12,9 +12,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -118,7 +116,6 @@ inline void runTest(DiscreteContactManager& checker, const std::string& file_pat
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_TRUE(result_vector.size() == 2712);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 
 #endif  // TESSERACT_COLLISION_COLLISION_OCTOMAP_MESH_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_octomap_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_octomap_unit.hpp
@@ -10,9 +10,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/continuous_contact_manager.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -155,6 +153,5 @@ inline void runTest(DiscreteContactManager& checker)
   detail::runTestOctomap(*cloned_checker, ContactTestType::FIRST);
 }
 
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_OCTOMAP_OCTOMAP_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
@@ -13,9 +13,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -136,7 +134,6 @@ inline void runTest(DiscreteContactManager& checker, double tol, bool use_convex
   detail::runTestTyped(checker, tol, ContactTestType::ALL);
 }
 
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 
 #endif  // TESSERACT_COLLISION_COLLISION_OCTOMAP_SPHERE_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_cast_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_cast_unit.hpp
@@ -6,9 +6,7 @@
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -452,6 +450,5 @@ inline void runTest(ContinuousContactManager& checker, bool use_convex_mesh)
     detail::runTestPrimitive(checker);
 }
 
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 #endif  // TESSERACT_COLLISION_COLLISION_SPHERE_SPHERE_CAST_UNIT_HPP

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
@@ -6,9 +6,7 @@
 #include <tesseract_collision/core/common.h>
 #include <tesseract_geometry/geometries.h>
 
-namespace tesseract_collision
-{
-namespace test_suite
+namespace tesseract_collision::test_suite
 {
 namespace detail
 {
@@ -431,7 +429,6 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh)
   else
     detail::runTestPrimitive(checker);
 }
-}  // namespace test_suite
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::test_suite
 
 #endif  // TESSERACT_COLLISION_COLLISION_SPHERE_SPHERE_UNIT_HPP

--- a/tesseract_collision/core/src/common.cpp
+++ b/tesseract_collision/core/src/common.cpp
@@ -151,7 +151,7 @@ ContactResult* processResult(ContactTestData& cdata,
     if (contact.distance < dr[0].distance)
     {
       dr[0] = contact;
-      return &(dr[0]);
+      return dr.data();
     }
   }
   //    else if (cdata.cdata.condition == DistanceRequestType::LIMITED)

--- a/tesseract_collision/examples/CMakeLists.txt
+++ b/tesseract_collision/examples/CMakeLists.txt
@@ -14,8 +14,8 @@ target_link_libraries(
   ${LIBFCL_LIBRARIES})
 target_compile_options(${PROJECT_NAME}_box_box_example PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
                                                                ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
-target_clang_tidy(${PROJECT_NAME}_box_box_example ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_box_box_example PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_box_box_example ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_compile_definitions(${PROJECT_NAME}_box_box_example PRIVATE DATA_DIR="${CMAKE_SOURCE_DIR}/test"
                                                                    ${BULLET_DEFINITIONS})
 

--- a/tesseract_collision/fcl/CMakeLists.txt
+++ b/tesseract_collision/fcl/CMakeLists.txt
@@ -14,8 +14,8 @@ target_link_libraries(
 target_compile_options(${PROJECT_NAME}_fcl PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME}_fcl PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_fcl PUBLIC ${TESSERACT_COMPILE_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_fcl ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_fcl PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_fcl ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_fcl
   PRIVATE

--- a/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
+++ b/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_collision_object_wrapper.h
@@ -32,9 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_fcl
+namespace tesseract_collision::tesseract_collision_fcl
 {
 /**
  * @brief This is a wrapper around FCL Collision Object Class which allows you to expand the AABB by the contact dist.
@@ -78,7 +76,6 @@ protected:
   double contact_distance_{ 0 }; /**< @brief The contact distance threshold. */
 };
 
-}  // namespace tesseract_collision_fcl
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_fcl
 
 #endif  // TESSERACT_COLLISION_FCL_COLLISION_OBJECT_WRAPPER_H

--- a/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -49,9 +49,7 @@
 %shared_ptr(tesseract_collision::tesseract_collision_fcl::FCLDiscreteBVHManager)
 #endif  // SWIG
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_fcl
+namespace tesseract_collision::tesseract_collision_fcl
 {
 /** @brief A FCL implementation of the discrete contact manager */
 class FCLDiscreteBVHManager : public DiscreteContactManager
@@ -159,6 +157,5 @@ private:
   void onCollisionMarginDataChanged();
 };
 
-}  // namespace tesseract_collision_fcl
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_fcl
 #endif  // TESSERACT_COLLISION_FCL_DISCRETE_MANAGERS_H

--- a/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_utils.h
+++ b/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_utils.h
@@ -56,9 +56,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/common.h>
 #include <tesseract_collision/fcl/fcl_collision_object_wrapper.h>
 
-namespace tesseract_collision
-{
-namespace tesseract_collision_fcl
+namespace tesseract_collision::tesseract_collision_fcl
 {
 using CollisionGeometryPtr = std::shared_ptr<fcl::CollisionGeometryd>;
 using CollisionObjectPtr = std::shared_ptr<FCLCollisionObjectWrapper>;
@@ -276,6 +274,5 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
 
 bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data);
 
-}  // namespace tesseract_collision_fcl
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::tesseract_collision_fcl
 #endif  // TESSERACT_COLLISION_FCL_UTILS_H

--- a/tesseract_collision/fcl/src/fcl_utils.cpp
+++ b/tesseract_collision/fcl/src/fcl_utils.cpp
@@ -99,7 +99,7 @@ CollisionGeometryPtr createShapePrimitive(const tesseract_geometry::Mesh::ConstP
     std::vector<fcl::Triangle> tri_indices(static_cast<size_t>(triangle_count));
     for (int i = 0; i < triangle_count; ++i)
     {
-      assert(triangles[4 * i] == 3);
+      assert(triangles[4L * i] == 3);
       tri_indices[static_cast<size_t>(i)] = fcl::Triangle(static_cast<size_t>(triangles[(4 * i) + 1]),
                                                           static_cast<size_t>(triangles[(4 * i) + 2]),
                                                           static_cast<size_t>(triangles[(4 * i) + 3]));

--- a/tesseract_collision/test/CMakeLists.txt
+++ b/tesseract_collision/test/CMakeLists.txt
@@ -1,12 +1,14 @@
 find_package(OpenMP REQUIRED)
-if(OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-else(OPENMP_FOUND)
-  message(STATUS "Not found OpenMP")
+if(NOT TARGET OpenMP::OpenMP_CXX)
+  find_package(Threads REQUIRED)
+  add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+  set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+  # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
+  set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
 endif()
 
 find_package(tesseract_scene_graph REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 find_gtest()
 
@@ -23,14 +25,16 @@ macro(add_gtest test_name test_file)
             tesseract::tesseract_geometry
             tesseract::tesseract_scene_graph
             console_bridge::console_bridge
+            OpenMP::OpenMP_CXX
+            Eigen3::Eigen
             ${Boost_LIBRARIES}
             octomap
             octomath
             ${LIBFCL_LIBRARIES})
   target_compile_options(${test_name} PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE} ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
   target_compile_definitions(${test_name} PRIVATE ${TESSERACT_COMPILE_DEFINITIONS})
-  target_clang_tidy(${test_name} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_cxx_version(${test_name} PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+  target_clang_tidy(${test_name} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_code_coverage(
     ${test_name}
     PRIVATE

--- a/tesseract_collision/test/benchmarks/CMakeLists.txt
+++ b/tesseract_collision/test/benchmarks/CMakeLists.txt
@@ -7,7 +7,6 @@ macro(add_benchmark benchmark_name benchmark_file)
   target_compile_options(${benchmark_name} PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
                                                    ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
   target_compile_definitions(${benchmark_name} PRIVATE ${TESSERACT_COMPILE_DEFINITIONS} ${BULLET_DEFINITIONS})
-  target_clang_tidy(${benchmark_name} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_cxx_version(${benchmark_name} PRIVATE VERSION ${TESSERACT_CXX_VERSION})
   target_link_libraries(
     ${benchmark_name}
@@ -23,6 +22,7 @@ macro(add_benchmark benchmark_name benchmark_file)
     octomap
     octomath
     ${LIBFCL_LIBRARIES})
+  target_clang_tidy(${benchmark_name} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
   target_include_directories(${benchmark_name} PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
   add_dependencies(
     ${benchmark_name}
@@ -50,8 +50,8 @@ target_link_libraries(
           ${LIBFCL_LIBRARIES})
 target_compile_options(${PROJECT_NAME}_profile PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_definitions(${PROJECT_NAME}_profile INTERFACE ${TESSERACT_COMPILE_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_profile ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_profile PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_profile ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_profile
   PRIVATE

--- a/tesseract_collision/test/collision_core_unit.cpp
+++ b/tesseract_collision/test/collision_core_unit.cpp
@@ -64,7 +64,7 @@ TEST(TesseractCoreUnit, isContactAllowedUnit)  // NOLINT
 
 TEST(TesseractCoreUnit, scaleVerticesUnit)  // NOLINT
 {
-  tesseract_common::VectorVector3d base_vertices;
+  tesseract_common::VectorVector3d base_vertices{};
   base_vertices.push_back(Eigen::Vector3d(0, 0, 0));
   base_vertices.push_back(Eigen::Vector3d(0, 0, 1));
   base_vertices.push_back(Eigen::Vector3d(0, 1, 1));
@@ -75,7 +75,8 @@ TEST(TesseractCoreUnit, scaleVerticesUnit)  // NOLINT
   base_vertices.push_back(Eigen::Vector3d(1, 1, 0));
 
   // Test identity scale
-  tesseract_common::VectorVector3d test_vertices = base_vertices;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  tesseract_common::VectorVector3d test_vertices{ base_vertices };
   tesseract_collision::scaleVertices(test_vertices, Eigen::Vector3d(1, 1, 1));
   for (std::size_t i = 0; i < 8; ++i)
   {

--- a/tesseract_collision/vhacd/CMakeLists.txt
+++ b/tesseract_collision/vhacd/CMakeLists.txt
@@ -89,8 +89,8 @@ target_link_libraries(
 target_compile_options(${PROJECT_NAME}_vhacd_convex_decomposition PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME}_vhacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_vhacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_DEFINITIONS})
-target_clang_tidy(${PROJECT_NAME}_vhacd_convex_decomposition ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_vhacd_convex_decomposition PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME}_vhacd_convex_decomposition ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_code_coverage(
   ${PROJECT_NAME}_vhacd_convex_decomposition
   PRIVATE

--- a/tesseract_collision/vhacd/include/tesseract_collision/vhacd/VHACD.h
+++ b/tesseract_collision/vhacd/include/tesseract_collision/vhacd/VHACD.h
@@ -55,9 +55,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-namespace tesseract_collision
-{
-namespace VHACD
+namespace tesseract_collision::VHACD
 {
 class IVHACD
 {
@@ -182,5 +180,4 @@ public:
 };
 IVHACD* CreateVHACD();
 IVHACD* CreateVHACD_ASYNC();
-}  // namespace VHACD
-}  // namespace tesseract_collision
+}  // namespace tesseract_collision::VHACD

--- a/tesseract_common/include/tesseract_common/any.h
+++ b/tesseract_common/include/tesseract_common/any.h
@@ -64,10 +64,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
   TESSERACT_ANY_EXPORT_KEY(N, C)                                                                                       \
   TESSERACT_ANY_EXPORT_IMPLEMENT(N::C)
 
-namespace tesseract_common
-{
 #ifndef SWIG
-namespace detail_any
+namespace tesseract_common::detail_any
 {
 template <typename A>
 struct AnyConcept  // NOLINT
@@ -108,9 +106,8 @@ private:
     ar& boost::serialization::make_nvp("base", boost::serialization::base_object<BaseType>(*this));
   }
 };
-}  // namespace detail_any
+}  // namespace tesseract_common::detail_any
 #endif  // SWIG
-}  // namespace tesseract_common
 
 namespace tesseract_common
 {

--- a/tesseract_common/include/tesseract_common/atomic_serialization.h
+++ b/tesseract_common/include/tesseract_common/atomic_serialization.h
@@ -36,9 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 /** @note When using this header only include it in the cpp never in the header */
-namespace boost
-{
-namespace serialization
+namespace boost::serialization
 {
 template <class Archive, class T>
 inline void save(Archive& ar, const std::atomic<T>& t, const unsigned int)
@@ -60,6 +58,5 @@ inline void serialize(Archive& ar, std::atomic<T>& t, const unsigned int version
 {
   boost::serialization::split_free(ar, t, version);
 }
-}  // namespace serialization
-}  // namespace boost
+}  // namespace boost::serialization
 #endif  // TESSERACT_COMMON_ATOMIC_SERIALIZATION_H

--- a/tesseract_common/include/tesseract_common/class_loader.hpp
+++ b/tesseract_common/include/tesseract_common/class_loader.hpp
@@ -135,7 +135,7 @@ std::vector<std::string> ClassLoader::getAvailableSymbols(const std::string& sec
     CONSOLE_BRIDGE_logDebug("Failed to find or load library: %s with error: %s",
                             decorate(library_name, library_directory).c_str(),
                             ec.message().c_str());
-    return std::vector<std::string>();
+    return {};
   }
 
   // Class `library_info` can extract information from a library
@@ -170,7 +170,7 @@ std::vector<std::string> ClassLoader::getAvailableSections(const std::string& li
     CONSOLE_BRIDGE_logDebug("Failed to find or load library: %s with error: %s",
                             decorate(library_name, library_directory).c_str(),
                             ec.message().c_str());
-    return std::vector<std::string>();
+    return {};
   }
 
   // Class `library_info` can extract information from a library

--- a/tesseract_common/include/tesseract_common/eigen_serialization.h
+++ b/tesseract_common/include/tesseract_common/eigen_serialization.h
@@ -44,9 +44,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/tracking_enum.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-namespace boost
-{
-namespace serialization
+namespace boost::serialization
 {
 /*****************************/
 /****** Eigen::VectorXd ******/
@@ -133,8 +131,7 @@ void load(Archive& ar, std::variant<std::string, Eigen::Isometry3d>& g, const un
 template <class Archive>
 void serialize(Archive& ar, std::variant<std::string, Eigen::Isometry3d>& g, const unsigned int version);  // NOLINT
 
-}  // namespace serialization
-}  // namespace boost
+}  // namespace boost::serialization
 
 // Set the tracking to track_never for all Eigen types.
 BOOST_CLASS_TRACKING(Eigen::VectorXd, boost::serialization::track_never);

--- a/tesseract_common/include/tesseract_common/kinematic_limits.h
+++ b/tesseract_common/include/tesseract_common/kinematic_limits.h
@@ -128,11 +128,11 @@ bool satisfiesPositionLimits(const Eigen::Ref<const Eigen::Matrix<FloatType, Eig
                              FloatType max_diff = static_cast<FloatType>(1e-6),
                              FloatType max_rel_diff = std::numeric_limits<FloatType>::epsilon())
 {
-  return satisfiesPositionLimits<FloatType>(
-      joint_positions,
-      position_limits,
-      Eigen::Matrix<FloatType, Eigen::Dynamic, 1>::Constant(joint_positions.size(), max_diff),
-      Eigen::Matrix<FloatType, Eigen::Dynamic, 1>::Constant(joint_positions.size(), max_rel_diff));
+  const auto eigen_max_diff = Eigen::Matrix<FloatType, Eigen::Dynamic, 1>::Constant(joint_positions.size(), max_diff);
+  const auto eigen_max_rel_diff =
+      Eigen::Matrix<FloatType, Eigen::Dynamic, 1>::Constant(joint_positions.size(), max_rel_diff);
+  // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+  return satisfiesPositionLimits<FloatType>(joint_positions, position_limits, eigen_max_diff, eigen_max_rel_diff);
 }
 
 /**

--- a/tesseract_common/include/tesseract_common/kinematic_limits.h
+++ b/tesseract_common/include/tesseract_common/kinematic_limits.h
@@ -62,27 +62,90 @@ private:
 };
 
 /**
- * @brief Check if joint position is within bounds or relativilty equal to a limit
+ * @brief Check if within position limits
+ * @param joint_positions The joint position to check
+ * @param position_limits The joint limits to perform check
+ * @return
+ */
+template <typename FloatType>
+bool isWithinPositionLimits(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& joint_positions,
+                            const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 2>>& position_limits)
+{
+  auto p = joint_positions.array();
+  auto l0 = position_limits.col(0).array();
+  auto l1 = position_limits.col(1).array();
+  return (!(p > l1).any() && !(p < l0).any());
+}
+
+/**
+ * @brief Check if joint position is within bounds or relatively equal to a limit
  * @param joint_positions The joint position to check
  * @param joint_limits The joint limits to perform check
  * @param max_diff The max diff when comparing position to limit value max(abs(position - limit)) <= max_diff, if true
  * they are considered equal
  * @param max_rel_diff The max relative diff between position and limit abs(position - limit) <= largest * max_rel_diff,
  * if true considered equal. The largest is the largest of the absolute values of position and limit.
- * @return True if the all position are within the limits or relativily equal to the limit, otherwise false.
+ * @return True if the all position are within the limits or relatively equal to the limit, otherwise false.
  */
-bool satisfiesPositionLimits(const Eigen::Ref<const Eigen::VectorXd>& joint_positions,
-                             const Eigen::Ref<const Eigen::MatrixX2d>& position_limits,
-                             double max_diff = 1e-6,
-                             double max_rel_diff = std::numeric_limits<double>::epsilon());
+template <typename FloatType>
+bool satisfiesPositionLimits(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& joint_positions,
+                             const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 2>>& position_limits,
+                             const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& max_diff,
+                             const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& max_rel_diff)
+{
+  auto p = joint_positions.array();
+  auto l0 = position_limits.col(0).array();
+  auto l1 = position_limits.col(1).array();
+  auto md = max_diff.array();
+  auto mrd = max_rel_diff.array();
+
+  auto lower_diff_abs = (p - l0).abs();
+  auto lower_diff = (lower_diff_abs <= md);
+  auto lower_relative_diff = (lower_diff_abs <= mrd * p.abs().max(l0.abs()));
+  auto lower_check = p > l0 || lower_diff || lower_relative_diff;
+
+  auto upper_diff_abs = (p - l1).abs();
+  auto upper_diff = (upper_diff_abs <= md);
+  auto upper_relative_diff = (upper_diff_abs <= mrd * p.abs().max(l1.abs()));
+  auto upper_check = p < l1 || upper_diff || upper_relative_diff;
+
+  return (lower_check.all() && upper_check.all());
+}
+
+/**
+ * @brief Check if joint position is within bounds or relatively equal to a limit
+ * @param joint_positions The joint position to check
+ * @param joint_limits The joint limits to perform check
+ * @param max_diff The max diff when comparing position to limit value max(abs(position - limit)) <= max_diff, if true
+ * they are considered equal
+ * @param max_rel_diff The max relative diff between position and limit abs(position - limit) <= largest * max_rel_diff,
+ * if true considered equal. The largest is the largest of the absolute values of position and limit.
+ * @return True if the all position are within the limits or relatively equal to the limit, otherwise false.
+ */
+template <typename FloatType>
+bool satisfiesPositionLimits(const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>>& joint_positions,
+                             const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 2>>& position_limits,
+                             FloatType max_diff = static_cast<FloatType>(1e-6),
+                             FloatType max_rel_diff = std::numeric_limits<FloatType>::epsilon())
+{
+  return satisfiesPositionLimits<FloatType>(
+      joint_positions,
+      position_limits,
+      Eigen::Matrix<FloatType, Eigen::Dynamic, 1>::Constant(joint_positions.size(), max_diff),
+      Eigen::Matrix<FloatType, Eigen::Dynamic, 1>::Constant(joint_positions.size(), max_rel_diff));
+}
 
 /**
  * @brief Enforce position to be within the provided limits
  * @param joint_positions The joint position to enforce bounds on
  * @param joint_limits The limits to perform check
  */
-void enforcePositionLimits(Eigen::Ref<Eigen::VectorXd> joint_positions,
-                           const Eigen::Ref<const Eigen::MatrixX2d>& position_limits);
+template <typename FloatType>
+void enforcePositionLimits(Eigen::Ref<Eigen::Matrix<FloatType, Eigen::Dynamic, 1>> joint_positions,
+                           const Eigen::Ref<const Eigen::Matrix<FloatType, Eigen::Dynamic, 2>>& position_limits)
+{
+  joint_positions = joint_positions.array().min(position_limits.col(1).array()).max(position_limits.col(0).array());
+}
 }  // namespace tesseract_common
 
 #endif  // TESSERACT_COMMON_KINEMATIC_LIMITS_H

--- a/tesseract_common/include/tesseract_common/type_erasure.h
+++ b/tesseract_common/include/tesseract_common/type_erasure.h
@@ -156,7 +156,7 @@ public:
   ~TypeErasureBase() = default;
 
   // Copy constructor
-  TypeErasureBase(const TypeErasureBase& other) { value_ = other.value_->clone(); }
+  TypeErasureBase(const TypeErasureBase& other) : value_(other.value_->clone()) {}
 
   // Move ctor.
   TypeErasureBase(TypeErasureBase&& other) noexcept { value_.swap(other.value_); }
@@ -185,7 +185,7 @@ public:
   std::type_index getType() const
   {
     if (value_ == nullptr)
-      return std::type_index(typeid(nullptr));
+      return std::type_index{ typeid(nullptr) };
 
     return value_->getType();
   }
@@ -230,7 +230,7 @@ private:
     ar& boost::serialization::make_nvp("value", value_);
   }
 
-  std::unique_ptr<TypeErasureInterface> value_;
+  std::unique_ptr<TypeErasureInterface> value_{ nullptr };
 };
 
 }  // namespace tesseract_common

--- a/tesseract_common/include/tesseract_common/utils.h
+++ b/tesseract_common/include/tesseract_common/utils.h
@@ -64,7 +64,7 @@ std::string strFormat(const std::string& format, Args... args)
   auto size = static_cast<size_t>(size_s);
   auto buf = std::make_unique<char[]>(size);  // NOLINT
   std::snprintf(buf.get(), size, format.c_str(), args...);
-  return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
+  return std::string{ buf.get(), buf.get() + size - 1 };  // We don't want the '\0' inside
 }
 
 /**

--- a/tesseract_common/src/kinematic_limits.cpp
+++ b/tesseract_common/src/kinematic_limits.cpp
@@ -62,33 +62,45 @@ void KinematicLimits::serialize(Archive& ar, const unsigned int /*version*/)  //
   ar& BOOST_SERIALIZATION_NVP(acceleration_limits);
 }
 
-bool satisfiesPositionLimits(const Eigen::Ref<const Eigen::VectorXd>& joint_positions,
-                             const Eigen::Ref<const Eigen::MatrixX2d>& position_limits,
-                             double max_diff,
-                             double max_rel_diff)
-{
-  auto p = joint_positions.array();
-  auto l0 = position_limits.col(0).array();
-  auto l1 = position_limits.col(1).array();
+template bool
+isWithinPositionLimits<float>(const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 1>>& joint_positions,
+                              const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 2>>& position_limits);
 
-  auto lower_diff_abs = (p - l0).abs();
-  auto lower_diff = (lower_diff_abs <= max_diff);
-  auto lower_relative_diff = (lower_diff_abs <= max_rel_diff * p.abs().max(l0.abs()));
-  auto lower_check = p > l0 || lower_diff || lower_relative_diff;
+template bool
+isWithinPositionLimits<double>(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& joint_positions,
+                               const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 2>>& position_limits);
 
-  auto upper_diff_abs = (p - l1).abs();
-  auto upper_diff = (upper_diff_abs <= max_diff);
-  auto upper_relative_diff = (upper_diff_abs <= max_rel_diff * p.abs().max(l1.abs()));
-  auto upper_check = p < l1 || upper_diff || upper_relative_diff;
+template bool
+satisfiesPositionLimits<float>(const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 1>>& joint_positions,
+                               const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 2>>& position_limits,
+                               float max_diff,
+                               float max_rel_diff);
 
-  return (lower_check.all() && upper_check.all());
-}
+template bool
+satisfiesPositionLimits<double>(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& joint_positions,
+                                const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 2>>& position_limits,
+                                double max_diff,
+                                double max_rel_diff);
 
-void enforcePositionLimits(Eigen::Ref<Eigen::VectorXd> joint_positions,
-                           const Eigen::Ref<const Eigen::MatrixX2d>& position_limits)
-{
-  joint_positions = joint_positions.array().min(position_limits.col(1).array()).max(position_limits.col(0).array());
-}
+template bool
+satisfiesPositionLimits<float>(const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 1>>& joint_positions,
+                               const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 2>>& position_limits,
+                               const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 1>>& max_diff,
+                               const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 1>>& max_rel_diff);
+
+template bool
+satisfiesPositionLimits<double>(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& joint_positions,
+                                const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 2>>& position_limits,
+                                const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& max_diff,
+                                const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& max_rel_diff);
+
+template void
+enforcePositionLimits<float>(Eigen::Ref<Eigen::Matrix<float, Eigen::Dynamic, 1>> joint_positions,
+                             const Eigen::Ref<const Eigen::Matrix<float, Eigen::Dynamic, 2>>& position_limits);
+
+template void
+enforcePositionLimits<double>(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> joint_positions,
+                              const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 2>>& position_limits);
 }  // namespace tesseract_common
 
 #include <tesseract_common/serialization.h>

--- a/tesseract_common/src/kinematic_limits.cpp
+++ b/tesseract_common/src/kinematic_limits.cpp
@@ -32,7 +32,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/kinematic_limits.h>
 #include <tesseract_common/eigen_serialization.h>
-#include <tesseract_common/serialization.h>
 
 namespace tesseract_common
 {

--- a/tesseract_common/src/resource_locator.cpp
+++ b/tesseract_common/src/resource_locator.cpp
@@ -76,7 +76,7 @@ std::vector<uint8_t> SimpleLocatedResource::getResourceContents() const
   if (ifs.fail())
   {
     CONSOLE_BRIDGE_logError("Could not read all bytes from file: %s", filename_.c_str());
-    return std::vector<uint8_t>();
+    return {};
   }
   std::ifstream::pos_type pos = ifs.tellg();
 

--- a/tesseract_common/test/tesseract_common_serialization_unit.cpp
+++ b/tesseract_common/test/tesseract_common_serialization_unit.cpp
@@ -434,7 +434,7 @@ struct TestAtomic
     value = other.value.load();
     return *this;
   }
-  TestAtomic(TestAtomic&& other) noexcept { value = other.value.load(); }
+  TestAtomic(TestAtomic&& other) noexcept : value(other.value.load()) {}
   TestAtomic& operator=(TestAtomic&& other) noexcept
   {
     value = other.value.load();

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -246,7 +246,7 @@ TEST(TesseractCommonUnit, bytesResource)  // NOLINT
   }
 
   std::shared_ptr<tesseract_common::BytesResource> bytes_resource2 =
-      std::make_shared<tesseract_common::BytesResource>("package://test_package/data.bin", &data[0], data.size());
+      std::make_shared<tesseract_common::BytesResource>("package://test_package/data.bin", data.data(), data.size());
   EXPECT_EQ(bytes_resource2->getUrl(), "package://test_package/data.bin");
   EXPECT_EQ(bytes_resource->getResourceContents().size(), data.size());
 }
@@ -367,7 +367,7 @@ TEST(TesseractCommonUnit, boundsUnit)  // NOLINT
 {
   Eigen::VectorXd v = Eigen::VectorXd::Ones(6);
   v = v.array() + std::numeric_limits<float>::epsilon();
-  Eigen::MatrixX2d limits(6, 2);
+  Eigen::MatrixX2d limits(6, 2);  // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
   limits.col(0) = -Eigen::VectorXd::Ones(6);
   limits.col(1) = Eigen::VectorXd::Ones(6);
 
@@ -486,7 +486,7 @@ TEST(TesseractCommonUnit, isIdenticalArrayUnit)  // NOLINT
     EXPECT_FALSE(equal);
   }
   {
-    // Clang-tidy catches unitialized arrays anyway, but check it just in case the caller isn't running clang-tidy
+    // Clang-tidy catches initialized arrays anyway, but check it just in case the caller isn't running clang-tidy
     std::array<int, 4> v1 = { 1, 2, 3, 6 };
     std::array<int, 4> v2;  // NOLINT
     bool equal = tesseract_common::isIdenticalArray<int, 4>(v1, v2);
@@ -989,7 +989,7 @@ TEST(TesseractContactManagersFactoryUnit, KinematicsPluginInfoYamlUnit)  // NOLI
 
       for (auto it = search_paths.begin(); it != search_paths.end(); ++it)
       {
-        EXPECT_TRUE(std::find(sp.begin(), sp.end(), it->as<std::string>()) != sp.end());
+        EXPECT_TRUE(sp.find(it->as<std::string>()) != sp.end());
       }
     }
 
@@ -999,7 +999,7 @@ TEST(TesseractContactManagersFactoryUnit, KinematicsPluginInfoYamlUnit)  // NOLI
 
       for (auto it = search_libraries.begin(); it != search_libraries.end(); ++it)
       {
-        EXPECT_TRUE(std::find(sl.begin(), sl.end(), it->as<std::string>()) != sl.end());
+        EXPECT_TRUE(sl.find(it->as<std::string>()) != sl.end());
       }
     }
 
@@ -1234,7 +1234,7 @@ TEST(TesseractContactManagersFactoryUnit, ContactManagersPluginInfoYamlUnit)  //
 
       for (auto it = search_paths.begin(); it != search_paths.end(); ++it)
       {
-        EXPECT_TRUE(std::find(sp.begin(), sp.end(), it->as<std::string>()) != sp.end());
+        EXPECT_TRUE(sp.find(it->as<std::string>()) != sp.end());
       }
     }
 
@@ -1244,7 +1244,7 @@ TEST(TesseractContactManagersFactoryUnit, ContactManagersPluginInfoYamlUnit)  //
 
       for (auto it = search_libraries.begin(); it != search_libraries.end(); ++it)
       {
-        EXPECT_TRUE(std::find(sl.begin(), sl.end(), it->as<std::string>()) != sl.end());
+        EXPECT_TRUE(sl.find(it->as<std::string>()) != sl.end());
       }
     }
 

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -371,29 +371,45 @@ TEST(TesseractCommonUnit, boundsUnit)  // NOLINT
   limits.col(0) = -Eigen::VectorXd::Ones(6);
   limits.col(1) = Eigen::VectorXd::Ones(6);
 
-  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<float>::epsilon()));
-  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
-  tesseract_common::enforcePositionLimits(v, limits);
-  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
+  EXPECT_FALSE(tesseract_common::isWithinPositionLimits<double>(v, limits));
+  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<float>::epsilon()));
+  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<double>::epsilon()));
+  tesseract_common::enforcePositionLimits<double>(v, limits);
+  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<double>::epsilon()));
 
   v = -Eigen::VectorXd::Ones(6);
   v = v.array() - std::numeric_limits<float>::epsilon();
 
-  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<float>::epsilon()));
-  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
-  tesseract_common::enforcePositionLimits(v, limits);
-  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
+  EXPECT_FALSE(tesseract_common::isWithinPositionLimits<double>(v, limits));
+  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<float>::epsilon()));
+  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<double>::epsilon()));
+  tesseract_common::enforcePositionLimits<double>(v, limits);
+  EXPECT_TRUE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<double>::epsilon()));
 
   // Check that clamp is done correctly on both sides
   v = Eigen::VectorXd::Constant(6, -2);
-  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
-  tesseract_common::enforcePositionLimits(v, limits);
+  EXPECT_FALSE(tesseract_common::isWithinPositionLimits<double>(v, limits));
+  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<double>::epsilon()));
+  tesseract_common::enforcePositionLimits<double>(v, limits);
   ASSERT_EQ((v - limits.col(0)).norm(), 0);
 
   v = Eigen::VectorXd::Constant(6, 2);
-  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits(v, limits, std::numeric_limits<double>::epsilon()));
-  tesseract_common::enforcePositionLimits(v, limits);
+  EXPECT_FALSE(tesseract_common::isWithinPositionLimits<double>(v, limits));
+  EXPECT_FALSE(tesseract_common::satisfiesPositionLimits<double>(v, limits, std::numeric_limits<double>::epsilon()));
+  tesseract_common::enforcePositionLimits<double>(v, limits);
   ASSERT_EQ((v - limits.col(1)).norm(), 0);
+
+  v = Eigen::VectorXd::Ones(6);
+  v = v.array() - std::numeric_limits<float>::epsilon();
+  EXPECT_TRUE(tesseract_common::isWithinPositionLimits<double>(v, limits));
+
+  v = Eigen::VectorXd::Ones(6);
+  v(3) = v(3) + std::numeric_limits<float>::epsilon();
+  EXPECT_FALSE(tesseract_common::isWithinPositionLimits<double>(v, limits));
+
+  v = -Eigen::VectorXd::Ones(6);
+  v(3) = v(3) - std::numeric_limits<float>::epsilon();
+  EXPECT_FALSE(tesseract_common::isWithinPositionLimits<double>(v, limits));
 }
 
 TEST(TesseractCommonUnit, isIdenticalUnit)  // NOLINT

--- a/tesseract_environment/include/tesseract_environment/commands/add_scene_graph_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/add_scene_graph_command.h
@@ -54,13 +54,7 @@ public:
    * into the environment graph. The prefix argument is meant to allow adding multiple copies of the same subgraph with
    * different names
    */
-  AddSceneGraphCommand(const tesseract_scene_graph::SceneGraph& scene_graph, std::string prefix = "")
-    : Command(CommandType::ADD_SCENE_GRAPH)
-    , scene_graph_(scene_graph.clone())
-    , joint_(nullptr)
-    , prefix_(std::move(prefix))
-  {
-  }
+  AddSceneGraphCommand(const tesseract_scene_graph::SceneGraph& scene_graph, std::string prefix = "");
 
   /**
    * @brief Merge a graph into the current environment
@@ -74,13 +68,7 @@ public:
    */
   AddSceneGraphCommand(const tesseract_scene_graph::SceneGraph& scene_graph,
                        const tesseract_scene_graph::Joint& joint,
-                       std::string prefix = "")
-    : Command(CommandType::ADD_SCENE_GRAPH)
-    , scene_graph_(scene_graph.clone())
-    , joint_(std::make_shared<tesseract_scene_graph::Joint>(joint.clone()))
-    , prefix_(std::move(prefix))
-  {
-  }
+                       std::string prefix = "");
 
   const tesseract_scene_graph::SceneGraph::ConstPtr& getSceneGraph() const { return scene_graph_; }
   const tesseract_scene_graph::Joint::ConstPtr& getJoint() const { return joint_; }

--- a/tesseract_environment/include/tesseract_environment/commands/change_collision_margins_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_collision_margins_command.h
@@ -48,39 +48,21 @@ public:
   using Ptr = std::shared_ptr<ChangeCollisionMarginsCommand>;
   using ConstPtr = std::shared_ptr<const ChangeCollisionMarginsCommand>;
 
-  ChangeCollisionMarginsCommand() : Command(CommandType::CHANGE_COLLISION_MARGINS){};
+  ChangeCollisionMarginsCommand();
 
   ChangeCollisionMarginsCommand(
       double default_margin,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN)
-    : Command(CommandType::CHANGE_COLLISION_MARGINS)
-    , collision_margin_data_(CollisionMarginData(default_margin))
-    , collision_margin_override_(override_type)
-  {
-  }
+      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN);
 
   ChangeCollisionMarginsCommand(
       PairsCollisionMarginData pairs_margin,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN)
-    : Command(CommandType::CHANGE_COLLISION_MARGINS)
-    , collision_margin_data_(CollisionMarginData(std::move(pairs_margin)))
-    , collision_margin_override_(override_type)
-  {
-  }
+      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN);
 
   ChangeCollisionMarginsCommand(CollisionMarginData collision_margin_data,
-                                CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE)
-    : Command(CommandType::CHANGE_COLLISION_MARGINS)
-    , collision_margin_data_(std::move(collision_margin_data))
-    , collision_margin_override_(override_type)
-  {
-  }
+                                CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE);
 
-  tesseract_common::CollisionMarginData getCollisionMarginData() const { return collision_margin_data_; }
-  tesseract_common::CollisionMarginOverrideType getCollisionMarginOverrideType() const
-  {
-    return collision_margin_override_;
-  }
+  tesseract_common::CollisionMarginData getCollisionMarginData() const;
+  tesseract_common::CollisionMarginOverrideType getCollisionMarginOverrideType() const;
 
   bool operator==(const ChangeCollisionMarginsCommand& rhs) const;
   bool operator!=(const ChangeCollisionMarginsCommand& rhs) const;

--- a/tesseract_environment/include/tesseract_environment/commands/change_joint_acceleration_limits_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_joint_acceleration_limits_command.h
@@ -45,30 +45,22 @@ public:
   using Ptr = std::shared_ptr<ChangeJointAccelerationLimitsCommand>;
   using ConstPtr = std::shared_ptr<const ChangeJointAccelerationLimitsCommand>;
 
-  ChangeJointAccelerationLimitsCommand() : Command(CommandType::CHANGE_JOINT_ACCELERATION_LIMITS){};
+  ChangeJointAccelerationLimitsCommand();
 
   /**
    * @brief Changes the acceleration limits associated with a joint
    * @param joint_name Name of the joint to be updated
    * @param limits New acceleration limits to be set as the joint limits
    */
-  ChangeJointAccelerationLimitsCommand(std::string joint_name, double limit)
-    : Command(CommandType::CHANGE_JOINT_ACCELERATION_LIMITS), limits_({ std::make_pair(std::move(joint_name), limit) })
-  {
-    assert(limit > 0);
-  }
+  ChangeJointAccelerationLimitsCommand(std::string joint_name, double limit);
 
   /**
    * @brief Changes the acceleration limits associated with a joint
    * @param limits A map of joint names to new acceleration limits
    */
-  ChangeJointAccelerationLimitsCommand(std::unordered_map<std::string, double> limits)
-    : Command(CommandType::CHANGE_JOINT_ACCELERATION_LIMITS), limits_(std::move(limits))
-  {
-    assert(std::all_of(limits_.begin(), limits_.end(), [](const auto& p) { return p.second > 0; }));
-  }
+  ChangeJointAccelerationLimitsCommand(std::unordered_map<std::string, double> limits);
 
-  const std::unordered_map<std::string, double>& getLimits() const { return limits_; }
+  const std::unordered_map<std::string, double>& getLimits() const;
 
   bool operator==(const ChangeJointAccelerationLimitsCommand& rhs) const;
   bool operator!=(const ChangeJointAccelerationLimitsCommand& rhs) const;

--- a/tesseract_environment/include/tesseract_environment/commands/change_joint_origin_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_joint_origin_command.h
@@ -47,7 +47,7 @@ public:
   using Ptr = std::shared_ptr<ChangeJointOriginCommand>;
   using ConstPtr = std::shared_ptr<const ChangeJointOriginCommand>;
 
-  ChangeJointOriginCommand() : Command(CommandType::CHANGE_JOINT_ORIGIN){};
+  ChangeJointOriginCommand();
 
   /**
    * @brief Changes the origin associated with the joint
@@ -57,13 +57,10 @@ public:
    * @param joint_name Name of the joint to be updated
    * @param new_origin New transform to be set as the origin
    */
-  ChangeJointOriginCommand(std::string joint_name, const Eigen::Isometry3d& origin)
-    : Command(CommandType::CHANGE_JOINT_ORIGIN), joint_name_(std::move(joint_name)), origin_(origin)
-  {
-  }
+  ChangeJointOriginCommand(std::string joint_name, const Eigen::Isometry3d& origin);
 
-  const std::string& getJointName() const { return joint_name_; }
-  const Eigen::Isometry3d& getOrigin() const { return origin_; }
+  const std::string& getJointName() const;
+  const Eigen::Isometry3d& getOrigin() const;
 
   bool operator==(const ChangeJointOriginCommand& rhs) const;
   bool operator!=(const ChangeJointOriginCommand& rhs) const;

--- a/tesseract_environment/include/tesseract_environment/commands/change_joint_position_limits_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_joint_position_limits_command.h
@@ -45,32 +45,23 @@ public:
   using Ptr = std::shared_ptr<ChangeJointPositionLimitsCommand>;
   using ConstPtr = std::shared_ptr<const ChangeJointPositionLimitsCommand>;
 
-  ChangeJointPositionLimitsCommand() : Command(CommandType::CHANGE_JOINT_POSITION_LIMITS){};
+  ChangeJointPositionLimitsCommand();
 
   /**
    * @brief Changes the position limits associated with a joint
    * @param joint_name Name of the joint to be updated
    * @param limits New position limits to be set as the joint limits
    */
-  ChangeJointPositionLimitsCommand(std::string joint_name, double lower, double upper)
-    : Command(CommandType::CHANGE_JOINT_POSITION_LIMITS)
-    , limits_({ std::make_pair(std::move(joint_name), std::make_pair(lower, upper)) })
-  {
-    assert(upper > lower);
-  }
+  ChangeJointPositionLimitsCommand(std::string joint_name, double lower, double upper);
 
   /**
    * @brief Changes the position limits associated with one or more joints
    * @param limits A map of joint names to new position limits.
    * For each limit pair, first is the lower limit second is the upper limit
    */
-  ChangeJointPositionLimitsCommand(std::unordered_map<std::string, std::pair<double, double>> limits)
-    : Command(CommandType::CHANGE_JOINT_POSITION_LIMITS), limits_(std::move(limits))
-  {
-    assert(std::all_of(limits_.begin(), limits_.end(), [](const auto& p) { return p.second.second > p.second.first; }));
-  }
+  ChangeJointPositionLimitsCommand(std::unordered_map<std::string, std::pair<double, double>> limits);
 
-  const std::unordered_map<std::string, std::pair<double, double>>& getLimits() const { return limits_; }
+  const std::unordered_map<std::string, std::pair<double, double>>& getLimits() const;
 
   bool operator==(const ChangeJointPositionLimitsCommand& rhs) const;
   bool operator!=(const ChangeJointPositionLimitsCommand& rhs) const;

--- a/tesseract_environment/include/tesseract_environment/commands/change_joint_velocity_limits_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_joint_velocity_limits_command.h
@@ -45,30 +45,22 @@ public:
   using Ptr = std::shared_ptr<ChangeJointVelocityLimitsCommand>;
   using ConstPtr = std::shared_ptr<const ChangeJointVelocityLimitsCommand>;
 
-  ChangeJointVelocityLimitsCommand() : Command(CommandType::CHANGE_JOINT_VELOCITY_LIMITS){};
+  ChangeJointVelocityLimitsCommand();
 
   /**
    * @brief Changes the velocity limits associated with a joint
    * @param joint_name Name of the joint to be updated
    * @param limits New velocity limits to be set as the joint limits
    */
-  ChangeJointVelocityLimitsCommand(std::string joint_name, double limit)
-    : Command(CommandType::CHANGE_JOINT_VELOCITY_LIMITS), limits_({ std::make_pair(std::move(joint_name), limit) })
-  {
-    assert(limit > 0);
-  }
+  ChangeJointVelocityLimitsCommand(std::string joint_name, double limit);
 
   /**
    * @brief Changes the velocity limits associated with a joint
    * @param limits A map of joint names to new velocity limits
    */
-  ChangeJointVelocityLimitsCommand(std::unordered_map<std::string, double> limits)
-    : Command(CommandType::CHANGE_JOINT_VELOCITY_LIMITS), limits_(std::move(limits))
-  {
-    assert(std::all_of(limits_.begin(), limits_.end(), [](const auto& p) { return p.second > 0; }));
-  }
+  ChangeJointVelocityLimitsCommand(std::unordered_map<std::string, double> limits);
 
-  const std::unordered_map<std::string, double>& getLimits() const { return limits_; }
+  const std::unordered_map<std::string, double>& getLimits() const;
 
   bool operator==(const ChangeJointVelocityLimitsCommand& rhs) const;
   bool operator!=(const ChangeJointVelocityLimitsCommand& rhs) const;

--- a/tesseract_environment/include/tesseract_environment/commands/change_link_collision_enabled_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_link_collision_enabled_command.h
@@ -61,7 +61,7 @@ public:
   bool operator!=(const ChangeLinkCollisionEnabledCommand& rhs) const;
 
 private:
-  std::string link_name_{ "" };
+  std::string link_name_;
   bool enabled_{ false };
 
   friend class boost::serialization::access;

--- a/tesseract_environment/include/tesseract_environment/commands/change_link_origin_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_link_origin_command.h
@@ -62,7 +62,7 @@ public:
 
 private:
   std::string link_name_;
-  Eigen::Isometry3d origin_;
+  Eigen::Isometry3d origin_{ Eigen::Isometry3d::Identity() };
 
   friend class boost::serialization::access;
   template <class Archive>

--- a/tesseract_environment/include/tesseract_environment/commands/change_link_visibility_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_link_visibility_command.h
@@ -61,7 +61,7 @@ public:
   bool operator!=(const ChangeLinkVisibilityCommand& rhs) const;
 
 private:
-  std::string link_name_{ "" };
+  std::string link_name_;
   bool enabled_{ false };
 
   friend class boost::serialization::access;

--- a/tesseract_environment/include/tesseract_environment/environment.h
+++ b/tesseract_environment/include/tesseract_environment/environment.h
@@ -542,19 +542,19 @@ protected:
   int init_revision_{ 0 };
 
   /** @brief The history of commands applied to the environment after initialization */
-  Commands commands_;
+  Commands commands_{};
 
   /**
    * @brief Tesseract Scene Graph
    * @note This is intentionally not serialized it will auto updated
    */
-  tesseract_scene_graph::SceneGraph::Ptr scene_graph_;
+  tesseract_scene_graph::SceneGraph::Ptr scene_graph_{ nullptr };
 
   /**
    * @brief Tesseract Scene Graph Const
    * @note This is intentionally not serialized it will auto updated
    */
-  tesseract_scene_graph::SceneGraph::ConstPtr scene_graph_const_;
+  tesseract_scene_graph::SceneGraph::ConstPtr scene_graph_const_{ nullptr };
 
   /**
    * @brief The kinematics information
@@ -581,7 +581,7 @@ protected:
    * @brief Tesseract State Solver
    * @note This is intentionally not serialized it will auto updated
    */
-  tesseract_scene_graph::MutableStateSolver::UPtr state_solver_;
+  tesseract_scene_graph::MutableStateSolver::UPtr state_solver_{ nullptr };
 
   /**
    * @brief The function used to determine if two objects are allowed in collision
@@ -593,16 +593,16 @@ protected:
    * @brief A vector of user defined callbacks for locating tool center point
    * @todo This needs to be switched to class so it may be serialized
    */
-  std::vector<FindTCPOffsetCallbackFn> find_tcp_cb_;
+  std::vector<FindTCPOffsetCallbackFn> find_tcp_cb_{};
 
   /**
    * @brief A map of user defined event callback functions
    * @details This should not be cloned or serialized
    */
-  std::map<std::size_t, EventCallbackFn> event_cb_;
+  std::map<std::size_t, EventCallbackFn> event_cb_{};
 
   /** @brief Used when initialized by URDF_STRING, URDF_STRING_SRDF_STRING, URDF_PATH, and URDF_PATH_SRDF_PATH */
-  tesseract_common::ResourceLocator::ConstPtr resource_locator_;
+  tesseract_common::ResourceLocator::ConstPtr resource_locator_{ nullptr };
 
   /**
    * @brief The contact manager information
@@ -626,14 +626,14 @@ protected:
    * @brief The discrete contact manager object
    * @note This is intentionally not serialized it will auto updated
    */
-  mutable tesseract_collision::DiscreteContactManager::UPtr discrete_manager_;
+  mutable tesseract_collision::DiscreteContactManager::UPtr discrete_manager_{ nullptr };
   mutable std::shared_mutex discrete_manager_mutex_;
 
   /**
    * @brief The continuous contact manager object
    * @note This is intentionally not serialized it will auto updated
    */
-  mutable tesseract_collision::ContinuousContactManager::UPtr continuous_manager_;
+  mutable tesseract_collision::ContinuousContactManager::UPtr continuous_manager_{ nullptr };
   mutable std::shared_mutex continuous_manager_mutex_;
 
   /**
@@ -641,7 +641,7 @@ protected:
    * @details This will cleared when environment changes
    * @note This is intentionally not serialized it will auto updated
    */
-  mutable std::unordered_map<std::string, std::vector<std::string>> group_joint_names_cache_;
+  mutable std::unordered_map<std::string, std::vector<std::string>> group_joint_names_cache_{};
   mutable std::shared_mutex group_joint_names_cache_mutex_;
 
   /**
@@ -649,7 +649,7 @@ protected:
    * @details This will cleared when environment changes
    * @note This is intentionally not serialized it will auto updated
    */
-  mutable std::unordered_map<std::string, tesseract_kinematics::JointGroup::UPtr> joint_group_cache_;
+  mutable std::unordered_map<std::string, tesseract_kinematics::JointGroup::UPtr> joint_group_cache_{};
   mutable std::shared_mutex joint_group_cache_mutex_;
 
   /**
@@ -658,7 +658,7 @@ protected:
    * @note This is intentionally not serialized it will auto updated
    */
   mutable std::map<std::pair<std::string, std::string>, tesseract_kinematics::KinematicGroup::UPtr>
-      kinematic_group_cache_;
+      kinematic_group_cache_{};
   mutable std::shared_mutex kinematic_group_cache_mutex_;
 
   /** @brief The environment can be accessed from multiple threads, need use mutex throughout */

--- a/tesseract_environment/src/command.cpp
+++ b/tesseract_environment/src/command.cpp
@@ -32,7 +32,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_common/serialization.h>
 #include <tesseract_environment/command.h>
 
 namespace tesseract_environment

--- a/tesseract_environment/src/commands/add_scene_graph_command.cpp
+++ b/tesseract_environment/src/commands/add_scene_graph_command.cpp
@@ -37,6 +37,24 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {
+AddSceneGraphCommand::AddSceneGraphCommand(const tesseract_scene_graph::SceneGraph& scene_graph, std::string prefix)
+  : Command(CommandType::ADD_SCENE_GRAPH)
+  , scene_graph_(scene_graph.clone())
+  , joint_(nullptr)
+  , prefix_(std::move(prefix))
+{
+}
+
+AddSceneGraphCommand::AddSceneGraphCommand(const tesseract_scene_graph::SceneGraph& scene_graph,
+                                           const tesseract_scene_graph::Joint& joint,
+                                           std::string prefix)
+  : Command(CommandType::ADD_SCENE_GRAPH)
+  , scene_graph_(scene_graph.clone())
+  , joint_(std::make_shared<tesseract_scene_graph::Joint>(joint.clone()))
+  , prefix_(std::move(prefix))
+{
+}
+
 bool AddSceneGraphCommand::operator==(const AddSceneGraphCommand& rhs) const
 {
   bool equal = true;

--- a/tesseract_environment/src/commands/change_collision_margins_command.cpp
+++ b/tesseract_environment/src/commands/change_collision_margins_command.cpp
@@ -36,6 +36,41 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {
+ChangeCollisionMarginsCommand::ChangeCollisionMarginsCommand() : Command(CommandType::CHANGE_COLLISION_MARGINS){};
+
+ChangeCollisionMarginsCommand::ChangeCollisionMarginsCommand(double default_margin,
+                                                             CollisionMarginOverrideType override_type)
+  : Command(CommandType::CHANGE_COLLISION_MARGINS)
+  , collision_margin_data_(CollisionMarginData(default_margin))
+  , collision_margin_override_(override_type)
+{
+}
+
+ChangeCollisionMarginsCommand::ChangeCollisionMarginsCommand(PairsCollisionMarginData pairs_margin,
+                                                             CollisionMarginOverrideType override_type)
+  : Command(CommandType::CHANGE_COLLISION_MARGINS)
+  , collision_margin_data_(CollisionMarginData(std::move(pairs_margin)))
+  , collision_margin_override_(override_type)
+{
+}
+
+ChangeCollisionMarginsCommand::ChangeCollisionMarginsCommand(CollisionMarginData collision_margin_data,
+                                                             CollisionMarginOverrideType override_type)
+  : Command(CommandType::CHANGE_COLLISION_MARGINS)
+  , collision_margin_data_(std::move(collision_margin_data))
+  , collision_margin_override_(override_type)
+{
+}
+
+tesseract_common::CollisionMarginData ChangeCollisionMarginsCommand::getCollisionMarginData() const
+{
+  return collision_margin_data_;
+}
+tesseract_common::CollisionMarginOverrideType ChangeCollisionMarginsCommand::getCollisionMarginOverrideType() const
+{
+  return collision_margin_override_;
+}
+
 bool ChangeCollisionMarginsCommand::operator==(const ChangeCollisionMarginsCommand& rhs) const
 {
   bool equal = true;

--- a/tesseract_environment/src/commands/change_joint_acceleration_limits_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_acceleration_limits_command.cpp
@@ -37,6 +37,27 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {
+ChangeJointAccelerationLimitsCommand::ChangeJointAccelerationLimitsCommand()
+  : Command(CommandType::CHANGE_JOINT_ACCELERATION_LIMITS){};
+
+ChangeJointAccelerationLimitsCommand::ChangeJointAccelerationLimitsCommand(std::string joint_name, double limit)
+  : Command(CommandType::CHANGE_JOINT_ACCELERATION_LIMITS), limits_({ std::make_pair(std::move(joint_name), limit) })
+{
+  assert(limit > 0);
+}
+
+ChangeJointAccelerationLimitsCommand::ChangeJointAccelerationLimitsCommand(
+    std::unordered_map<std::string, double> limits)
+  : Command(CommandType::CHANGE_JOINT_ACCELERATION_LIMITS), limits_(std::move(limits))
+{
+  assert(std::all_of(limits_.begin(), limits_.end(), [](const auto& p) { return p.second > 0; }));
+}
+
+const std::unordered_map<std::string, double>& ChangeJointAccelerationLimitsCommand::getLimits() const
+{
+  return limits_;
+}
+
 bool ChangeJointAccelerationLimitsCommand::operator==(const ChangeJointAccelerationLimitsCommand& rhs) const
 {
   bool equal = true;

--- a/tesseract_environment/src/commands/change_joint_origin_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_origin_command.cpp
@@ -38,6 +38,16 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {
+ChangeJointOriginCommand::ChangeJointOriginCommand() : Command(CommandType::CHANGE_JOINT_ORIGIN){};
+
+ChangeJointOriginCommand::ChangeJointOriginCommand(std::string joint_name, const Eigen::Isometry3d& origin)
+  : Command(CommandType::CHANGE_JOINT_ORIGIN), joint_name_(std::move(joint_name)), origin_(origin)
+{
+}
+
+const std::string& ChangeJointOriginCommand::getJointName() const { return joint_name_; }
+const Eigen::Isometry3d& ChangeJointOriginCommand::getOrigin() const { return origin_; }
+
 bool ChangeJointOriginCommand::operator==(const ChangeJointOriginCommand& rhs) const
 {
   bool equal = true;

--- a/tesseract_environment/src/commands/change_joint_position_limits_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_position_limits_command.cpp
@@ -37,6 +37,28 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {
+ChangeJointPositionLimitsCommand::ChangeJointPositionLimitsCommand()
+  : Command(CommandType::CHANGE_JOINT_POSITION_LIMITS){};
+
+ChangeJointPositionLimitsCommand::ChangeJointPositionLimitsCommand(std::string joint_name, double lower, double upper)
+  : Command(CommandType::CHANGE_JOINT_POSITION_LIMITS)
+  , limits_({ std::make_pair(std::move(joint_name), std::make_pair(lower, upper)) })
+{
+  assert(upper > lower);
+}
+
+ChangeJointPositionLimitsCommand::ChangeJointPositionLimitsCommand(
+    std::unordered_map<std::string, std::pair<double, double>> limits)
+  : Command(CommandType::CHANGE_JOINT_POSITION_LIMITS), limits_(std::move(limits))
+{
+  assert(std::all_of(limits_.begin(), limits_.end(), [](const auto& p) { return p.second.second > p.second.first; }));
+}
+
+const std::unordered_map<std::string, std::pair<double, double>>& ChangeJointPositionLimitsCommand::getLimits() const
+{
+  return limits_;
+}
+
 bool ChangeJointPositionLimitsCommand::operator==(const ChangeJointPositionLimitsCommand& rhs) const
 {
   auto fn = [](const std::pair<double, double>& p1, const std::pair<double, double>& p2) {

--- a/tesseract_environment/src/commands/change_joint_velocity_limits_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_velocity_limits_command.cpp
@@ -37,6 +37,23 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_environment
 {
+ChangeJointVelocityLimitsCommand::ChangeJointVelocityLimitsCommand()
+  : Command(CommandType::CHANGE_JOINT_VELOCITY_LIMITS){};
+
+ChangeJointVelocityLimitsCommand::ChangeJointVelocityLimitsCommand(std::string joint_name, double limit)
+  : Command(CommandType::CHANGE_JOINT_VELOCITY_LIMITS), limits_({ std::make_pair(std::move(joint_name), limit) })
+{
+  assert(limit > 0);
+}
+
+ChangeJointVelocityLimitsCommand::ChangeJointVelocityLimitsCommand(std::unordered_map<std::string, double> limits)
+  : Command(CommandType::CHANGE_JOINT_VELOCITY_LIMITS), limits_(std::move(limits))
+{
+  assert(std::all_of(limits_.begin(), limits_.end(), [](const auto& p) { return p.second > 0; }));
+}
+
+const std::unordered_map<std::string, double>& ChangeJointVelocityLimitsCommand::getLimits() const { return limits_; }
+
 bool ChangeJointVelocityLimitsCommand::operator==(const ChangeJointVelocityLimitsCommand& rhs) const
 {
   bool equal = true;

--- a/tesseract_environment/src/environment.cpp
+++ b/tesseract_environment/src/environment.cpp
@@ -262,13 +262,13 @@ Commands Environment::getInitCommands(const tesseract_scene_graph::SceneGraph& s
   if (local_sg == nullptr)
   {
     CONSOLE_BRIDGE_logError("Null pointer to Scene Graph");
-    return Commands();
+    return {};
   }
 
   if (!local_sg->getLink(local_sg->getRoot()))
   {
     CONSOLE_BRIDGE_logError("The scene graph has an invalid root.");
-    return Commands();
+    return {};
   }
 
   if (srdf_model != nullptr)

--- a/tesseract_environment/test/CMakeLists.txt
+++ b/tesseract_environment/test/CMakeLists.txt
@@ -1,11 +1,12 @@
 find_gtest()
 find_package(tesseract_support REQUIRED)
 find_package(OpenMP REQUIRED)
-if(OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-else(OPENMP_FOUND)
-  message(STATUS "Not found OpenMP")
+if(NOT TARGET OpenMP::OpenMP_CXX)
+  find_package(Threads REQUIRED)
+  add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+  set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+  # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
+  set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
 endif()
 
 add_executable(${PROJECT_NAME}_unit tesseract_environment_unit.cpp)
@@ -14,6 +15,7 @@ target_link_libraries(
   PRIVATE GTest::GTest
           GTest::Main
           ${PROJECT_NAME}
+          OpenMP::OpenMP_CXX
           tesseract::tesseract_support
           tesseract::tesseract_urdf
           tesseract::tesseract_collision_bullet

--- a/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -3,6 +3,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <vector>
+#include <omp.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_urdf/urdf_parser.h>
@@ -1993,6 +1994,7 @@ TEST(TesseractEnvironmentUnit, EnvMultithreadedApplyCommandsTest)  // NOLINT
 #pragma omp parallel for num_threads(10) shared(env)
   for (long i = 0; i < 10; ++i)  // NOLINT
   {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     const int tn = omp_get_thread_num();
     CONSOLE_BRIDGE_logDebug("Thread (ID: %i): %i of %i", tn, i, 10);
 
@@ -2508,9 +2510,7 @@ bool hasProcessInterpolatedResultsTime1(const tesseract_collision::ContactResult
   return false;
 }
 
-/**
- * @brief Get the total number of contacts
- */
+/** @brief Get the total number of contacts */
 int getContactCount(const std::vector<tesseract_collision::ContactResultMap>& contacts)
 {
   int total{ 0 };

--- a/tesseract_geometry/include/tesseract_geometry/impl/mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/mesh.h
@@ -89,7 +89,7 @@ public:
                   std::move(mesh_textures),
                   GeometryType::MESH)
   {
-    if ((getFaceCount() * 4) != getFaces()->size())
+    if ((static_cast<long>(getFaceCount()) * 4) != getFaces()->size())
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));  // LCOV_EXCL_LINE
   }
 
@@ -128,7 +128,7 @@ public:
                   std::move(mesh_textures),
                   GeometryType::MESH)
   {
-    if ((getFaceCount() * 4) != getFaces()->size())
+    if ((static_cast<long>(getFaceCount()) * 4) != getFaces()->size())
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));  // LCOV_EXCL_LINE
   }
 

--- a/tesseract_geometry/include/tesseract_geometry/impl/polygon_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/polygon_mesh.h
@@ -84,6 +84,7 @@ public:
     : Geometry(type)
     , vertices_(std::move(vertices))
     , faces_(std::move(faces))
+    , vertex_count_(static_cast<int>(vertices_->size()))
     , resource_(std::move(resource))
     , scale_(scale)
     , normals_(std::move(normals))
@@ -91,9 +92,6 @@ public:
     , mesh_material_(std::move(mesh_material))
     , mesh_textures_(std::move(mesh_textures))
   {
-    vertex_count_ = static_cast<int>(vertices_->size());
-
-    face_count_ = 0;
     for (int i = 0; i < faces_->size(); ++i)
     {
       ++face_count_;
@@ -132,6 +130,7 @@ public:
     : Geometry(type)
     , vertices_(std::move(vertices))
     , faces_(std::move(faces))
+    , vertex_count_(static_cast<int>(vertices_->size()))
     , face_count_(face_count)
     , resource_(std::move(resource))
     , scale_(scale)
@@ -140,7 +139,6 @@ public:
     , mesh_material_(std::move(mesh_material))
     , mesh_textures_(std::move(mesh_textures))
   {
-    vertex_count_ = static_cast<int>(vertices_->size());
   }
 
   PolygonMesh() = default;

--- a/tesseract_geometry/include/tesseract_geometry/impl/sdf_mesh.h
+++ b/tesseract_geometry/include/tesseract_geometry/impl/sdf_mesh.h
@@ -87,7 +87,7 @@ public:
                   std::move(mesh_textures),
                   GeometryType::SDF_MESH)
   {
-    if ((getFaceCount() * 4) != getFaces()->size())
+    if ((static_cast<long>(getFaceCount()) * 4) != getFaces()->size())
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));  // LCOV_EXCL_LINE
   }
 
@@ -126,7 +126,7 @@ public:
                   std::move(mesh_textures),
                   GeometryType::SDF_MESH)
   {
-    if ((getFaceCount() * 4) != getFaces()->size())
+    if ((static_cast<long>(getFaceCount()) * 4) != getFaces()->size())
       std::throw_with_nested(std::runtime_error("Mesh is not triangular"));  // LCOV_EXCL_LINE
   }
 

--- a/tesseract_geometry/include/tesseract_geometry/mesh_parser.h
+++ b/tesseract_geometry/include/tesseract_geometry/mesh_parser.h
@@ -476,14 +476,14 @@ std::vector<std::shared_ptr<T>> createMeshFromResource(tesseract_common::Resourc
   // And have it read the given file with some post-processing
   const aiScene* scene = nullptr;
   if (triangulate)
-    scene = importer.ReadFileFromMemory(&data[0],
+    scene = importer.ReadFileFromMemory(data.data(),
                                         data.size(),
                                         aiProcess_Triangulate | aiProcess_JoinIdenticalVertices |
                                             aiProcess_SortByPType | aiProcess_RemoveComponent,
                                         hint);
   else
     scene =
-        importer.ReadFileFromMemory(&data[0],
+        importer.ReadFileFromMemory(data.data(),
                                     data.size(),
                                     aiProcess_JoinIdenticalVertices | aiProcess_SortByPType | aiProcess_RemoveComponent,
                                     hint);

--- a/tesseract_geometry/src/geometries/octree.cpp
+++ b/tesseract_geometry/src/geometries/octree.cpp
@@ -119,7 +119,7 @@ void Octree::load(Archive& ar, const unsigned int /*version*/)
 
   // Write that data into the stringstream required by octree and load data
   std::stringstream s;
-  s.write(data_string.data(), octree_data_size);
+  s.write(data_string.data(), static_cast<std::streamsize>(octree_data_size));
 
   if (binary_octree_)
     local_octree->readBinary(s);

--- a/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
+++ b/tesseract_kinematics/core/include/tesseract_kinematics/core/utils.h
@@ -385,9 +385,9 @@ inline void getRedundantSolutionsHelper(std::vector<VectorX<FloatType>>& redunda
           Eigen::VectorXd new_sol = sol;
           new_sol[*current_index] = val;
 
-          if (tesseract_common::satisfiesPositionLimits(new_sol, limits))
+          if (tesseract_common::satisfiesPositionLimits<double>(new_sol, limits))
           {
-            tesseract_common::enforcePositionLimits(new_sol, limits);
+            tesseract_common::enforcePositionLimits<double>(new_sol, limits);
             redundant_sols.push_back(new_sol.template cast<FloatType>());
           }
 
@@ -416,9 +416,9 @@ inline void getRedundantSolutionsHelper(std::vector<VectorX<FloatType>>& redunda
           Eigen::VectorXd new_sol = sol;
           new_sol[*current_index] = val;
 
-          if (tesseract_common::satisfiesPositionLimits(new_sol, limits))
+          if (tesseract_common::satisfiesPositionLimits<double>(new_sol, limits))
           {
-            tesseract_common::enforcePositionLimits(new_sol, limits);
+            tesseract_common::enforcePositionLimits<double>(new_sol, limits);
             redundant_sols.push_back(new_sol.template cast<FloatType>());
           }
 

--- a/tesseract_kinematics/core/src/kinematic_group.cpp
+++ b/tesseract_kinematics/core/src/kinematic_group.cpp
@@ -40,9 +40,10 @@ KinematicGroup::KinematicGroup(std::string name,
                                InverseKinematics::UPtr inv_kin,
                                const tesseract_scene_graph::SceneGraph& scene_graph,
                                const tesseract_scene_graph::SceneState& scene_state)
-  : JointGroup(std::move(name), joint_names, scene_graph, scene_state), joint_names_(std::move(joint_names))
+  : JointGroup(std::move(name), joint_names, scene_graph, scene_state)
+  , joint_names_(std::move(joint_names))
+  , inv_kin_(std::move(inv_kin))
 {
-  inv_kin_ = std::move(inv_kin);
   std::vector<std::string> inv_kin_joint_names = inv_kin_->getJointNames();
 
   if (static_cast<Eigen::Index>(joint_names_.size()) != inv_kin_->numJoints())

--- a/tesseract_kinematics/core/src/kinematic_group.cpp
+++ b/tesseract_kinematics/core/src/kinematic_group.cpp
@@ -155,7 +155,7 @@ IKSolutions KinematicGroup::calcInvKin(const KinGroupIKInputs& tip_link_poses,
       for (Eigen::Index i = 0; i < inv_kin_->numJoints(); ++i)
         ordered_sol(i) = solution(inv_kin_joint_map_[static_cast<std::size_t>(i)]);
 
-      if (tesseract_common::satisfiesPositionLimits(ordered_sol, limits_.joint_limits))
+      if (tesseract_common::satisfiesPositionLimits<double>(ordered_sol, limits_.joint_limits))
         solutions_filtered.push_back(ordered_sol);
     }
 
@@ -167,7 +167,7 @@ IKSolutions KinematicGroup::calcInvKin(const KinGroupIKInputs& tip_link_poses,
   solutions_filtered.reserve(solutions.size());
   for (auto& solution : solutions)
   {
-    if (tesseract_common::satisfiesPositionLimits(solution, limits_.joint_limits))
+    if (tesseract_common::satisfiesPositionLimits<double>(solution, limits_.joint_limits))
       solutions_filtered.push_back(solution);
   }
 

--- a/tesseract_kinematics/core/src/rep_inv_kin.cpp
+++ b/tesseract_kinematics/core/src/rep_inv_kin.cpp
@@ -235,6 +235,7 @@ void REPInvKin::ikAt(IKSolutions& solutions,
 IKSolutions REPInvKin::calcInvKin(const tesseract_common::TransformMap& tip_link_poses,
                                   const Eigen::Ref<const Eigen::VectorXd>& seed) const
 {
+  // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
   assert(tip_link_poses.find(manip_tip_link_) != tip_link_poses.end());
   assert(std::abs(1.0 - tip_link_poses.at(manip_tip_link_).matrix().determinant()) < 1e-6);  // NOLINT
 

--- a/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_lma.cpp
+++ b/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_lma.cpp
@@ -113,7 +113,7 @@ IKSolutions KDLInvKinChainLMA::calcInvKinHelper(const Eigen::Isometry3d& pose,
     CONSOLE_BRIDGE_logDebug("KDL LMA Failed to calculate IK");
 #endif
     // LCOV_EXCL_STOP
-    return IKSolutions();
+    return {};
   }
 
   KDLToEigen(kdl_solution, solution);

--- a/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_nr.cpp
+++ b/tesseract_kinematics/kdl/src/kdl_inv_kin_chain_nr.cpp
@@ -126,7 +126,7 @@ IKSolutions KDLInvKinChainNR::calcInvKinHelper(const Eigen::Isometry3d& pose,
       CONSOLE_BRIDGE_logDebug("KDL NR Failed to calculate IK");
     }
     // LCOV_EXCL_STOP
-    return IKSolutions();
+    return {};
   }
 
   KDLToEigen(kdl_solution, solution);

--- a/tesseract_kinematics/test/kinematics_core_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_core_unit.cpp
@@ -61,7 +61,7 @@ void runRedundantSolutionsTest()
     {  // Test when initial solution is at the lower limit
       std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
           tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
-      if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+      if (tesseract_common::satisfiesPositionLimits<double>(q.template cast<double>(), limits, max_diff))
         solutions.push_back(q);
 
       EXPECT_EQ(solutions.size(), 8);
@@ -72,7 +72,7 @@ void runRedundantSolutionsTest()
       limits << -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI, -2.0 * M_PI, 2.0 * M_PI;
       std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
           tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
-      if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+      if (tesseract_common::satisfiesPositionLimits<double>(q.template cast<double>(), limits, max_diff))
         solutions.push_back(q);
 
       EXPECT_EQ(solutions.size(), 27);
@@ -85,7 +85,7 @@ void runRedundantSolutionsTest()
 
       std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
           tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
-      if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+      if (tesseract_common::satisfiesPositionLimits<double>(q.template cast<double>(), limits, max_diff))
         solutions.push_back(q);
 
       EXPECT_EQ(solutions.size(), 27);
@@ -107,7 +107,7 @@ void runRedundantSolutionsTest()
 
     std::vector<tesseract_kinematics::VectorX<FloatType>> solutions =
         tesseract_kinematics::getRedundantSolutions<FloatType>(q, limits, redundancy_capable_joints);
-    if (tesseract_common::satisfiesPositionLimits(q.template cast<double>(), limits, max_diff))
+    if (tesseract_common::satisfiesPositionLimits<double>(q.template cast<double>(), limits, max_diff))
       solutions.push_back(q);
 
     EXPECT_EQ(solutions.size(), 27);

--- a/tesseract_kinematics/test/kinematics_factory_unit.cpp
+++ b/tesseract_kinematics/test/kinematics_factory_unit.cpp
@@ -73,7 +73,7 @@ void runKinematicsFactoryTest(const tesseract_common::fs::path& config_path)
 
     for (auto it = search_paths.begin(); it != search_paths.end(); ++it)
     {
-      EXPECT_TRUE(std::find(sp.begin(), sp.end(), it->as<std::string>()) != sp.end());
+      EXPECT_TRUE(sp.find(it->as<std::string>()) != sp.end());
     }
   }
 
@@ -83,7 +83,7 @@ void runKinematicsFactoryTest(const tesseract_common::fs::path& config_path)
 
     for (auto it = search_libraries.begin(); it != search_libraries.end(); ++it)
     {
-      EXPECT_TRUE(std::find(sl.begin(), sl.end(), it->as<std::string>()) != sl.end());
+      EXPECT_TRUE(sl.find(it->as<std::string>()) != sl.end());
     }
   }
 

--- a/tesseract_scene_graph/src/graph.cpp
+++ b/tesseract_scene_graph/src/graph.cpp
@@ -786,7 +786,7 @@ std::vector<std::string> SceneGraph::getJointChildrenNames(const std::vector<std
     link_names.insert(joint_children.begin(), joint_children.end());
   }
 
-  return std::vector<std::string>(link_names.begin(), link_names.end());
+  return std::vector<std::string>{ link_names.begin(), link_names.end() };
 }
 
 std::unordered_map<std::string, std::string>

--- a/tesseract_scene_graph/src/kdl_parser.cpp
+++ b/tesseract_scene_graph/src/kdl_parser.cpp
@@ -67,9 +67,9 @@ Eigen::Isometry3d convert(const KDL::Frame& frame)
   return transform;
 }
 
-KDL::Vector convert(const Eigen::Vector3d& vector) { return KDL::Vector(vector(0), vector(1), vector(2)); }
+KDL::Vector convert(const Eigen::Vector3d& vector) { return KDL::Vector{ vector(0), vector(1), vector(2) }; }
 
-Eigen::Vector3d convert(const KDL::Vector& vector) { return Eigen::Vector3d(vector(0), vector(1), vector(2)); }
+Eigen::Vector3d convert(const KDL::Vector& vector) { return Eigen::Vector3d{ vector(0), vector(1), vector(2) }; }
 
 Eigen::MatrixXd convert(const KDL::Jacobian& jacobian) { return jacobian.data; }
 
@@ -111,17 +111,17 @@ KDL::Joint convert(const Joint::ConstPtr& joint)
     case JointType::REVOLUTE:
     {
       KDL::Vector axis = convert(joint->axis);
-      return KDL::Joint(name, parent_joint.p, parent_joint.M * axis, KDL::Joint::RotAxis);
+      return KDL::Joint{ name, parent_joint.p, parent_joint.M * axis, KDL::Joint::RotAxis };
     }
     case JointType::CONTINUOUS:
     {
       KDL::Vector axis = convert(joint->axis);
-      return KDL::Joint(name, parent_joint.p, parent_joint.M * axis, KDL::Joint::RotAxis);
+      return KDL::Joint{ name, parent_joint.p, parent_joint.M * axis, KDL::Joint::RotAxis };
     }
     case JointType::PRISMATIC:
     {
       KDL::Vector axis = convert(joint->axis);
-      return KDL::Joint(name, parent_joint.p, parent_joint.M * axis, KDL::Joint::TransAxis);
+      return KDL::Joint{ name, parent_joint.p, parent_joint.M * axis, KDL::Joint::TransAxis };
     }
     default:
     {

--- a/tesseract_srdf/include/tesseract_srdf/collision_margins.h
+++ b/tesseract_srdf/include/tesseract_srdf/collision_margins.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 }
 namespace tesseract_scene_graph
 {

--- a/tesseract_srdf/include/tesseract_srdf/configs.h
+++ b/tesseract_srdf/include/tesseract_srdf/configs.h
@@ -36,7 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 }
 namespace tesseract_scene_graph
 {

--- a/tesseract_srdf/include/tesseract_srdf/disabled_collisions.h
+++ b/tesseract_srdf/include/tesseract_srdf/disabled_collisions.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 }
 namespace tesseract_scene_graph
 {

--- a/tesseract_srdf/include/tesseract_srdf/group_states.h
+++ b/tesseract_srdf/include/tesseract_srdf/group_states.h
@@ -35,7 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 }
 namespace tesseract_scene_graph
 {

--- a/tesseract_srdf/include/tesseract_srdf/group_tool_center_points.h
+++ b/tesseract_srdf/include/tesseract_srdf/group_tool_center_points.h
@@ -36,7 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 }
 namespace tesseract_scene_graph
 {

--- a/tesseract_srdf/include/tesseract_srdf/groups.h
+++ b/tesseract_srdf/include/tesseract_srdf/groups.h
@@ -36,7 +36,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 }
 namespace tesseract_scene_graph
 {

--- a/tesseract_srdf/src/srdf_model.cpp
+++ b/tesseract_srdf/src/srdf_model.cpp
@@ -28,6 +28,7 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/nvp.hpp>
 #include <unordered_map>
 #include <vector>
 #include <utility>
@@ -47,9 +48,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_srdf/configs.h>
 #include <tesseract_srdf/srdf_model.h>
 #include <tesseract_srdf/utils.h>
-#include <tesseract_common/serialization.h>
 #include <tesseract_common/utils.h>
 #include <tesseract_common/yaml_utils.h>
+#include <tesseract_common/eigen_serialization.h>
 
 namespace tesseract_srdf
 {

--- a/tesseract_state_solver/src/kdl_state_solver.cpp
+++ b/tesseract_state_solver/src/kdl_state_solver.cpp
@@ -131,6 +131,7 @@ SceneState KDLStateSolver::getState(const std::unordered_map<std::string, double
       state.joints[joint.first] = joint.second;
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
   calculateTransforms(state, jnt_array, data_.tree.getRootSegment(), Eigen::Isometry3d::Identity());
 
   return state;

--- a/tesseract_state_solver/test/CMakeLists.txt
+++ b/tesseract_state_solver/test/CMakeLists.txt
@@ -1,13 +1,6 @@
 find_gtest()
 find_package(tesseract_support REQUIRED)
 find_package(tesseract_urdf REQUIRED)
-find_package(OpenMP REQUIRED)
-if(OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-else(OPENMP_FOUND)
-  message(STATUS "Not found OpenMP")
-endif()
 
 add_executable(${PROJECT_NAME}_unit tesseract_state_solver_ofkt_unit.cpp)
 target_link_libraries(

--- a/tesseract_urdf/include/tesseract_urdf/box.h
+++ b/tesseract_urdf/include/tesseract_urdf/box.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_geometry

--- a/tesseract_urdf/include/tesseract_urdf/calibration.h
+++ b/tesseract_urdf/include/tesseract_urdf/calibration.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/capsule.h
+++ b/tesseract_urdf/include/tesseract_urdf/capsule.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_geometry

--- a/tesseract_urdf/include/tesseract_urdf/collision.h
+++ b/tesseract_urdf/include/tesseract_urdf/collision.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/cone.h
+++ b/tesseract_urdf/include/tesseract_urdf/cone.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_geometry

--- a/tesseract_urdf/include/tesseract_urdf/convex_mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/convex_mesh.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/cylinder.h
+++ b/tesseract_urdf/include/tesseract_urdf/cylinder.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_geometry

--- a/tesseract_urdf/include/tesseract_urdf/dynamics.h
+++ b/tesseract_urdf/include/tesseract_urdf/dynamics.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/geometry.h
+++ b/tesseract_urdf/include/tesseract_urdf/geometry.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/inertial.h
+++ b/tesseract_urdf/include/tesseract_urdf/inertial.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/joint.h
+++ b/tesseract_urdf/include/tesseract_urdf/joint.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/limits.h
+++ b/tesseract_urdf/include/tesseract_urdf/limits.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/link.h
+++ b/tesseract_urdf/include/tesseract_urdf/link.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/material.h
+++ b/tesseract_urdf/include/tesseract_urdf/material.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/mesh.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/mimic.h
+++ b/tesseract_urdf/include/tesseract_urdf/mimic.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/octomap.h
+++ b/tesseract_urdf/include/tesseract_urdf/octomap.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/octree.h
+++ b/tesseract_urdf/include/tesseract_urdf/octree.h
@@ -35,7 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/origin.h
+++ b/tesseract_urdf/include/tesseract_urdf/origin.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/point_cloud.h
+++ b/tesseract_urdf/include/tesseract_urdf/point_cloud.h
@@ -35,7 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/safety_controller.h
+++ b/tesseract_urdf/include/tesseract_urdf/safety_controller.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/include/tesseract_urdf/sdf_mesh.h
+++ b/tesseract_urdf/include/tesseract_urdf/sdf_mesh.h
@@ -34,7 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 

--- a/tesseract_urdf/include/tesseract_urdf/sphere.h
+++ b/tesseract_urdf/include/tesseract_urdf/sphere.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_geometry

--- a/tesseract_urdf/include/tesseract_urdf/visual.h
+++ b/tesseract_urdf/include/tesseract_urdf/visual.h
@@ -35,7 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tinyxml2
 {
-class XMLElement;
+class XMLElement;  // NOLINT
 class XMLDocument;
 }  // namespace tinyxml2
 namespace tesseract_scene_graph

--- a/tesseract_urdf/src/octomap.cpp
+++ b/tesseract_urdf/src/octomap.cpp
@@ -36,7 +36,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_urdf/octomap.h>
 #include <tesseract_urdf/octree.h>
 #include <tesseract_common/resource_locator.h>
-#include <tesseract_geometry/impl/octree.h>
 #include <tesseract_urdf/utils.h>
 
 #ifdef TESSERACT_PARSE_POINT_CLOUDS

--- a/tesseract_urdf/src/octree.cpp
+++ b/tesseract_urdf/src/octree.cpp
@@ -34,7 +34,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <tinyxml2.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_urdf/octree.h>
 #include <tesseract_common/resource_locator.h>
 #include <tesseract_urdf/octree.h>
 #include <tesseract_urdf/utils.h>

--- a/tesseract_urdf/test/tesseract_urdf_origin_unit.cpp
+++ b/tesseract_urdf/test/tesseract_urdf_origin_unit.cpp
@@ -24,7 +24,7 @@ Eigen::Quaterniond fromRPY(double roll, double pitch, double yaw)
   z = std::cos(phi) * std::cos(the) * std::sin(psi) - std::sin(phi) * std::sin(the) * std::cos(psi);
   w = std::cos(phi) * std::cos(the) * std::cos(psi) + std::sin(phi) * std::sin(the) * std::sin(psi);
 
-  return Eigen::Quaterniond(w, x, y, z);
+  return Eigen::Quaterniond{ w, x, y, z };
 }
 
 TEST(TesseractURDFUnit, parse_origin)  // NOLINT

--- a/tesseract_visualization/include/tesseract_visualization/markers/arrow_marker.h
+++ b/tesseract_visualization/include/tesseract_visualization/markers/arrow_marker.h
@@ -27,7 +27,7 @@ public:
    * @param pt1 The starting point
    * @param pt2 The final point
    */
-  ArrowMarker(const Eigen::Vector3d& pt1, const Eigen::Vector3d& pt2)
+  ArrowMarker(const Eigen::Vector3d& pt1, const Eigen::Vector3d& pt2) : shaft_radius(0.005), head_radius(0.01)
   {
     Eigen::Vector3d x, y, z;
     z = (pt2 - pt1).normalized();
@@ -42,9 +42,7 @@ public:
 
     double length = (pt2 - pt1).norm();
     shaft_length = length - 0.01;
-    shaft_radius = 0.005;
     head_length = length - shaft_length;
-    head_radius = 0.01;
   }
 
   int getType() const override { return static_cast<int>(MarkerType::ARROW); }


### PR DESCRIPTION
I noticed that we had duplicate function in motion planning because these were not templates and were not unit tested. This will allow these unit tested methods to be used in motion planning.