### PR TITLE
Changed fcl to a system dependency

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -7,10 +7,6 @@
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
     version: 0.5.0
 - git:
-    local-name: fcl
-    uri: https://github.com/flexible-collision-library/fcl.git
-    version: 0.6.1
-- git:
     local-name: octomap
     uri: https://github.com/OctoMap/octomap.git
     version: v1.9.8

--- a/tesseract_collision/package.xml
+++ b/tesseract_collision/package.xml
@@ -20,7 +20,7 @@
   <depend>yaml-cpp</depend>
   <depend>bullet</depend>
   <depend>bullet-extras</depend>
-  <depend>fcl</depend>
+  <depend>libfcl-dev</depend>
   <depend>libconsole-bridge-dev</depend>
   <depend>tesseract_support</depend>
   <depend>libomp-dev</depend>


### PR DESCRIPTION
`fcl` is available as a system dependency using `rosdep` in most distros.