### PR TITLE
Add ContactResultMap class to reduce heap allocations for multiple contact requests

### DIFF
--- a/tesseract_collision/bullet/src/bullet_utils.cpp
+++ b/tesseract_collision/bullet/src/bullet_utils.cpp
@@ -688,10 +688,10 @@ btScalar addDiscreteSingleResult(btManifoldPoint& cp,
   const auto* cd0 = static_cast<const CollisionObjectWrapper*>(colObj0Wrap->getCollisionObject());  // NOLINT
   const auto* cd1 = static_cast<const CollisionObjectWrapper*>(colObj1Wrap->getCollisionObject());  // NOLINT
 
-  ObjectPairKey pc = getObjectPairKey(cd0->getName(), cd1->getName());
+  ObjectPairKey pc = tesseract_common::makeOrderedLinkPair(cd0->getName(), cd1->getName());
 
-  const auto& it = collisions.res->find(pc);
-  bool found = (it != collisions.res->end());
+  const auto it = collisions.res->find(pc);
+  bool found = (it != collisions.res->end() && !it->second.empty());
 
   //    size_t l = 0;
   //    if (found)
@@ -823,8 +823,8 @@ btScalar addCastSingleResult(btManifoldPoint& cp,
                                                       std::make_pair(cd0->getName(), cd1->getName()) :
                                                       std::make_pair(cd1->getName(), cd0->getName());
 
-  auto it = collisions.res->find(pc);
-  bool found = it != collisions.res->end();
+  const auto it = collisions.res->find(pc);
+  bool found = (it != collisions.res->end() && !it->second.empty());
 
   //    size_t l = 0;
   //    if (found)

--- a/tesseract_collision/core/include/tesseract_collision/core/common.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/common.h
@@ -40,14 +40,6 @@ namespace tesseract_collision
 using ObjectPairKey = std::pair<std::string, std::string>;
 
 /**
- * @brief Get a key for two object to search the collision matrix
- * @param obj1 First collision object name
- * @param obj2 Second collision object name
- * @return The collision pair key
- */
-ObjectPairKey getObjectPairKey(const std::string& obj1, const std::string& obj2);
-
-/**
  * @brief Get a vector of possible collision object pairs
  * @todo Should this also filter out links without geometry?
  * @param active_links The active link names

--- a/tesseract_collision/core/include/tesseract_collision/core/serialization.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/serialization.h
@@ -56,6 +56,14 @@ void load(Archive& ar, tesseract_collision::ContactResult& g, const unsigned int
 template <class Archive>
 void serialize(Archive& ar, tesseract_collision::ContactResult& g, const unsigned int version);  // NOLINT
 
+template <class Archive>
+void save(Archive& ar, const tesseract_collision::ContactResultMap& g, const unsigned int version);  // NOLINT
+
+template <class Archive>
+void load(Archive& ar, tesseract_collision::ContactResultMap& g, const unsigned int version);  // NOLINT
+
+template <class Archive>
+void serialize(Archive& ar, tesseract_collision::ContactResultMap& g, const unsigned int version);  // NOLINT
 }  // namespace boost::serialization
 
 #endif  // TESSERACT_COLLISION_SERIALIZATION_H

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -132,6 +132,24 @@ struct ContactResult
 };
 
 using ContactResultVector = tesseract_common::AlignedVector<ContactResult>;
+
+/**
+ * @brief This structure hold contact results for link pairs
+ * @details A custom class was implemented to avoid a large number of heap allocations during motion which avoids full
+ * clearing the map. This class provides methods const container methods for access the internal unordered_map and has
+ * two distinct different when it comes to the clear, size and release methods.
+ *
+ * The clear method does not call clear on the unordered_map but instead it loops over all entries and calls clear on
+ * the vector being stored. This allows the memory to remain with the map and not get release for each of the vectors
+ * stored in the map.
+ *
+ * The size method loops over the map and counts those that have vectors which are not empty.
+ *
+ * The release method actually calls clear on the internal unordered_map relasing all memory.
+ *
+ * @todo This should be updated to leverage a object pool for `ContactResultVector` where in the set and add methods
+ * it would check it the pair exists and if not it would pull from the object pool.
+ */
 class ContactResultMap
 {
 public:
@@ -160,15 +178,15 @@ public:
 
   /**
    * @brief Set contact results for the provided key
-   * @param key The key to append the results to
-   * @param result The results to add
+   * @param key The key to assign the provided results to
+   * @param result The results to assign
    */
   ContactResult& setContactResult(const KeyType& key, ContactResult result);
 
   /**
    * @brief Set contact results for the provided key
-   * @param key The key to append the results to
-   * @param result The results to add
+   * @param key The key to assign the provided results to
+   * @param result The results to assign
    */
   ContactResult& setContactResult(const KeyType& key, const MappedType& results);
 
@@ -261,7 +279,7 @@ public:
 
 private:
   ContainerType data_;
-  long cnt_{ 0 };
+  long count_{ 0 };
 };
 
 /**

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/benchmarks/large_dataset_benchmarks.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/benchmarks/large_dataset_benchmarks.hpp
@@ -87,14 +87,15 @@ static void BM_LARGE_DATASET_MULTILINK(benchmark::State& state,
   checker->setCollisionMarginData(CollisionMarginData(0.1));
   checker->setCollisionObjectsTransform(location);
 
+  ContactResultMap result;
   ContactResultVector result_vector;
 
   for (auto _ : state)  // NOLINT
   {
-    ContactResultMap result;
+    result.clear();
     result_vector.clear();
     checker->contactTest(result, ContactTestType::ALL);
-    flattenMoveResults(std::move(result), result_vector);
+    result.flattenMoveResults(result_vector);
   }
 }
 
@@ -181,14 +182,15 @@ static void BM_LARGE_DATASET_SINGLELINK(benchmark::State& state,
   checker->setCollisionMarginData(CollisionMarginData(0.1));
   //  checker->setCollisionObjectsTransform(location);
 
+  ContactResultMap result;
   ContactResultVector result_vector;
 
   for (auto _ : state)  // NOLINT
   {
-    ContactResultMap result;
+    result.clear();
     result_vector.clear();
     checker->contactTest(result, ContactTestType::ALL);
-    flattenMoveResults(std::move(result), result_vector);
+    result.flattenMoveResults(result_vector);
   }
 }
 

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
@@ -160,7 +160,7 @@ inline void runTest(ContinuousContactManager& checker)
     checker.contactTest(result, ContactRequest(t));
 
     ContactResultVector result_vector;
-    flattenMoveResults(std::move(result), result_vector);
+    result.flattenMoveResults(result_vector);
 
     EXPECT_TRUE(!result_vector.empty());
     EXPECT_NEAR(result_vector[0].distance, -0.2475, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -151,7 +151,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -1.30, 0.001);
@@ -183,7 +183,6 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   ////////////////////////////////////////////////
   {
     location["box_link"].translation() = Eigen::Vector3d(1.60, 0, 0);
-    result = ContactResultMap();
     result.clear();
     result_vector.clear();
 
@@ -192,7 +191,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
     tesseract_common::VectorIsometry3d transforms = { location["box_link"] };
     checker.setCollisionObjectsTransform(names, transforms);
     checker.contactTest(result, test_type);
-    flattenCopyResults(result, result_vector);
+    result.flattenCopyResults(result_vector);
 
     EXPECT_TRUE(result_vector.empty());
   }
@@ -207,7 +206,6 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
     EXPECT_EQ(checker.getCollisionMarginData().getMaxCollisionMargin(), 1.7);
     EXPECT_NEAR(checker.getCollisionMarginData().getPairCollisionMargin("box_link", "second_box_link"), 0.1, 1e-5);
     location["box_link"].translation() = Eigen::Vector3d(1.60, 0, 0);
-    result = ContactResultMap();
     result.clear();
     result_vector.clear();
 
@@ -216,7 +214,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
     tesseract_common::VectorIsometry3d transforms = { location["box_link"] };
     checker.setCollisionObjectsTransform(names, transforms);
     checker.contactTest(result, test_type);
-    flattenMoveResults(std::move(result), result_vector);
+    result.flattenMoveResults(result_vector);
 
     EXPECT_TRUE(result_vector.empty());
   }
@@ -224,7 +222,6 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   // Test object inside the contact distance only for this link pair
   /////////////////////////////////////////////
   {
-    result = ContactResultMap();
     result.clear();
     result_vector.clear();
 
@@ -235,7 +232,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
     EXPECT_NEAR(checker.getCollisionMarginData().getPairCollisionMargin("box_link", "second_box_link"), 0.25, 1e-5);
     EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.25, 1e-5);
     checker.contactTest(result, ContactRequest(test_type));
-    flattenCopyResults(result, result_vector);
+    result.flattenCopyResults(result_vector);
 
     EXPECT_TRUE(!result_vector.empty());
     EXPECT_NEAR(result_vector[0].distance, 0.1, 0.001);
@@ -266,14 +263,13 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   // Test object inside the contact distance
   /////////////////////////////////////////////
   {
-    result = ContactResultMap();
     result.clear();
     result_vector.clear();
 
     checker.setCollisionMarginData(CollisionMarginData(0.25));
     EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.25, 1e-5);
     checker.contactTest(result, ContactRequest(test_type));
-    flattenMoveResults(std::move(result), result_vector);
+    result.flattenMoveResults(result_vector);
 
     EXPECT_TRUE(!result_vector.empty());
     EXPECT_NEAR(result_vector[0].distance, 0.1, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
@@ -132,7 +132,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.55, 0.0001);
@@ -163,27 +163,25 @@ inline void runTest(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["capsule_link"].translation() = Eigen::Vector3d(0, 0, 1);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.251));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.251, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.125, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
@@ -137,7 +137,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.55, 0.0001);
@@ -174,28 +174,26 @@ inline void runTest(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["cone_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   // Use different method for setting transforms
   checker.setCollisionObjectsTransform("cone_link", location["cone_link"]);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.251));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.251, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.25, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_cylinder_unit.hpp
@@ -133,7 +133,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.55, 0.0001);
@@ -164,7 +164,6 @@ inline void runTest(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["cylinder_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
@@ -173,21 +172,20 @@ inline void runTest(DiscreteContactManager& checker)
   tesseract_common::VectorIsometry3d transforms = { location["cylinder_link"] };
   checker.setCollisionObjectsTransform(names, transforms);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.251));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.251, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.25, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
@@ -147,7 +147,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.55, 0.001);
@@ -182,28 +182,26 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["sphere_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   // Use different method for setting transforms
   checker.setCollisionObjectsTransform("sphere_link", location["sphere_link"]);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.251));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.251, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.25, 0.001);
@@ -262,7 +260,7 @@ inline void runTestConvex(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.53776, 0.001);
@@ -292,27 +290,25 @@ inline void runTestConvex(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["sphere_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.27));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.27, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.26224, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_clone_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_clone_unit.hpp
@@ -147,7 +147,7 @@ runTest(DiscreteContactManager& checker, double dist_tol = 0.001, double nearest
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   std::vector<int> idx = { 0, 1, 1 };
   if (result_vector[0].link_names[0] != "sphere_link")
@@ -160,7 +160,7 @@ runTest(DiscreteContactManager& checker, double dist_tol = 0.001, double nearest
   cloned_checker->contactTest(cloned_result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector cloned_result_vector;
-  flattenMoveResults(std::move(cloned_result), cloned_result_vector);
+  cloned_result.flattenMoveResults(cloned_result_vector);
 
   std::vector<int> cloned_idx = { 0, 1, 1 };
   if (cloned_result_vector[0].link_names[0] != "sphere_link")

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
@@ -95,7 +95,7 @@ inline void runTestCompound(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   for (const auto& cr : result_vector)
@@ -140,7 +140,7 @@ inline void runTestCompound(ContinuousContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   for (const auto& cr : result_vector)

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_large_dataset_unit.hpp
@@ -75,16 +75,17 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
   checker.setCollisionObjectsTransform(location);
 
+  ContactResultMap result;
   ContactResultVector result_vector;
 
   auto start_time = std::chrono::high_resolution_clock::now();
   num_interations = 1;
   for (auto i = 0; i < num_interations; ++i)
   {
-    ContactResultMap result;
+    result.clear();
     result_vector.clear();
     checker.contactTest(result, ContactRequest(ContactTestType::ALL));
-    flattenMoveResults(std::move(result), result_vector);
+    result.flattenMoveResults(result_vector);
 
     if (result_vector.size() != 300)
       for (const auto& result : result_vector)

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
@@ -146,7 +146,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(result_vector.size() >= 37);
 
@@ -154,27 +154,25 @@ inline void runTest(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ///////////////////////////////////////////////
   location["sphere1_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
   checker.contactTest(result, ContactRequest(ContactTestType::ALL));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////////////////////////////////
   // Test object inside the contact distance (Closest Feature Edge to Edge)
   /////////////////////////////////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.55));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.55, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.52448, 0.001);
@@ -194,7 +192,6 @@ inline void runTest(DiscreteContactManager& checker)
   // Test object inside the contact distance (Closest Feature Vertex to Vertex)
   /////////////////////////////////////////////////////////////////////////////
   location["sphere1_link"].translation() = Eigen::Vector3d(0, 1, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
@@ -204,7 +201,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.setCollisionMarginData(CollisionMarginData(0.55));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.55, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.5, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_multi_threaded_unit.hpp
@@ -124,7 +124,7 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
 
     ContactResultMap result;
     manager->contactTest(result, ContactRequest(ContactTestType::ALL));
-    flattenMoveResults(std::move(result), result_vector[static_cast<size_t>(tn)]);
+    result.flattenMoveResults(result_vector[static_cast<size_t>(tn)]);
   }
   auto end_time = std::chrono::high_resolution_clock::now();
 

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
@@ -98,7 +98,7 @@ inline void runTest(DiscreteContactManager& checker, const std::string& file_pat
   checker.contactTest(result, ContactRequest(ContactTestType::ALL));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   const tesseract_collision::CollisionShapesConst& geom = checker.getCollisionObjectGeometries("plane_link");
   const auto& mesh = std::static_pointer_cast<const tesseract_geometry::Mesh>(geom.at(0));

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_octomap_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_octomap_unit.hpp
@@ -96,7 +96,7 @@ inline void runTestOctomap(DiscreteContactManager& checker, ContactTestType test
   checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   for (const auto& cr : result_vector)
@@ -138,7 +138,7 @@ inline void runTestOctomap(ContinuousContactManager& checker, ContactTestType te
   checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   for (const auto& cr : result_vector)

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
@@ -106,7 +106,7 @@ inline void runTestTyped(DiscreteContactManager& checker, double tol, ContactTes
   checker.contactTest(result, ContactRequest(test_type));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   if (test_type == ContactTestType::CLOSEST)

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_cast_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_cast_unit.hpp
@@ -174,7 +174,7 @@ inline void runTestPrimitive(ContinuousContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.1, 0.0001);
@@ -241,11 +241,11 @@ inline void runTestPrimitive(ContinuousContactManager& checker)
   checker.setCollisionObjectsTransform(location_start, location_end);
 
   // Perform collision check
-  result = ContactResultMap();
+  result.clear();
+  result_vector.clear();
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
-  result_vector = ContactResultVector();
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.1, 0.0001);
@@ -330,7 +330,7 @@ inline void runTestConvex(ContinuousContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.0754, 0.001);
@@ -397,11 +397,11 @@ inline void runTestConvex(ContinuousContactManager& checker)
   checker.setCollisionObjectsTransform(location_start, location_end);
 
   // Perform collision check
-  result = ContactResultMap();
+  result.clear();
+  result_vector.clear();
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
-  result_vector = ContactResultVector();
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.0754, 0.001);

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/collision_sphere_sphere_unit.hpp
@@ -149,7 +149,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.30, 0.0001);
@@ -187,27 +187,25 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["sphere1_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
   checker.setCollisionObjectsTransform("sphere1_link", location["sphere1_link"]);
 
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   checker.setCollisionMarginData(CollisionMarginData(0.52));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.52, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.5, 0.0001);
@@ -268,7 +266,7 @@ inline void runTestConvex1(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   // Bullet: -0.270548 {0.232874,0,-0.025368} {-0.032874,0,0.025368}
   // FCL:    -0.270548 {0.232874,0,-0.025368} {-0.032874,0,0.025368}
@@ -306,13 +304,12 @@ inline void runTestConvex1(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ///////////////////////////////////////////////
   location["sphere1_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
   checker.setCollisionObjectsTransform(location);
 
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 }
@@ -341,7 +338,7 @@ inline void runTestConvex2(DiscreteContactManager& checker)
   checker.setCollisionMarginData(CollisionMarginData(0.55));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.55, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   // Bullet: 0.524565 {0.237717,0,0} {0.7622825,0,0} Using blender this appears to be the correct result
   // FCL:    0.546834 {0.237717,-0.0772317,0} {0.7622825,0.0772317}
@@ -394,7 +391,7 @@ inline void runTestConvex3(DiscreteContactManager& checker)
   ContactResultMap result;
   ContactResultVector result_vector;
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   // Bullet: -0.280223 {0.0425563,0.2308753,-0.0263040} {-0.0425563, -0.0308753, 0.0263040}
   // FCL:    -0.280223 {0.0425563,0.2308753,-0.0263040} {-0.0425563, -0.0308753, 0.0263040}

--- a/tesseract_collision/core/include/tesseract_collision/test_suite/contact_manager_config_unit.hpp
+++ b/tesseract_collision/core/include/tesseract_collision/test_suite/contact_manager_config_unit.hpp
@@ -157,7 +157,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.30, 0.0001);
@@ -182,20 +182,18 @@ inline void runTest(DiscreteContactManager& checker)
   // Test object is out side the contact distance
   ////////////////////////////////////////////////
   location["sphere1_link"].translation() = Eigen::Vector3d(1, 0, 0);
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
   checker.setCollisionObjectsTransform("sphere1_link", location["sphere1_link"]);
 
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(result_vector.empty());
 
   /////////////////////////////////////////////
   // Test object inside the contact distance
   /////////////////////////////////////////////
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
@@ -203,7 +201,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.52, 1e-5);
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, 0.5, 0.0001);
@@ -282,7 +280,7 @@ inline void runTest(ContinuousContactManager& checker)
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
   ContactResultVector result_vector;
-  flattenCopyResults(result, result_vector);
+  result.flattenCopyResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.1, 0.0001);
@@ -349,11 +347,11 @@ inline void runTest(ContinuousContactManager& checker)
   checker.setCollisionObjectsTransform(location_start, location_end);
 
   // Perform collision check
-  result = ContactResultMap();
+  result.clear();
+  result_vector.clear();
   checker.contactTest(result, ContactRequest(ContactTestType::CLOSEST));
 
-  result_vector = ContactResultVector();
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   EXPECT_TRUE(!result_vector.empty());
   EXPECT_NEAR(result_vector[0].distance, -0.1, 0.0001);

--- a/tesseract_collision/core/src/serialization.cpp
+++ b/tesseract_collision/core/src/serialization.cpp
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/vector.hpp>
+#include <boost/serialization/map.hpp>
 #include <tesseract_common/eigen_serialization.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -86,7 +87,32 @@ void serialize(Archive& ar, tesseract_collision::ContactResult& g, const unsigne
   split_free(ar, g, version);
 }
 
+/***************************************************/
+/****** tesseract_collision::ContactResultMap ******/
+/***************************************************/
+template <class Archive>
+void save(Archive& ar, const tesseract_collision::ContactResultMap& g, const unsigned int /*version*/)
+{
+  ar& boost::serialization::make_nvp("container", g.getContainer());
+}
+
+template <class Archive>
+void load(Archive& ar, tesseract_collision::ContactResultMap& g, const unsigned int /*version*/)
+{
+  tesseract_collision::ContactResultMap container;
+  ar& boost::serialization::make_nvp("container", container);
+
+  for (const auto& c : container)
+    g.addContactResult(c.first, c.second);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tesseract_collision::ContactResultMap& g, const unsigned int version)
+{
+  split_free(ar, g, version);
+}
 }  // namespace boost::serialization
 
 #include <tesseract_common/serialization.h>
 TESSERACT_SERIALIZE_SAVE_LOAD_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactResult)
