### PR TITLE
Use absolute paths for bullet libraries

### DIFF
--- a/tesseract_collision/bullet/CMakeLists.txt
+++ b/tesseract_collision/bullet/CMakeLists.txt
@@ -27,6 +27,14 @@ else()
   set(BULLET_LIBRARY_DIRS_ABS ${BULLET_LIBRARY_DIRS})
 endif()
 
+set(BULLET_LIBRARIES_ABS "")
+foreach(BULLET_LIB IN LISTS BULLET_LIBRARIES)
+  find_library(BULLET_LIB_ABS_${BULLET_LIB} ${BULLET_LIB} PATHS ${BULLET_LIBRARY_DIRS_ABS} NO_DEFAULT_PATH REQUIRED)
+  list(APPEND BULLET_LIBRARIES_ABS "${BULLET_LIB_ABS_${BULLET_LIB}}")
+  message(STATUS "BULLET_LIB=${BULLET_LIB} BULLET_LIB_ABS=${BULLET_LIB_ABS_${BULLET_LIB}}")
+endforeach()
+message(STATUS "BULLET_LIBRARIES_ABS=${BULLET_LIBRARIES_ABS}")
+
 find_library(HACD_LIBRARY HACD HINTS ${BULLET_LIBRARY_DIRS_ABS})
 if(NOT HACD_LIBRARY)
   message(
@@ -55,7 +63,7 @@ target_link_libraries(
          console_bridge::console_bridge
          octomap
          octomath)
-target_link_libraries(${PROJECT_NAME}_bullet PUBLIC ${BULLET_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_bullet PUBLIC ${BULLET_LIBRARIES_ABS})
 target_compile_options(${PROJECT_NAME}_bullet PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
 target_compile_options(${PROJECT_NAME}_bullet PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_compile_definitions(${PROJECT_NAME}_bullet PUBLIC ${TESSERACT_COMPILE_DEFINITIONS} ${BULLET_DEFINITIONS})
@@ -100,7 +108,7 @@ if(${HACD_LIBRARY})
            Eigen3::Eigen
            tesseract::tesseract_geometry
            console_bridge::console_bridge
-           ${BULLET_LIBRARIES}
+           ${BULLET_LIBRARIES_ABS}
            ${HACD_LIBRARY})
   target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})
   target_compile_options(${PROJECT_NAME}_hacd_convex_decomposition PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})

--- a/tesseract_collision/examples/CMakeLists.txt
+++ b/tesseract_collision/examples/CMakeLists.txt
@@ -7,7 +7,6 @@ target_link_libraries(
   tesseract::tesseract_support
   tesseract::tesseract_geometry
   console_bridge::console_bridge
-  ${BULLET_LIBRARIES}
   ${Boost_LIBRARIES}
   octomap
   octomath

--- a/tesseract_collision/test/benchmarks/CMakeLists.txt
+++ b/tesseract_collision/test/benchmarks/CMakeLists.txt
@@ -16,7 +16,6 @@ macro(add_benchmark benchmark_name benchmark_file)
     ${PROJECT_NAME}_fcl
     tesseract::tesseract_geometry
     tesseract::tesseract_scene_graph
-    ${BULLET_LIBRARIES}
     console_bridge
     ${Boost_LIBRARIES}
     octomap
@@ -44,7 +43,6 @@ target_link_libraries(
           ${PROJECT_NAME}_fcl
           tesseract::tesseract_geometry
           tesseract::tesseract_support
-          ${BULLET_LIBRARIES}
           ${Boost_LIBRARIES}
           ${OCTOMAP_LIBRARIES}
           ${LIBFCL_LIBRARIES})

--- a/tesseract_collision/vhacd/CMakeLists.txt
+++ b/tesseract_collision/vhacd/CMakeLists.txt
@@ -27,6 +27,14 @@ else()
   set(BULLET_LIBRARY_DIRS_ABS ${BULLET_LIBRARY_DIRS})
 endif()
 
+set(BULLET_LIBRARIES_ABS "")
+foreach(BULLET_LIB IN LISTS BULLET_LIBRARIES)
+  find_library(BULLET_LIB_ABS_${BULLET_LIB} ${BULLET_LIB} PATHS ${BULLET_LIBRARY_DIRS_ABS} NO_DEFAULT_PATH REQUIRED)
+  list(APPEND BULLET_LIBRARIES_ABS "${BULLET_LIB_ABS_${BULLET_LIB}}")
+  message(STATUS "BULLET_LIB=${BULLET_LIB} BULLET_LIB_ABS=${BULLET_LIB_ABS_${BULLET_LIB}}")
+endforeach()
+message(STATUS "BULLET_LIBRARIES_ABS=${BULLET_LIBRARIES_ABS}")
+
 # Third party vhacd
 include("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/vhacd_common.cmake")
 
@@ -71,7 +79,7 @@ target_link_libraries(
   PUBLIC OpenMP::OpenMP_CXX
          tesseract::tesseract_common
          Eigen3::Eigen
-         ${BULLET_LIBRARIES})
+         ${BULLET_LIBRARIES_ABS})
 target_include_directories(${PROJECT_NAME}_vhacd PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                         "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_vhacd SYSTEM PUBLIC "${BULLET_INCLUDE_DIRS_ABS}")


### PR DESCRIPTION
Currently the bullet libraries are being included using relative paths, and the linker is finding the wrong libraries in some unexpected paths. This PR uses `find_library()` on each library with the desired path, and includes the libraries as absolute paths.