### PR TITLE
Fix command serialization

### DIFF
--- a/tesseract_environment/src/command.cpp
+++ b/tesseract_environment/src/command.cpp
@@ -40,14 +40,14 @@ template <class Archive>
 void save(Archive& ar, const CommandType& g, const unsigned int /*version*/)
 {
   int value = static_cast<int>(g);
-  ar &= BOOST_SERIALIZATION_NVP(value);
+  ar& BOOST_SERIALIZATION_NVP(value);
 }
 
 template <class Archive>
 void load(Archive& ar, CommandType& g, const unsigned int /*version*/)
 {
   int value = 0;
-  ar &= BOOST_SERIALIZATION_NVP(value);
+  ar& BOOST_SERIALIZATION_NVP(value);
   g = static_cast<CommandType>(value);
 }
 


### PR DESCRIPTION
There are 656 lines of serialization code within tesseract and these two line had the incorrect syntax.