### PR TITLE
Remove deprecated AnalyzeTemporaryDtors (attempt 2)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -70,7 +70,6 @@ WarningsAsErrors: >
     -readability-identifier-length,
     -readability-suspicious-call-argument
 HeaderFilterRegex: '.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
   - key:             modernize-use-override.AllowOverrideAndFinal


### PR DESCRIPTION
See llvm/llvm-project#62020 and https://stackoverflow.com/questions/63920634/what-is-the-meaning-of-the-analyzetemporarydtors-option-in-clang-tidy