### PR TITLE
Boost 1.74 issue fix

### DIFF
--- a/tesseract_common/src/allowed_collision_matrix.cpp
+++ b/tesseract_common/src/allowed_collision_matrix.cpp
@@ -28,6 +28,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/utility.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP

--- a/tesseract_common/src/collision_margin_data.cpp
+++ b/tesseract_common/src/collision_margin_data.cpp
@@ -28,6 +28,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/utility.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP

--- a/tesseract_environment/src/commands/change_joint_acceleration_limits_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_acceleration_limits_command.cpp
@@ -27,6 +27,9 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 #include <string>

--- a/tesseract_environment/src/commands/change_joint_position_limits_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_position_limits_command.cpp
@@ -27,6 +27,9 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 #include <string>

--- a/tesseract_environment/src/commands/change_joint_velocity_limits_command.cpp
+++ b/tesseract_environment/src/commands/change_joint_velocity_limits_command.cpp
@@ -27,6 +27,9 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 #include <string>

--- a/tesseract_environment/src/commands/change_link_collision_enabled_command.cpp
+++ b/tesseract_environment/src/commands/change_link_collision_enabled_command.cpp
@@ -27,6 +27,9 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 #include <string>

--- a/tesseract_environment/src/commands/change_link_origin_command.cpp
+++ b/tesseract_environment/src/commands/change_link_origin_command.cpp
@@ -27,6 +27,9 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <memory>
 #include <string>

--- a/tesseract_scene_graph/src/graph.cpp
+++ b/tesseract_scene_graph/src/graph.cpp
@@ -38,6 +38,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/split_member.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/utility.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP


### PR DESCRIPTION
Including <boost/serialization/library_version_type.hpp> for Boost 1.74. Fixes tesseract-robotics/tesseract#764