### PR TITLE
Use latest vcpkg release for GitHub Action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,6 @@ jobs:
         token: ${{ github.token }}
         cache-key: ci-${{ matrix.os }}
         github-binarycache: true
-        revision: 2024.01.12
 
     - name: configure-msvc
       uses: ilammy/msvc-dev-cmd@v1

--- a/tesseract_common/src/resource_locator.cpp
+++ b/tesseract_common/src/resource_locator.cpp
@@ -109,7 +109,7 @@ void GeneralResourceLocator::processToken(const std::string& token)
         if (package_paths_.find(dir_name) == package_paths_.end())
           package_paths_[dir_name] = dir->path().string();
 
-        dir.no_push();  // don't recurse into this directory.
+        dir.disable_recursion_pending();  // don't recurse into this directory.
       }
 
       ++dir;
@@ -153,7 +153,7 @@ std::shared_ptr<Resource> GeneralResourceLocator::locateResource(const std::stri
     }
   }
 
-  if (!tesseract_common::fs::path(mod_url).is_complete())
+  if (!tesseract_common::fs::path(mod_url).is_absolute())
   {
     CONSOLE_BRIDGE_logWarn("Resource not handled: %s", mod_url.c_str());
     return nullptr;

--- a/tesseract_common/test/resource_locator_unit.cpp
+++ b/tesseract_common/test/resource_locator_unit.cpp
@@ -40,7 +40,7 @@ public:
       mod_url = package_path + mod_url;
     }
 
-    if (!tesseract_common::fs::path(mod_url).is_complete())
+    if (!tesseract_common::fs::path(mod_url).is_absolute())
       return nullptr;
 
     return std::make_shared<tesseract_common::SimpleLocatedResource>(

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -50,7 +50,7 @@ public:
       mod_url = package_path + mod_url;
     }
 
-    if (!tesseract_common::fs::path(mod_url).is_complete())
+    if (!tesseract_common::fs::path(mod_url).is_absolute())
       return nullptr;
 
     return std::make_shared<tesseract_common::SimpleLocatedResource>(

--- a/tesseract_support/src/tesseract_support_resource_locator.cpp
+++ b/tesseract_support/src/tesseract_support_resource_locator.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Resource> TesseractSupportResourceLocator::locateResource(const 
     mod_url = package_path + mod_url;
   }
 
-  if (!tesseract_common::fs::path(mod_url).is_complete())
+  if (!tesseract_common::fs::path(mod_url).is_absolute())
     return nullptr;
 
   return std::make_shared<SimpleLocatedResource>(


### PR DESCRIPTION
This enables the use of the latest vcpkg release with boost 1.85 after the serialization failure was fixed in #1034.

Also fixes some deprecated boost::filesystem functions.