+TESSERACT_SERIALIZE_SAVE_LOAD_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactResultMap)

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -61,9 +61,6 @@ ContactResult& ContactResultMap::addContactResult(const KeyType& key, ContactRes
 {
   ++cnt_;
   auto& cv = data_[key];
-  if (cv.capacity() == 0)
-    cv.reserve(100);
-
   return cv.emplace_back(std::move(result));
 }
 
@@ -72,7 +69,8 @@ ContactResult& ContactResultMap::addContactResult(const KeyType& key, const Mapp
   assert(!results.empty());
   cnt_ += static_cast<long>(results.size());
   auto& cv = data_[key];
-  cv.reserve(std::max(static_cast<std::size_t>(100), cv.size() + results.size()));
+  ;
+  cv.reserve(cv.size() + results.size());
   cv.insert(cv.end(), results.begin(), results.end());
   return cv.back();
 }
@@ -83,8 +81,6 @@ ContactResult& ContactResultMap::setContactResult(const KeyType& key, ContactRes
   cnt_ += (1 - static_cast<long>(cv.size()));
   assert(cnt_ >= 0);
   cv.clear();
-  if (cv.capacity() == 0)
-    cv.reserve(100);
 
   return cv.emplace_back(std::move(result));
 }
@@ -96,7 +92,7 @@ ContactResult& ContactResultMap::setContactResult(const KeyType& key, const Mapp
   cnt_ += (static_cast<long>(results.size()) - static_cast<long>(cv.size()));
   assert(cnt_ >= 0);
   cv.clear();
-  cv.reserve(std::max(static_cast<std::size_t>(100), cv.size() + results.size()));
+  cv.reserve(cv.size() + results.size());
   cv.insert(cv.end(), results.begin(), results.end());
   return cv.back();
 }
@@ -109,7 +105,6 @@ void ContactResultMap::addInterpolatedCollisionResults(ContactResultMap& sub_seg
                                                        bool discrete,
                                                        const tesseract_collision::ContactResultMap::FilterFn& filter)
 {
-  //  double segment_dt = (sub_segment_last_index > 0) ? 1.0 / static_cast<double>(sub_segment_last_index) : 0.0;
   for (auto& pair : sub_segment_results.data_)
   {
     // Update cc_time and cc_type

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -59,7 +59,7 @@ ContactRequest::ContactRequest(ContactTestType type) : type(type) {}
 
 ContactResult& ContactResultMap::addContactResult(const KeyType& key, ContactResult result)
 {
-  ++cnt_;
+  ++count_;
   auto& cv = data_[key];
   return cv.emplace_back(std::move(result));
 }
@@ -67,9 +67,8 @@ ContactResult& ContactResultMap::addContactResult(const KeyType& key, ContactRes
 ContactResult& ContactResultMap::addContactResult(const KeyType& key, const MappedType& results)
 {
   assert(!results.empty());
-  cnt_ += static_cast<long>(results.size());
+  count_ += static_cast<long>(results.size());
   auto& cv = data_[key];
-  ;
   cv.reserve(cv.size() + results.size());
   cv.insert(cv.end(), results.begin(), results.end());
   return cv.back();
@@ -78,8 +77,8 @@ ContactResult& ContactResultMap::addContactResult(const KeyType& key, const Mapp
 ContactResult& ContactResultMap::setContactResult(const KeyType& key, ContactResult result)
 {
   auto& cv = data_[key];
-  cnt_ += (1 - static_cast<long>(cv.size()));
-  assert(cnt_ >= 0);
+  count_ += (1 - static_cast<long>(cv.size()));
+  assert(count_ >= 0);
   cv.clear();
 
   return cv.emplace_back(std::move(result));
@@ -89,10 +88,10 @@ ContactResult& ContactResultMap::setContactResult(const KeyType& key, const Mapp
 {
   assert(!results.empty());
   auto& cv = data_[key];
-  cnt_ += (static_cast<long>(results.size()) - static_cast<long>(cv.size()));
-  assert(cnt_ >= 0);
+  count_ += (static_cast<long>(results.size()) - static_cast<long>(cv.size()));
+  assert(count_ >= 0);
   cv.clear();
-  cv.reserve(cv.size() + results.size());
+  cv.reserve(results.size());
   cv.insert(cv.end(), results.begin(), results.end());
   return cv.back();
 }
@@ -142,7 +141,7 @@ void ContactResultMap::addInterpolatedCollisionResults(ContactResultMap& sub_seg
     if (!pair.second.empty())
     {
       // Add results to the full segment results
-      cnt_ += static_cast<long>(pair.second.size());
+      count_ += static_cast<long>(pair.second.size());
       auto it = data_.find(pair.first);
       if (it == data_.end())
       {
@@ -162,11 +161,11 @@ void ContactResultMap::addInterpolatedCollisionResults(ContactResultMap& sub_seg
   }
 }
 
-long ContactResultMap::count() const { return cnt_; }
+long ContactResultMap::count() const { return count_; }
 
 std::size_t ContactResultMap::size() const
 {
-  if (cnt_ == 0)
+  if (count_ == 0)
     return 0;
 
   std::size_t cnt{ 0 };
@@ -179,24 +178,24 @@ std::size_t ContactResultMap::size() const
   return cnt;
 }
 
-bool ContactResultMap::empty() const { return (cnt_ == 0); }
+bool ContactResultMap::empty() const { return (count_ == 0); }
 
 void ContactResultMap::clear()
 {
-  if (cnt_ == 0)
+  if (count_ == 0)
     return;
 
   // Only clear the vectors so the capacity stays the same
   for (auto& cv : data_)
     cv.second.clear();
 
-  cnt_ = 0;
+  count_ = 0;
 }
 
 void ContactResultMap::release()
 {
   data_.clear();
-  cnt_ = 0;
+  count_ = 0;
 }
 
 const ContactResultMap::ContainerType& ContactResultMap::getContainer() const { return data_; }
@@ -216,19 +215,19 @@ ContactResultMap::ConstIteratorType ContactResultMap::find(const KeyType& key) c
 void ContactResultMap::flattenMoveResults(ContactResultVector& v)
 {
   v.clear();
-  v.reserve(static_cast<std::size_t>(cnt_));
+  v.reserve(static_cast<std::size_t>(count_));
   for (auto& mv : data_)
   {
     std::move(mv.second.begin(), mv.second.end(), std::back_inserter(v));
     mv.second.clear();
   }
-  cnt_ = 0;
+  count_ = 0;
 }
 
 void ContactResultMap::flattenCopyResults(ContactResultVector& v) const
 {
   v.clear();
-  v.reserve(static_cast<std::size_t>(cnt_));
+  v.reserve(static_cast<std::size_t>(count_));
   for (const auto& mv : data_)
     std::copy(mv.second.begin(), mv.second.end(), std::back_inserter(v));
 }
@@ -236,7 +235,7 @@ void ContactResultMap::flattenCopyResults(ContactResultVector& v) const
 void ContactResultMap::flattenWrapperResults(std::vector<std::reference_wrapper<ContactResult>>& v)
 {
   v.clear();
-  v.reserve(static_cast<std::size_t>(cnt_));
+  v.reserve(static_cast<std::size_t>(count_));
   for (auto& mv : data_)
     v.insert(v.end(), mv.second.begin(), mv.second.end());
 }
@@ -244,7 +243,7 @@ void ContactResultMap::flattenWrapperResults(std::vector<std::reference_wrapper<
 void ContactResultMap::flattenWrapperResults(std::vector<std::reference_wrapper<const ContactResult>>& v) const
 {
   v.clear();
-  v.reserve(static_cast<std::size_t>(cnt_));
+  v.reserve(static_cast<std::size_t>(count_));
   for (const auto& mv : data_)
     v.insert(v.end(), mv.second.begin(), mv.second.end());
 }
@@ -258,8 +257,8 @@ void ContactResultMap::filter(const FilterFn& filter)
     filter(pair);
     removed_cnt += (current_cnt - pair.second.size());
   }
-  cnt_ -= static_cast<long>(removed_cnt);
-  assert(cnt_ >= 0);
+  count_ -= static_cast<long>(removed_cnt);
+  assert(count_ >= 0);
 }
 
 ContactTestData::ContactTestData(const std::vector<std::string>& active,

--- a/tesseract_collision/examples/box_box_example.cpp
+++ b/tesseract_collision/examples/box_box_example.cpp
@@ -105,7 +105,7 @@ int main(int /*argc*/, char** /*argv*/)
   checker.contactTest(result, request);
 
   ContactResultVector result_vector;
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());
   CONSOLE_BRIDGE_logInform("Distance: %f", result_vector[0].distance);
@@ -128,13 +128,12 @@ int main(int /*argc*/, char** /*argv*/)
   // documentation:end:10: Set collision object transform
 
   // documentation:start:11: Perform collision check
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   // Check for collision after moving object
   checker.contactTest(result, request);
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
   CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());
   // documentation:end:11: Perform collision check
 
@@ -145,13 +144,12 @@ int main(int /*argc*/, char** /*argv*/)
 
   // documentation:start:13: Perform collision check
   CONSOLE_BRIDGE_logInform("Test object inside the contact distance");
-  result = ContactResultMap();
   result.clear();
   result_vector.clear();
 
   // Check for contact with new threshold
   checker.contactTest(result, request);
-  flattenMoveResults(std::move(result), result_vector);
+  result.flattenMoveResults(result_vector);
 
   CONSOLE_BRIDGE_logInform("Has collision: %s", toString(result_vector.empty()).c_str());
   CONSOLE_BRIDGE_logInform("Distance: %f", result_vector[0].distance);

--- a/tesseract_collision/fcl/src/fcl_utils.cpp
+++ b/tesseract_collision/fcl/src/fcl_utils.cpp
@@ -257,9 +257,9 @@ bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, voi
       contact.distance = -1.0 * fcl_contact.penetration_depth;
       contact.normal = fcl_contact.normal;
 
-      ObjectPairKey pc = getObjectPairKey(cd1->getName(), cd2->getName());
-      const auto& it = cdata->res->find(pc);
-      bool found = (it != cdata->res->end());
+      ObjectPairKey pc = tesseract_common::makeOrderedLinkPair(cd1->getName(), cd2->getName());
+      const auto it = cdata->res->find(pc);
+      bool found = (it != cdata->res->end() && !it->second.empty());
 
       processResult(*cdata, contact, pc, found);
     }
@@ -322,9 +322,9 @@ bool distanceCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void
     // TODO: There is an issue with FCL need to track down
     assert(!std::isnan(contact.nearest_points[0](0)));
 
-    ObjectPairKey pc = getObjectPairKey(cd1->getName(), cd2->getName());
-    const auto& it = cdata->res->find(pc);
-    bool found = (it != cdata->res->end());
+    ObjectPairKey pc = tesseract_common::makeOrderedLinkPair(cd1->getName(), cd2->getName());
+    const auto it = cdata->res->find(pc);
+    bool found = (it != cdata->res->end() && !it->second.empty());
 
     processResult(*cdata, contact, pc, found);
   }

--- a/tesseract_collision/test/benchmarks/collision_profile.cpp
+++ b/tesseract_collision/test/benchmarks/collision_profile.cpp
@@ -176,10 +176,11 @@ void runDiscreteProfile(bool use_single_link, bool use_convex_mesh, double conta
   std::vector<Eigen::Isometry3d> poses = getTransforms(50);
   std::vector<DiscreteContactManager::Ptr> checkers = { bt_simple_checker, bt_bvh_checker, fcl_bvh_checker };
   std::vector<std::string> checker_names = { "BtSimple", "BtBVH", "FCLBVH" };
-  std::vector<std::size_t> checker_contacts = { 0, 0, 0 };
+  std::vector<long> checker_contacts = { 0, 0, 0 };
 
   std::printf("Total number of shape: %d\n", int(DIM * DIM * DIM));
   //  for (std::size_t i = 0; i < checkers.size(); ++i)
+  ContactResultMap result;
   for (std::size_t i = 0; i < 2; ++i)
   {
     addCollisionObjects(*checkers[i], use_single_link, use_convex_mesh);
@@ -191,9 +192,9 @@ void runDiscreteProfile(bool use_single_link, bool use_convex_mesh, double conta
       checkers[i]->setCollisionObjectsTransform("move_link", pose);
 
       // Perform collision check
-      ContactResultMap result;
+      result.clear();
       checkers[i]->contactTest(result, ContactTestType::FIRST);
-      checker_contacts[i] += result.size();
+      checker_contacts[i] += result.count();
     }
     auto end_time = std::chrono::high_resolution_clock::now();
     double total_time = std::chrono::duration<double, std::milli>(end_time - start_time).count();
@@ -211,7 +212,7 @@ void runContinuousProfile(bool use_single_link, bool use_convex_mesh, double con
   std::vector<Eigen::Isometry3d> poses = getTransforms(50);
   std::vector<ContinuousContactManager::Ptr> checkers = { bt_simple_checker, bt_bvh_checker };
   std::vector<std::string> checker_names = { "BtCastSimple", "BtCastBVH" };
-  std::vector<std::size_t> checker_contacts = { 0, 0, 0 };
+  std::vector<long> checker_contacts = { 0, 0, 0 };
 
   Eigen::Isometry3d delta_pose;
   delta_pose.setIdentity();
@@ -219,6 +220,7 @@ void runContinuousProfile(bool use_single_link, bool use_convex_mesh, double con
 
   std::printf("Total number of shape: %d\n", int(DIM * DIM * DIM));
   //  for (std::size_t i = 0; i < checkers.size(); ++i)
+  ContactResultMap result;
   for (std::size_t i = 0; i < 2; ++i)
   {
     addCollisionObjects(*checkers[i], use_single_link, use_convex_mesh);
@@ -230,9 +232,9 @@ void runContinuousProfile(bool use_single_link, bool use_convex_mesh, double con
       checkers[i]->setCollisionObjectsTransform("move_link", pose, pose * delta_pose);
 
       // Perform collision check
-      ContactResultMap result;
+      result.clear();
       checkers[i]->contactTest(result, ContactTestType::FIRST);
-      checker_contacts[i] += result.size();
+      checker_contacts[i] += result.count();
     }
     auto end_time = std::chrono::high_resolution_clock::now();
     double total_time = std::chrono::duration<double, std::milli>(end_time - start_time).count();

--- a/tesseract_common/include/tesseract_common/allowed_collision_matrix.h
+++ b/tesseract_common/include/tesseract_common/allowed_collision_matrix.h
@@ -96,7 +96,8 @@ public:
    */
   virtual bool isCollisionAllowed(const std::string& link_name1, const std::string& link_name2) const
   {
-    auto link_pair = tesseract_common::makeOrderedLinkPair(link_name1, link_name2);
+    thread_local LinkNamesPair link_pair;
+    tesseract_common::makeOrderedLinkPair(link_pair, link_name1, link_name2);
     return (lookup_table_.find(link_pair) != lookup_table_.end());
   }
 

--- a/tesseract_common/include/tesseract_common/collision_margin_data.h
+++ b/tesseract_common/include/tesseract_common/collision_margin_data.h
@@ -109,7 +109,7 @@ public:
    * @brief Get the default collision margin
    * @return default collision margin
    */
-  double getDefaultCollisionMargin() const { return default_collision_margin_; };
+  double getDefaultCollisionMargin() const { return default_collision_margin_; }
 
   /**
    * @brief Set the margin for a given contact pair
@@ -139,7 +139,8 @@ public:
    */
   double getPairCollisionMargin(const std::string& obj1, const std::string& obj2) const
   {
-    auto key = tesseract_common::makeOrderedLinkPair(obj1, obj2);
+    thread_local LinkNamesPair key;
+    tesseract_common::makeOrderedLinkPair(key, obj1, obj2);
     const auto it = lookup_table_.find(key);
 
     if (it != lookup_table_.end())

--- a/tesseract_common/include/tesseract_common/types.h
+++ b/tesseract_common/include/tesseract_common/types.h
@@ -84,6 +84,7 @@ struct PairHash
  * @return LinkNamesPair a lexicographically sorted pair of strings
  */
 LinkNamesPair makeOrderedLinkPair(const std::string& link_name1, const std::string& link_name2);
+void makeOrderedLinkPair(LinkNamesPair& pair, const std::string& link_name1, const std::string& link_name2);
 
 /** @brief The Plugin Information struct */
 // NOLINTNEXTLINE

--- a/tesseract_common/include/tesseract_common/types.h
+++ b/tesseract_common/include/tesseract_common/types.h
@@ -84,6 +84,18 @@ struct PairHash
  * @return LinkNamesPair a lexicographically sorted pair of strings
  */
 LinkNamesPair makeOrderedLinkPair(const std::string& link_name1, const std::string& link_name2);
+
+/**
+ * @brief Populate a pair of strings, where the pair.first is always <= pair.second.
+ *
+ * This is used to avoid multiple memory application throughout the code base
+ *
+ * This is commonly used along with PairHash as the key to an unordered_map<LinkNamesPair, Type, PairHash>
+ *
+ * @param pair The link name pair to load a lexicographically sorted pair of strings
+ * @param link_name1 First link name
+ * @param link_name2 Second link nam
+ */
 void makeOrderedLinkPair(LinkNamesPair& pair, const std::string& link_name1, const std::string& link_name2);
 
 /** @brief The Plugin Information struct */

--- a/tesseract_common/src/types.cpp
+++ b/tesseract_common/src/types.cpp
@@ -47,7 +47,9 @@ namespace tesseract_common
 std::size_t PairHash::operator()(const LinkNamesPair& pair) const
 {
   thread_local std::string key;
-  key = pair.first + pair.second;
+  key.clear();
+  key.append(pair.first);
+  key.append(pair.second);
   return std::hash<std::string>()(key);
 }
 

--- a/tesseract_common/src/types.cpp
+++ b/tesseract_common/src/types.cpp
@@ -46,15 +46,28 @@ namespace tesseract_common
 {
 std::size_t PairHash::operator()(const LinkNamesPair& pair) const
 {
-  return std::hash<std::string>()(pair.first + pair.second);
+  thread_local std::string key;
+  key = pair.first + pair.second;
+  return std::hash<std::string>()(key);
 }
 
 LinkNamesPair makeOrderedLinkPair(const std::string& link_name1, const std::string& link_name2)
 {
-  if (link_name1 <= link_name2)
-    return std::make_pair(link_name1, link_name2);
+  return (link_name1 <= link_name2) ? std::make_pair(link_name1, link_name2) : std::make_pair(link_name2, link_name1);
+}
 
-  return std::make_pair(link_name2, link_name1);
+void makeOrderedLinkPair(LinkNamesPair& pair, const std::string& link_name1, const std::string& link_name2)
+{
+  if (link_name1 <= link_name2)
+  {
+    pair.first = link_name1;
+    pair.second = link_name2;
+  }
+  else
+  {
+    pair.first = link_name2;
+    pair.second = link_name1;
+  }
 }
 
 /*********************************************************/

--- a/tesseract_environment/include/tesseract_environment/utils.h
+++ b/tesseract_environment/include/tesseract_environment/utils.h
@@ -53,70 +53,56 @@ void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
 
 /**
  * @brief Should perform a continuous collision check between two states configuring the manager with the config
+ * @param contact_results The contact results to populate. It does not get cleared
  * @param manager A continuous contact manager
  * @param state0 First environment state
  * @param state1 Second environment state
  * @param config CollisionCheckConfig used to specify collision check settings
- * @return Return the contact results map. If empty no contacts were found
  */
-tesseract_collision::ContactResultMap checkTrajectorySegment(tesseract_collision::ContinuousContactManager& manager,
-                                                             const tesseract_common::TransformMap& state0,
-                                                             const tesseract_common::TransformMap& state1,
-                                                             const tesseract_collision::CollisionCheckConfig& config);
+void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_results,
+                            tesseract_collision::ContinuousContactManager& manager,
+                            const tesseract_common::TransformMap& state0,
+                            const tesseract_common::TransformMap& state1,
+                            const tesseract_collision::CollisionCheckConfig& config);
 
 /**
  * @brief Should perform a continuous collision check between two states only passing along the contact_request to the
  * manager
+ * @param contact_results The contact results to populate. It does not get cleared
  * @param manager A continuous contact manager
  * @param state0 First environment state
  * @param state1 Second environment state
  * @param contact_request Contact request passed to the manager
- * @return Return the contact results map. If empty not contacts were found
  */
-tesseract_collision::ContactResultMap
-checkTrajectorySegment(tesseract_collision::ContinuousContactManager& manager,
-                       const tesseract_common::TransformMap& state0,
-                       const tesseract_common::TransformMap& state1,
-                       const tesseract_collision::ContactRequest& contact_request);
+void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_results,
+                            tesseract_collision::ContinuousContactManager& manager,
+                            const tesseract_common::TransformMap& state0,
+                            const tesseract_common::TransformMap& state1,
+                            const tesseract_collision::ContactRequest& contact_request);
 
 /**
  * @brief Should perform a discrete collision check a state first configuring manager with config
+ * @param contact_results The contact results to populate. It does not get cleared
  * @param manager A discrete contact manager
  * @param state First environment state
  * @param config CollisionCheckConfig used to specify collision check settings
- * @return Return the contact results map. If empty no contacts were found
  */
-tesseract_collision::ContactResultMap checkTrajectoryState(tesseract_collision::DiscreteContactManager& manager,
-                                                           const tesseract_common::TransformMap& state,
-                                                           const tesseract_collision::CollisionCheckConfig& config);
+void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
+                          tesseract_collision::DiscreteContactManager& manager,
+                          const tesseract_common::TransformMap& state,
+                          const tesseract_collision::CollisionCheckConfig& config);
 
 /**
  * @brief Should perform a discrete collision check a state only passing contact_request to the manager
+ * @param contact_results The contact results to populate. It does not get cleared
  * @param manager A discrete contact manager
  * @param state First environment state
  * @param contact_request Contact request passed to the manager
- * @return Return the contact results map. If empty no contacts were found
  */
-tesseract_collision::ContactResultMap checkTrajectoryState(tesseract_collision::DiscreteContactManager& manager,
-                                                           const tesseract_common::TransformMap& state,
-                                                           const tesseract_collision::ContactRequest& contact_request);
-
-/**
- * @brief This processes interpolated contact results and updated cc_time and cc_type
- * @details This is copied from the trajopt utility processInterpolatedCollisionResults
- * @param segment_results The full results to store sub segment results in after processing
- * @param sub_segment_results The interpolated results to process
- * @param sub_segment_index The current sub segment index
- * @param sub_segment_last_index The last sub segment index
- * @param manip_active_link_names The active link names
- * @param discrete If discrete contact checker was used
- */
-void processInterpolatedSubSegmentCollisionResults(tesseract_collision::ContactResultMap& segment_results,
-                                                   tesseract_collision::ContactResultMap& sub_segment_results,
-                                                   int sub_segment_index,
-                                                   int sub_segment_last_index,
-                                                   const std::vector<std::string>& manip_active_link_names,
-                                                   bool discrete);
+void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
+                          tesseract_collision::DiscreteContactManager& manager,
+                          const tesseract_common::TransformMap& state,
+                          const tesseract_collision::ContactRequest& contact_request);
 
 /**
  * @brief Should perform a continuous collision check over the trajectory and stop on first collision.

--- a/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -2715,22 +2715,18 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(
         tesseract_environment::checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
-    EXPECT_EQ(contacts[4].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
 
     contacts.clear();
     EXPECT_TRUE(
         tesseract_environment::checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
   }
@@ -2784,22 +2780,18 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(
         tesseract_environment::checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
-    EXPECT_EQ(contacts[4].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
 
     contacts.clear();
     EXPECT_TRUE(
         tesseract_environment::checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
   }
@@ -2867,21 +2859,17 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
-    EXPECT_EQ(contacts[4].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
 
     contacts.clear();
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *discrete_manager, *joint_group, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
   }
@@ -2932,21 +2920,17 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
-    EXPECT_EQ(contacts[4].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
 
     contacts.clear();
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *discrete_manager, *joint_group, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows()));
+    EXPECT_EQ(contacts.size(), 2);
     EXPECT_EQ(contacts[0].size(), 0);
     EXPECT_EQ(contacts[1].size(), 1);
-    EXPECT_EQ(contacts[2].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResults(contacts);
   }
@@ -3015,11 +2999,8 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(tesseract_environment::checkTrajectory(
         contacts, *continuous_manager, *state_solver, joint_names, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
@@ -3027,9 +3008,8 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     contacts.clear();
     EXPECT_TRUE(tesseract_environment::checkTrajectory(
         contacts, *continuous_manager, *state_solver, joint_names, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
@@ -3073,11 +3053,8 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(tesseract_environment::checkTrajectory(
         contacts, *continuous_manager, *state_solver, joint_names, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
@@ -3085,9 +3062,8 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     contacts.clear();
     EXPECT_TRUE(tesseract_environment::checkTrajectory(
         contacts, *continuous_manager, *state_solver, joint_names, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
@@ -3153,20 +3129,16 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
 
     contacts.clear();
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *continuous_manager, *joint_group, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
@@ -3206,20 +3178,16 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
-    EXPECT_EQ(contacts[2].size(), 0);
-    EXPECT_EQ(contacts[3].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);
 
     contacts.clear();
     EXPECT_TRUE(tesseract_environment::checkTrajectory(contacts, *continuous_manager, *joint_group, traj2, config));
-    EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows() - 1));
+    EXPECT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts[0].size(), 1);
-    EXPECT_EQ(contacts[1].size(), 0);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(1));
     checkProcessInterpolatedResultsNoTime0(contacts[0]);
     checkProcessInterpolatedResults(contacts);

--- a/tesseract_environment/test/tesseract_environment_utils.cpp
+++ b/tesseract_environment/test/tesseract_environment_utils.cpp
@@ -129,6 +129,7 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
   default_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::REPLACE;
 
+  tesseract_collision::ContactResultMap contacts;
   // Check Discrete
   {
     auto config = default_config;
@@ -144,7 +145,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
 
     // In collision by default
     {
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config);
       EXPECT_FALSE(contacts.empty());
     }
 
@@ -152,7 +154,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     {
       config.contact_manager_config.modify_object_enabled["boxbot_link"] = false;
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config);
       EXPECT_TRUE(contacts.empty());
     }
 
@@ -160,7 +163,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     {
       config.contact_manager_config.modify_object_enabled["boxbot_link"] = true;
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config);
       EXPECT_FALSE(contacts.empty());
     }
 
@@ -168,7 +172,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     {
       config.contact_manager_config.modify_object_enabled["nonexistant_link"] = false;
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config);
       EXPECT_FALSE(contacts.empty());
     }
   }
@@ -192,8 +197,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     tmap2["test_box_link"].translate(Eigen::Vector3d(0.9, -2, 0));
 
     {
-      tesseract_collision::ContactResultMap contacts =
-          checkTrajectorySegment(*manager, tmap1, tmap2, config.contact_request);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config.contact_request);
       // In collision by default
       EXPECT_FALSE(contacts.empty());
     }
@@ -202,8 +207,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     {
       config.contact_manager_config.modify_object_enabled["boxbot_link"] = false;
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts =
-          checkTrajectorySegment(*manager, tmap1, tmap2, config.contact_request);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config.contact_request);
       EXPECT_TRUE(contacts.empty());
     }
 
@@ -211,8 +216,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     {
       config.contact_manager_config.modify_object_enabled["boxbot_link"] = true;
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts =
-          checkTrajectorySegment(*manager, tmap1, tmap2, config.contact_request);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config.contact_request);
       EXPECT_FALSE(contacts.empty());
     }
 
@@ -220,8 +225,8 @@ TEST(TesseractEnvironmentUtils, applyContactManagerConfigObjectEnable)  // NOLIN
     {
       config.contact_manager_config.modify_object_enabled["nonexistant_link"] = false;
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts =
-          checkTrajectorySegment(*manager, tmap1, tmap2, config.contact_request);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config.contact_request);
       EXPECT_FALSE(contacts.empty());
     }
   }
@@ -249,6 +254,7 @@ TEST(TesseractEnvironmentUtils, checkTrajectoryState)  // NOLINT
   default_config.contact_manager_config.margin_data_override_type =
       tesseract_common::CollisionMarginOverrideType::REPLACE;
 
+  tesseract_collision::ContactResultMap contacts;
   // Check Discrete
   {
     auto config = default_config;
@@ -265,26 +271,30 @@ TEST(TesseractEnvironmentUtils, checkTrajectoryState)  // NOLINT
     // Not in collision
     {
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config.contact_request);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config.contact_request);
       EXPECT_TRUE(contacts.empty());
     }
     // In collision if manager->applyContactManagerConfig works correctly
     {
       config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.1);
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config.contact_request);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config.contact_request);
       EXPECT_FALSE(contacts.empty());
     }
     // Not collision if checkTrajectoryState applies the config
     {
       config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.0);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config);
       EXPECT_TRUE(contacts.empty());
     }
     // In collision if checkTrajectoryState applies the config
     {
       config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.1);
-      tesseract_collision::ContactResultMap contacts = checkTrajectoryState(*manager, tmap, config);
+      contacts.clear();
+      checkTrajectoryState(contacts, *manager, tmap, config);
       EXPECT_FALSE(contacts.empty());
     }
   }
@@ -310,28 +320,30 @@ TEST(TesseractEnvironmentUtils, checkTrajectoryState)  // NOLINT
     // Not in collision
     {
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts =
-          checkTrajectorySegment(*manager, tmap1, tmap2, config.contact_request);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config.contact_request);
       EXPECT_TRUE(contacts.empty());
     }
     // In collision if manager->applyContactManagerConfig works correctly
     {
       config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.1);
       manager->applyContactManagerConfig(config.contact_manager_config);
-      tesseract_collision::ContactResultMap contacts =
-          checkTrajectorySegment(*manager, tmap1, tmap2, config.contact_request);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config.contact_request);
       EXPECT_FALSE(contacts.empty());
     }
     // Not collision if checkTrajectoryState applies the config
     {
       config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.0);
-      tesseract_collision::ContactResultMap contacts = checkTrajectorySegment(*manager, tmap1, tmap2, config);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config);
       EXPECT_TRUE(contacts.empty());
     }
     // In collision if checkTrajectoryState applies the config
     {
       config.contact_manager_config.margin_data.setDefaultCollisionMargin(0.1);
-      tesseract_collision::ContactResultMap contacts = checkTrajectorySegment(*manager, tmap1, tmap2, config);
+      contacts.clear();
+      checkTrajectorySegment(contacts, *manager, tmap1, tmap2, config);
       EXPECT_FALSE(contacts.empty());
     }
   }


### PR DESCRIPTION
Initial testing shows this can have a significant performance bump. See results bellow where the last two columns show % reduction in Time, CPU Time. In case with large number of contacts the reduction is around 99%.

![image](https://user-images.githubusercontent.com/9803128/226155739-f08e7b0c-7651-4d70-86fe-8839cef82b15.png)
