### PR TITLE
Updated to version of ICI with VCS shallow cloning

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -29,7 +29,7 @@ jobs:
           restore-keys: |
             benchmark-ccache-
 
-      - uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+      - uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           DOCKER_IMAGE: ubuntu:20.04
           ROS_DISTRO: false

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -69,6 +69,6 @@ jobs:
             ${{ matrix.job_type }}-ccache-
 
       - name: Build repository
-        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env: ${{ matrix.env }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             ${{ matrix.distro }}-ccache-
 
-      - uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+      - uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           DOCKER_IMAGE: ${{ matrix.image }}
           ROS_DISTRO: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Build repository
-        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           DOCKER_IMAGE: ubuntu:${{ matrix.distro }}
           ROS_DISTRO: false


### PR DESCRIPTION
Updates CI to use custom version of ICI with that clones shallow with VCS in addition to supporting ROS-independent builds