### PR TITLE
Add tesseract extension macro

### DIFF
--- a/tesseract_common/include/tesseract_common/serialization.h
+++ b/tesseract_common/include/tesseract_common/serialization.h
@@ -40,6 +40,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/tracking_enum.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_common/types.h>
+#include <tesseract_common/serialization_extensions.h>
+
 // Used to replace commas in these macros to avoid them being interpreted as multiple arguments
 // Example: TESSERACT_SERIALIZE_SAVE_LOAD_FREE_ARCHIVES_INSTANTIATE(std::variant<std::string COMMA Eigen::Isometry3d>)
 #define COMMA ,
@@ -110,7 +113,11 @@ struct Serialization
                                const std::string& file_path,
                                const std::string& name = "")
   {
-    std::ofstream os(file_path);
+    fs::path fp(file_path);
+    if (!fp.has_extension())
+      fp.append(".").append(serialization::xml::extension<SerializableType>::value);
+
+    std::ofstream os(fp.string());
     {  // Must be scoped because all data is not written until the oost::archive::xml_oarchive goes out of scope
       boost::archive::xml_oarchive oa(os);
       // Boost uses the same function for serialization and deserialization so it requires a non-const reference
@@ -131,7 +138,11 @@ struct Serialization
                                   const std::string& file_path,
                                   const std::string& name = "")
   {
-    std::ofstream os(file_path, std::ios_base::binary);
+    fs::path fp(file_path);
+    if (!fp.has_extension())
+      fp.append(".").append(serialization::binary::extension<SerializableType>::value);
+
+    std::ofstream os(fp.string(), std::ios_base::binary);
     {  // Must be scoped because all data is not written until the oost::archive::xml_oarchive goes out of scope
       boost::archive::binary_oarchive oa(os);
       // Boost uses the same function for serialization and deserialization so it requires a non-const reference
@@ -192,5 +203,4 @@ struct Serialization
   }
 };
 }  // namespace tesseract_common
-
 #endif  // TESSERACT_COMMON_SERIALIZATION_H

--- a/tesseract_common/include/tesseract_common/serialization_extensions.h
+++ b/tesseract_common/include/tesseract_common/serialization_extensions.h
@@ -1,0 +1,103 @@
+/**
+ * @file serialization_extensions.h
+ * @brief Boost serialization class extension macros and helpers
+ *
+ * @author Levi Armstrong
+ * @date July 24, 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COMMON_SERIALIZATION_EXTENSIONS_H
+#define TESSERACT_COMMON_SERIALIZATION_EXTENSIONS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <boost/mpl/string.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/sfinae_utils.h>
+
+CREATE_MEMBER_CHECK(extension_type);
+
+namespace tesseract_common
+{
+namespace serialization::xml
+{
+template <class T>
+struct extension
+{
+  template <class U>
+  struct traits_class_extension
+  {
+    using extension_type = typename U::extenstion;
+  };
+
+  using extension_type = typename boost::mpl::
+      eval_if<has_member_extension_type<T>, traits_class_extension<T>, boost::mpl::string<'t', 'r', 's', 'x'>>::type;
+
+  static constexpr const char* value = boost::mpl::c_str<extension::extension_type>::value;
+};
+}  // namespace serialization::xml
+
+namespace serialization::binary
+{
+template <class T>
+struct extension
+{
+  template <class U>
+  struct traits_class_extension
+  {
+    using extension_type = typename U::extenstion;
+  };
+
+  using extension_type = typename boost::mpl::
+      eval_if<has_member_extension_type<T>, traits_class_extension<T>, boost::mpl::string<'t', 'r', 's', 'b'>>::type;
+
+  static constexpr const char* value = boost::mpl::c_str<extension::extension_type>::value;
+};
+}  // namespace serialization::binary
+}  // namespace tesseract_common
+
+/**
+ * @brief A macro for defining serialization extension for classes
+ * @param T the class to define extensions for
+ * @param X the xml serialziation extension for the provided class
+ * @param B the binary serialzation extension for the provided class
+ */
+#define TESSERACT_CLASS_EXTENSION(T, X, B)                                                                             \
+  namespace tesseract_common                                                                                           \
+  {                                                                                                                    \
+  namespace serialization::xml                                                                                         \
+  {                                                                                                                    \
+  template <>                                                                                                          \
+  struct extension<T>                                                                                                  \
+  {                                                                                                                    \
+    static constexpr const char* value = X;                                                                            \
+  };                                                                                                                   \
+  }                                                                                                                    \
+  namespace serialization::binary                                                                                      \
+  {                                                                                                                    \
+  template <>                                                                                                          \
+  struct extension<T>                                                                                                  \
+  {                                                                                                                    \
+    static constexpr const char* value = B;                                                                            \
+  };                                                                                                                   \
+  }                                                                                                                    \
+  }
+
+#endif  // TESSERACT_COMMON_SERIALIZATION_EXTENSIONS_H

--- a/tesseract_common/test/tesseract_common_serialization_unit.cpp
+++ b/tesseract_common/test/tesseract_common_serialization_unit.cpp
@@ -462,6 +462,36 @@ TEST(TesseractCommonSerializeUnit, StdAtomic)  // NOLINT
   tesseract_common::testSerialization<TestAtomic>(object, "TestAtomic");
 }
 
+struct ExtensionMacroTestA
+{
+  double a{ 0 };
+};
+
+TESSERACT_CLASS_EXTENSION(ExtensionMacroTestA, "etax", "etab")
+
+struct ExtensionMacroTestB
+{
+  double b{ 0 };
+};
+
+TEST(TesseractCommonSerializeUnit, ExtensionXmlMacro)  // NOLINT
+{
+  std::string ext = tesseract_common::serialization::xml::extension<ExtensionMacroTestA>::value;
+  EXPECT_EQ(ext, "etax");
+
+  std::string default_ext = tesseract_common::serialization::xml::extension<ExtensionMacroTestB>::value;
+  EXPECT_EQ(default_ext, "trsx");
+}
+
+TEST(TesseractCommonSerializeUnit, ExtensionBinaryMacro)  // NOLINT
+{
+  std::string ext = tesseract_common::serialization::binary::extension<ExtensionMacroTestA>::value;
+  EXPECT_EQ(ext, "etab");
+
+  std::string default_ext = tesseract_common::serialization::binary::extension<ExtensionMacroTestB>::value;
+  EXPECT_EQ(default_ext, "trsb");
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/tesseract_srdf/src/srdf_model.cpp
+++ b/tesseract_srdf/src/srdf_model.cpp
@@ -450,8 +450,8 @@ void SRDFModel::serialize(Archive& ar, const unsigned int /*version*/)
   ar& BOOST_SERIALIZATION_NVP(calibration_info);
 }
 
+}  // namespace tesseract_srdf
+
 #include <tesseract_common/serialization.h>
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_srdf::SRDFModel)
-// This causes build failures for some reason, but it seems to work without it
-// BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_srdf::SRDFModel)
-}  // namespace tesseract_srdf
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_srdf::SRDFModel)


### PR DESCRIPTION
This PR adds a macro for defining extensions for classes which get used when serializing a class if an extension is no provided. This is to better support GUI importing and exporting. 