### PR TITLE
Add flattenWrapperResults methods

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -167,6 +167,11 @@ std::size_t flattenMoveResults(ContactResultMap&& m, ContactResultVector& v);
 
 std::size_t flattenCopyResults(const ContactResultMap& m, ContactResultVector& v);
 
+std::size_t flattenWrapperResults(ContactResultMap& m, std::vector<std::reference_wrapper<ContactResult>>& v);
+
+std::size_t flattenWrapperResults(const ContactResultMap& m,
+                                  std::vector<std::reference_wrapper<const ContactResult>>& v);
+
 /**
  * @brief This data is intended only to be used internal to the collision checkers as a container and should not
  *        be externally used by other libraries or packages.

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -62,7 +62,10 @@ std::size_t flattenMoveResults(ContactResultMap&& m, ContactResultVector& v)
   v.clear();
   v.reserve(m.size());
   for (const auto& mv : m)
+  {
+    v.reserve(v.size() + mv.second.size());
     std::move(mv.second.begin(), mv.second.end(), std::back_inserter(v));
+  }
 
   return v.size();
 }
@@ -72,7 +75,37 @@ std::size_t flattenCopyResults(const ContactResultMap& m, ContactResultVector& v
   v.clear();
   v.reserve(m.size());
   for (const auto& mv : m)
+  {
+    v.reserve(v.size() + mv.second.size());
     std::copy(mv.second.begin(), mv.second.end(), std::back_inserter(v));
+  }
+
+  return v.size();
+}
+
+std::size_t flattenWrapperResults(ContactResultMap& m, std::vector<std::reference_wrapper<ContactResult>>& v)
+{
+  v.clear();
+  v.reserve(m.size());
+  for (auto& mv : m)
+  {
+    v.reserve(v.size() + mv.second.size());
+    v.insert(v.end(), mv.second.begin(), mv.second.end());
+  }
+
+  return v.size();
+}
+
+std::size_t flattenWrapperResults(const ContactResultMap& m,
+                                  std::vector<std::reference_wrapper<const ContactResult>>& v)
+{
+  v.clear();
+  v.reserve(m.size());
+  for (const auto& mv : m)
+  {
+    v.reserve(v.size() + mv.second.size());
+    v.insert(v.end(), mv.second.begin(), mv.second.end());
+  }
 
   return v.size();
 }


### PR DESCRIPTION
These methods are used by TrajOpt to reduce memory consumption. 