### PR TITLE
Update to vcpkg-action@v6 and use vcpkg-binarycache

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         brew install libomp cmake automake autoconf libtool gcc ninja
     - name: vcpkg build
-      uses: johnwason/vcpkg-action@v5
+      uses: johnwason/vcpkg-action@v6
       with:
         pkgs: >-
           ${{ env.VCPKG_PKGS }}
@@ -53,6 +53,7 @@ jobs:
         token: ${{ github.token }}
         cache-key: osx-x64-vcpkg
         revision: master
+        github-binarycache: true
     - name: pip3
       run: |
         python3 -m pip install numpy setuptools wheel pytest delvewheel colcon-common-extensions vcstool

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,15 +27,14 @@ jobs:
         path: target_ws/src
 
     - name: vcpkg build
-      uses: johnwason/vcpkg-action@v5
+      uses: johnwason/vcpkg-action@v6
       with:
         pkgs: fcl bullet3[multithreading,double-precision,rtti] octomap console-bridge eigen3 yaml-cpp benchmark tinyxml2 assimp orocos-kdl pcl lapack-reference boost-dll boost-filesystem boost-filesystem boost-serialization boost-program-options boost-graph urdfdom ccd[double-precision] gtest
         triplet: x64-windows-release
         extra-args: --clean-after-build
         token: ${{ github.token }}
         cache-key: ci-${{ matrix.os }}
-        revision: 2023.08.09
-
+        github-binarycache: true
     - name: configure-msvc
       uses: ilammy/msvc-dev-cmd@v1
       with:


### PR DESCRIPTION
Update to v6 of vcpkg-action. v6 optionally uses the new built-in GitHub caching for vcpkg to provide more accurate caching.