### PR TITLE
Remove deletion of -dev libraries

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,7 +98,6 @@ jobs:
           PREFIX: ${{ github.repository }}_
           UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
           TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTESSERACT_ENABLE_TESTING=ON"
-          BEFORE_RUN_TARGET_TEST: 'apt remove *-dev -y -qq'
           BEFORE_RUN_TARGET_TEST_EMBED: "ici_with_unset_variables source $BASEDIR/${PREFIX}target_ws/install/setup.bash"
           AFTER_SCRIPT: 'rm -r $BASEDIR/${PREFIX}upstream_ws/build $BASEDIR/${PREFIX}target_ws/build'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Turns out the deletion of all `-dev` libraries from the CI docker image is problematic for downstream builds like `tesseract_planning` and `tesseract_ros2`, since some libraries (like `libtinyxml2-dev`) are only distributed with `-dev` names. In the case below, `trajopt_common` fails because its dependency (`tesseract_common`) can no longer find TinyXML2

```bash
  Call Stack (most recent call first):
    /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
    /root/tesseract-robotics/tesseract_target_ws/install/tesseract_common/lib/cmake/tesseract_common/FindTinyXML2.cmake:81 (find_package_handle_standard_args)
    /usr/share/cmake-3.16/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
    /root/tesseract-robotics/tesseract_target_ws/install/tesseract_common/lib/cmake/tesseract_common/tesseract_common-config.cmake:25 (find_dependency)
    CMakeLists.txt:17 (find_package)
```