### PR TITLE
Fix deprecated exec_program command

### DIFF
--- a/tesseract_common/cmake/tesseract_macros.cmake
+++ b/tesseract_common/cmake/tesseract_macros.cmake
@@ -80,7 +80,7 @@ macro(tesseract_variables)
           -Wsign-conversion
           -Wno-sign-compare
           -Wnon-virtual-dtor)
-      exec_program(uname ARGS -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
+      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
       if(NOT
          CMAKE_SYSTEM_NAME2
          MATCHES
@@ -117,7 +117,7 @@ macro(tesseract_variables)
           -Werror=sign-conversion
           -Wno-sign-compare
           -Werror=non-virtual-dtor)
-      exec_program(uname ARGS -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
+      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
       if(NOT
          CMAKE_SYSTEM_NAME2
          MATCHES


### PR DESCRIPTION
Replace [deprecated exec_program](https://cmake.org/cmake/help/v3.0/command/exec_program.html) command by [execute_process](https://cmake.org/cmake/help/v3.0/command/execute_process.html).