### PR TITLE
Make checkKin optional in debug

### DIFF
--- a/tesseract_environment/include/tesseract_environment/environment.h
+++ b/tesseract_environment/include/tesseract_environment/environment.h
@@ -204,7 +204,8 @@ public:
    * @return A kinematics group
    */
   std::unique_ptr<tesseract_kinematics::KinematicGroup> getKinematicGroup(const std::string& group_name,
-                                                                          const std::string& ik_solver_name = "") const;
+                                                                          const std::string& ik_solver_name = "",
+                                                                          bool check_kinematics = true) const;
 
   /**
    * @brief Find tool center point provided in the manipulator info


### PR DESCRIPTION
If a manipulator group has a lot of joints the kinematic check can take a very long time. This optionally removes that check which was previously always run in debug mode.