### PR TITLE
Add ability to briefly summarize trajectory collisions

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -560,6 +560,8 @@ struct ContactTrajectoryResults
 
   std::stringstream trajectoryCollisionResultsTable() const;
 
+  std::stringstream collisionFrequencyPerLink() const;
+
   std::vector<ContactTrajectoryStepResults> steps;
   std::vector<std::string> joint_names;
   int total_steps = 0;

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -712,7 +712,7 @@ std::stringstream ContactTrajectoryResults::collisionFrequencyPerLink() const
 {
   // Create a map to assign an index to each unique link name
   std::unordered_map<std::string, std::size_t> link_index_map;
-  int index = 0;
+  std::size_t index = 0;
   for (const auto& step : steps)
   {
     for (const auto& substep : step.substeps)

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -708,4 +708,51 @@ std::stringstream ContactTrajectoryResults::trajectoryCollisionResultsTable() co
   return ss;
 }
 
+std::stringstream ContactTrajectoryResults::collisionFrequencyPerLink() const
+{
+  // Count all links that experienced a collision
+  std::unordered_map<std::string, int> link_collision_count;
+  for (const auto& step : steps)
+  {
+    for (const auto& substep : step.substeps)
+    {
+      for (const auto& contact_pair : substep.contacts.getContainer())
+      {
+        const auto& link_pair = contact_pair.first;
+        link_collision_count[link_pair.first]++;
+        link_collision_count[link_pair.second]++;
+      }
+    }
+  }
+
+  // Determine the maximum width for the link name column to have a clean output
+  size_t max_link_name_length = 0;
+  for (const auto& entry : link_collision_count)
+  {
+    if (entry.first.size() > max_link_name_length)
+      max_link_name_length = entry.first.size();
+  }
+
+  // Adjust the width to have some extra space after the longest link name
+  const size_t column_width = max_link_name_length + 2;
+
+  // Create a vector of pairs and sort it by frequency in descending order
+  std::vector<std::pair<std::string, int>> sorted_collisions(link_collision_count.begin(), link_collision_count.end());
+  std::sort(sorted_collisions.begin(), sorted_collisions.end(), [](const auto& a, const auto& b) {
+    return b.second < a.second;
+  });
+
+  // Create a string stream to store the table
+  std::stringstream ss;
+  ss << std::left << std::setw(static_cast<int>(column_width)) << "Link Name"
+     << "Collisions" << std::endl;
+  ss << std::string(column_width + 10, '-') << std::endl;
+  for (const auto& entry : sorted_collisions)
+  {
+    ss << std::left << std::setw(static_cast<int>(column_width)) << entry.first << entry.second << std::endl;
+  }
+
+  return ss;
+}
+
 }  // namespace tesseract_collision

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -762,7 +762,7 @@ std::stringstream ContactTrajectoryResults::collisionFrequencyPerLink() const
   }
 
   // Determine the maximum width for the link name column
-  size_t max_link_name_length = 0;
+  std::size_t max_link_name_length = 0;
   for (const auto& entry : link_index_map)
   {
     if (entry.first.size() > max_link_name_length)
@@ -775,7 +775,7 @@ std::stringstream ContactTrajectoryResults::collisionFrequencyPerLink() const
   // Prepare the header row
   ss << std::setw(column_width + 5) << " "
      << "|";
-  for (size_t i = 0; i < link_index_map.size(); ++i)
+  for (std::size_t i = 0; i < link_index_map.size(); ++i)
   {
     ss << std::setw(5) << i << "|";
   }
@@ -784,7 +784,7 @@ std::stringstream ContactTrajectoryResults::collisionFrequencyPerLink() const
   // Prepare the separator row
   ss << std::setw(column_width + 5) << " "
      << "|";
-  for (size_t i = 0; i < link_index_map.size(); ++i)
+  for (std::size_t i = 0; i < link_index_map.size(); ++i)
   {
     ss << std::setw(5) << "-----"
        << "|";
@@ -798,19 +798,15 @@ std::stringstream ContactTrajectoryResults::collisionFrequencyPerLink() const
     link_names[entry.second] = entry.first;
   }
 
-  for (size_t i = 0; i < link_names.size(); ++i)
+  for (std::size_t i = 0; i < link_names.size(); ++i)
   {
     ss << std::setw(5) << i << std::setw(column_width) << link_names[i] << "|";
-    for (size_t j = 0; j < link_names.size(); ++j)
+    for (std::size_t j = 0; j < link_names.size(); ++j)
     {
       if (i == j)
-      {
         break;
-      }
-      else
-      {
-        ss << std::setw(5) << collision_matrix[i][j] << "|";
-      }
+
+      ss << std::setw(5) << collision_matrix[i][j] << "|";
     }
     ss << std::endl;
   }


### PR DESCRIPTION
This is to address the problem brought up [here](https://github.com/tesseract-robotics/tesseract_planning/pull/401#issuecomment-2145885476)

The output looks like this:
```
Link Name                      Collisions
-----------------------------------------
robot_link_2                   105
robot_link_3                   95
environment_object1            64
robot_link_4                   61
environment_object2            60
environment_object3            58
environment_object4            28
environment_object5            27
environment_object6            16
environment_object7            6
environment_object8            2
```

This is intended to help debug if the user realizes that the haven't disabled a collision, or give the user a place to look for what might be causing problems