### PR TITLE
TinyXML2: do not call find_package() if package has already been found.

### DIFF
--- a/tesseract_common/cmake/FindTinyXML2.cmake
+++ b/tesseract_common/cmake/FindTinyXML2.cmake
@@ -1,7 +1,9 @@
 # TinyXML2_FOUND TinyXML2_INCLUDE_DIRS TinyXML2_LIBRARIES
 
 # try to find the CMake config file for TinyXML2 first
-find_package(TinyXML2 CONFIG QUIET)
+if(NOT TinyXML2_FOUND)
+  find_package(TinyXML2 CONFIG QUIET)
+endif()
 if(TinyXML2_FOUND)
   message(STATUS "Found TinyXML2 via Config file: ${TinyXML2_DIR}")
   if(NOT TINYXML2_LIBRARY)


### PR DESCRIPTION
This greatly speeds up building of all of tesseract, as a lot of time was spent by FindTinyXML2.cmake. (I'll also submit this to https://github.com/ros2/tinyxml2_vendor.)