### PR TITLE
WIP: Add a 22.04 (jammy) workflow

### DIFF
--- a/.github/workflows/ubuntu_focal.yml
+++ b/.github/workflows/ubuntu_focal.yml
@@ -1,0 +1,109 @@
+name: Ubuntu-Focal
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'tesseract**'
+      - '.github/workflows/ubuntu_focal.yml'
+      - '**.repos'
+  schedule:
+    - cron: '0 5 * * *'
+  release:
+    types:
+      - released
+
+jobs:
+  ci:
+    name: ${{ matrix.distro }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [focal]
+        include:
+          - distro: focal
+            image: ubuntu:20.04
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/${{ matrix.distro }}/.ccache"
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      PUSH_DOCKER_IMAGE: ${{ github.ref == 'refs/heads/master' || github.event_name == 'release' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Free disk space
+        continue-on-error: true
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: ccache cache files
+        continue-on-error: true
+        uses: actions/cache@v1.1.0
+        with:
+          path: ${{ matrix.distro }}/.ccache
+          key: ${{ matrix.distro }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.distro }}-ccache-
+
+      - name: Login to Github container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker meta-information
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+          tags: |
+            type=ref,event=branch,prefix=${{ matrix.distro }}-
+            type=semver,pattern={{major}}.{{minor}},prefix=${{ matrix.distro }}-
+
+      - name: Set build type
+        run: |
+          if [[ "${{ env.PUSH_DOCKER_IMAGE }}" = true ]]
+          then
+            echo "BUILD_TYPE=Release" >> $GITHUB_ENV
+          else
+            echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
+          fi
+
+      - name: Build repository
+        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        env:
+          DOCKER_IMAGE: ${{ matrix.image }}
+          ROS_DISTRO: false
+          ADDITIONAL_DEBS: 'curl lsb-release liboctomap-dev'
+          AFTER_INIT: './.github/workflows/add_ros_apt_sources.sh'
+          UPSTREAM_WORKSPACE: 'dependencies.repos'
+          ROSDEP_SKIP_KEYS: "fcl opw_kinematics ros_industrial_cmake_boilerplate iwyu octomap catkin"
+          PREFIX: ${{ github.repository }}_
+          UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
+          TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTESSERACT_ENABLE_TESTING=ON"
+          BEFORE_RUN_TARGET_TEST_EMBED: "ici_with_unset_variables source $BASEDIR/${PREFIX}target_ws/install/setup.bash"
+          DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
+
+      - name: Push post-build Docker
+        if: ${{ env.PUSH_DOCKER_IMAGE  == 'true' }}
+        run: docker push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ubuntu_jammy.yml
+++ b/.github/workflows/ubuntu_jammy.yml
@@ -1,4 +1,4 @@
-name: Ubuntu
+name: Ubuntu-Jammy
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - 'tesseract**'
-      - '.github/workflows/ubuntu.yml'
+      - '.github/workflows/ubuntu_jammy.yml'
       - '**.repos'
   schedule:
     - cron: '0 5 * * *'
@@ -22,10 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [focal]
+        distro: [jammy]
         include:
-          - distro: focal
-            image: ubuntu:20.04
+          - distro: jammy
+            image: ubuntu:22.04
     env:
       CCACHE_DIR: "${{ github.workspace }}/${{ matrix.distro }}/.ccache"
       REGISTRY: ghcr.io

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 Platform             | CI Status
 ---------------------|:---------
-Linux (Focal)        | [![Build Status](https://github.com/tesseract-robotics/tesseract/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract/actions/workflows/ubuntu.yml)
+Linux (Focal)        | [![Build Status](https://github.com/tesseract-robotics/tesseract/actions/workflows/ubuntu_focal.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract/actions/workflows/ubuntu_focal.yml)
+Linux (Jammy)        | [![Build Status](https://github.com/tesseract-robotics/tesseract/actions/workflows/ubuntu_jammy.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract/actions/workflows/ubuntu_jammy.yml)
 Windows              | [![Build Status](https://github.com/tesseract-robotics/tesseract/actions/workflows/windows.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract/actions/workflows/windows.yml)
 Lint  (Clang-Format) | [![Build Status](https://github.com/tesseract-robotics/tesseract/actions/workflows/clang_format.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract/actions/workflows/clang_format.yml)
 Lint  (CMake-Format) | [![Build Status](https://github.com/tesseract-robotics/tesseract/actions/workflows/cmake_format.yml/badge.svg)](https://github.com/tesseract-robotics/tesseract/actions/workflows/cmake_format.yml)


### PR DESCRIPTION
Recently had a [failed pipeline](https://github.com/tesseract-robotics/tesseract_ros2/actions/runs/5280629534/jobs/9553023345?pr=47) on tesseract_ros2 that appears to be specifically related to a change that occurred from 20.04 to 22.04 causing an issue in tesseract_planning. tesseract and tesseract_planning should both be building on 22.04 without issues and this will ensure that.