### PR TITLE
Fixed convex mesh export

### DIFF
--- a/tesseract_urdf/src/convex_mesh.cpp
+++ b/tesseract_urdf/src/convex_mesh.cpp
@@ -124,7 +124,7 @@ tinyxml2::XMLElement* tesseract_urdf::writeConvexMesh(const std::shared_ptr<cons
 
   try
   {
-    writeMeshToFile(mesh, /*trailingSlash(package_path) + noLeadingSlash(*/ filename);
+    writeMeshToFile(mesh, trailingSlash(package_path) + noLeadingSlash(filename));
   }
   catch (...)
   {


### PR DESCRIPTION
Convex meshes don't generally save correctly when exporting a URDF because the package path is not included in the file path. This PR updates the convex mesh exporter to match the regular mesh exporter.