### PR TITLE
CI build on branches starting with 'dev**'

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'dev**'
   pull_request:
     paths:
       - 'tesseract**'

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'dev**'
   pull_request:
     paths:
       - 'tesseract**'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'dev**'
   pull_request:
     paths:
       - 'tesseract**'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'dev**'
   pull_request:
     paths:
       - 'tesseract**'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'dev**'
   pull_request:
     paths:
       - 'tesseract**'


### PR DESCRIPTION
This PR adds triggers so that branches starting with "dev/" will be built on GitHub actions. This is a convenience when developing on a branch before a pull request is started.