### PR TITLE
Fix clang detection on Mac OS

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -95,8 +95,7 @@ jobs:
             -DOpenMP_C_INCLUDE_DIR=${{ matrix.config.homebrew_root }}/opt/libomp/include \
             -DOpenMP_CXX_LIB_NAMES=libomp -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
             -DOpenMP_C_LIB_NAMES=libomp -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp" \
-            -DOpenMP_libomp_LIBRARY=${{ matrix.config.homebrew_root }}/opt/libomp/lib/libomp.dylib \
-            -DTESSERACT_WARNINGS_AS_ERRORS=OFF
+            -DOpenMP_libomp_LIBRARY=${{ matrix.config.homebrew_root }}/opt/libomp/lib/libomp.dylib
     - name: colcon test
       working-directory: ws
       run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -95,7 +95,8 @@ jobs:
             -DOpenMP_C_INCLUDE_DIR=${{ matrix.config.homebrew_root }}/opt/libomp/include \
             -DOpenMP_CXX_LIB_NAMES=libomp -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
             -DOpenMP_C_LIB_NAMES=libomp -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp" \
-            -DOpenMP_libomp_LIBRARY=${{ matrix.config.homebrew_root }}/opt/libomp/lib/libomp.dylib
+            -DOpenMP_libomp_LIBRARY=${{ matrix.config.homebrew_root }}/opt/libomp/lib/libomp.dylib \
+            -DTESSERACT_WARNINGS_AS_ERRORS=OFF
     - name: colcon test
       working-directory: ws
       run: |

--- a/tesseract_common/cmake/tesseract_macros.cmake
+++ b/tesseract_common/cmake/tesseract_macros.cmake
@@ -95,12 +95,13 @@ macro(tesseract_variables)
              "unknown")
         set(TESSERACT_COMPILE_OPTIONS_PUBLIC -mno-avx)
       endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TESSERACT_COMPILE_OPTIONS_PRIVATE
           -Wall
           -Wextra
           -Wconversion
           -Wsign-conversion)
+      set(TESSERACT_COMPILE_DEFINITIONS "BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED")
       message(WARNING "Non-GNU compiler detected. If using AVX instructions, Eigen alignment issues may result.")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       set(TESSERACT_COMPILE_DEFINITIONS "_USE_MATH_DEFINES=ON")
@@ -132,12 +133,13 @@ macro(tesseract_variables)
              "unknown")
         set(TESSERACT_COMPILE_OPTIONS_PUBLIC -mno-avx)
       endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TESSERACT_COMPILE_OPTIONS_PRIVATE
           -Werror=all
           -Werror=extra
           -Werror=conversion
           -Werror=sign-conversion)
+      set(TESSERACT_COMPILE_DEFINITIONS "BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED")
       message(WARNING "Non-GNU compiler detected. If using AVX instructions, Eigen alignment issues may result.")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       set(TESSERACT_COMPILE_DEFINITIONS "_USE_MATH_DEFINES=ON")

--- a/tesseract_common/include/tesseract_common/yaml_utils.h
+++ b/tesseract_common/include/tesseract_common/yaml_utils.h
@@ -332,8 +332,7 @@ struct convert<Eigen::VectorXd>
   static Node encode(const Eigen::VectorXd& rhs)
   {
     Node node;
-    long l = static_cast<long>(rhs.size());
-    for (long i = 0; i < l; ++i)
+    for (long i = 0; i < static_cast<long>(rhs.size()); ++i)
       node.push_back(rhs(i));
 
     return node;
@@ -345,8 +344,7 @@ struct convert<Eigen::VectorXd>
       return false;
 
     rhs.resize(static_cast<long>(node.size()));
-    long l = static_cast<long>(node.size());
-    for (long i = 0; i < l; ++i)
+    for (long i = 0; i < static_cast<long>(node.size()); ++i)
       rhs(i) = node[i].as<double>();
 
     return true;

--- a/tesseract_common/include/tesseract_common/yaml_utils.h
+++ b/tesseract_common/include/tesseract_common/yaml_utils.h
@@ -332,7 +332,7 @@ struct convert<Eigen::VectorXd>
   static Node encode(const Eigen::VectorXd& rhs)
   {
     Node node;
-    long l = static_cast<Eigen::Index>(rhs.size());
+    long l = static_cast<long>(rhs.size());
     for (long i = 0; i < l; ++i)
       node.push_back(rhs(i));
 
@@ -344,8 +344,8 @@ struct convert<Eigen::VectorXd>
     if (!node.IsSequence())
       return false;
 
-    rhs.resize(static_cast<Eigen::Index>(node.size()));
-    long l = static_cast<Eigen::Index>(node.size());
+    rhs.resize(static_cast<long>(node.size()));
+    long l = static_cast<long>(node.size());
     for (long i = 0; i < l; ++i)
       rhs(i) = node[i].as<double>();
 

--- a/tesseract_common/include/tesseract_common/yaml_utils.h
+++ b/tesseract_common/include/tesseract_common/yaml_utils.h
@@ -332,7 +332,8 @@ struct convert<Eigen::VectorXd>
   static Node encode(const Eigen::VectorXd& rhs)
   {
     Node node;
-    for (long i = 0; i < rhs.size(); ++i)
+    long l = static_cast<Eigen::Index>(rhs.size());
+    for (long i = 0; i < l; ++i)
       node.push_back(rhs(i));
 
     return node;
@@ -344,7 +345,8 @@ struct convert<Eigen::VectorXd>
       return false;
 
     rhs.resize(static_cast<Eigen::Index>(node.size()));
-    for (long i = 0; i < node.size(); ++i)
+    long l = static_cast<Eigen::Index>(node.size());
+    for (long i = 0; i < l; ++i)
       rhs(i) = node[i].as<double>();
 
     return true;

--- a/tesseract_environment/src/environment.cpp
+++ b/tesseract_environment/src/environment.cpp
@@ -1362,7 +1362,7 @@ bool Environment::Implementation::applyAddTrajectoryLinkCommand(const AddTraject
       return false;
     }
 
-    if (state.joint_names.size() != state.position.size())
+    if (static_cast<Eigen::Index>(state.joint_names.size()) != state.position.size())
     {
       CONSOLE_BRIDGE_logWarn("Tried to add trajectory link (%s) where joint names and position are different sizes.",
                              cmd->getLinkName().c_str());


### PR DESCRIPTION
Mac OS reports "Clang" as "AppleClang" and wasn't being detected. This PR fixes the compiler detection and a few compiler sign comparison warnings.