### PR TITLE
Bullet TesseractCompoundCollisionAlgorithm bugfix

### DIFF
--- a/tesseract_collision/bullet/src/convex_hull_utils.cpp
+++ b/tesseract_collision/bullet/src/convex_hull_utils.cpp
@@ -68,8 +68,7 @@ int createConvexHull(tesseract_common::VectorVector3d& vertices,
   for (int i = 0; i < num_verts; i++)
   {
     btVector3& v = conv.vertices[i];
-    vertices.push_back(
-        Eigen::Vector3d(static_cast<double>(v.getX()), static_cast<double>(v.getY()), static_cast<double>(v.getZ())));
+    vertices.emplace_back(static_cast<double>(v.getX()), static_cast<double>(v.getY()), static_cast<double>(v.getZ()));
   }
 
   auto num_faces = static_cast<size_t>(conv.faces.size());

--- a/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
@@ -164,13 +164,12 @@ public:
 
     if (TestAabbAgainstAabb2(aabbMin0, aabbMax0, aabbMin1, aabbMax1))
     {
-      btTransform preTransform = childTrans;
 #if BT_BULLET_VERSION >= 300
+      btTransform preTransform = childTrans;
       if (this->m_compoundColObjWrap->m_preTransform != nullptr)
       {
         preTransform = preTransform * (*(this->m_compoundColObjWrap->m_preTransform));
       }
-#endif
       btCollisionObjectWrapper compoundWrap(this->m_compoundColObjWrap,
                                             childShape,
                                             m_compoundColObjWrap->getCollisionObject(),
@@ -178,6 +177,14 @@ public:
                                             preTransform,
                                             -1,
                                             index);
+#else
+      btCollisionObjectWrapper compoundWrap(this->m_compoundColObjWrap,
+                                            childShape,
+                                            m_compoundColObjWrap->getCollisionObject(),
+                                            newChildWorldTrans,
+                                            -1,
+                                            index);
+#endif
 
       btCollisionAlgorithm* algo = nullptr;
       bool allocatedAlgorithm = false;

--- a/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
@@ -164,10 +164,16 @@ public:
 
     if (TestAabbAgainstAabb2(aabbMin0, aabbMax0, aabbMin1, aabbMax1))
     {
+      btTransform preTransform = childTrans;
+      if (this->m_compoundColObjWrap->m_preTransform != nullptr)
+      {
+        preTransform = preTransform * (*(this->m_compoundColObjWrap->m_preTransform));
+      }
       btCollisionObjectWrapper compoundWrap(this->m_compoundColObjWrap,
                                             childShape,
                                             m_compoundColObjWrap->getCollisionObject(),
                                             newChildWorldTrans,
+                                            preTransform,
                                             -1,
                                             index);
 

--- a/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
+++ b/tesseract_collision/bullet/src/tesseract_compound_collision_algorithm.cpp
@@ -165,10 +165,12 @@ public:
     if (TestAabbAgainstAabb2(aabbMin0, aabbMax0, aabbMin1, aabbMax1))
     {
       btTransform preTransform = childTrans;
+#if BT_BULLET_VERSION >= 300
       if (this->m_compoundColObjWrap->m_preTransform != nullptr)
       {
         preTransform = preTransform * (*(this->m_compoundColObjWrap->m_preTransform));
       }
+#endif
       btCollisionObjectWrapper compoundWrap(this->m_compoundColObjWrap,
                                             childShape,
                                             m_compoundColObjWrap->getCollisionObject(),


### PR DESCRIPTION
- Apply [bugfix](https://github.com/bulletphysics/bullet3/commit/fce12964139c8073676a50db0201c1460ad3fcad) and [bugfix](https://github.com/bulletphysics/bullet3/commit/a808d7489500935ac6665dcfe930c43a2008566b) from bullet
- Clang-tidy fix