### PR TITLE
Deploy documentation to separate repository

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -25,3 +25,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
           keep_files: true
+          external_repository: tesseract-robotics/tesseract_docs

--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -24,5 +24,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
+          destination_dir: tesseract
           keep_files: true
           external_repository: tesseract-robotics/tesseract_docs

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -69,5 +69,5 @@ jobs:
 
       # PERSONAL_GITHUB_TOKEN needed here since we are pushing to a branch
       - name: Push benchmark result
-        run: git push 'https://tesseract-robotics:${{ secrets.PERSONAL_GITHUB_TOKEN }}@github.com/tesseract-robotics/tesseract.git' gh-pages:gh-pages
+        run: git push 'https://tesseract-robotics:${{ secrets.PERSONAL_GITHUB_TOKEN }}@github.com/tesseract-robotics/tesseract_docs.git' gh-pages:gh-pages
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Use the [option to deploy documentation to a separate repository](https://github.com/peaceiris/actions-gh-pages/tree/e5d60a65a4bd200dd1f942fa8e0f677ba7167370#%EF%B8%8F-deploy-to-external-repository-external_repository) in order to remove the large `gh-pages` branch from this repo to improve download time. Addresses #840 and #842 