### PR TITLE
Replaced the implementation of `tesseract_kinematics::parseSceneGraph`

### DIFF
--- a/tesseract_kinematics/kdl/src/kdl_utils.cpp
+++ b/tesseract_kinematics/kdl/src/kdl_utils.cpp
@@ -156,4 +156,15 @@ bool parseSceneGraph(KDLChainData& results,
 
   return true;
 }
+
+bool parseSceneGraph(KDLChainData& results,
+                     const tesseract_scene_graph::SceneGraph& scene_graph,
+                     const std::string& base_name,
+                     const std::string& tip_name)
+{
+  std::vector<std::pair<std::string, std::string>> chains;
+  chains.emplace_back(base_name, tip_name);
+  return parseSceneGraph(results, scene_graph, chains);
+}
+
 }  // namespace tesseract_kinematics


### PR DESCRIPTION
One of the two implementations of `tesseract_kinematics::parseSceneGraph` appears to have been accidentally deleted in a previous commit (from #928). The header file still had it, but there was no implementation.