### PR TITLE
Include stdexcept in type_erasure.h

### DIFF
--- a/tesseract_common/include/tesseract_common/type_erasure.h
+++ b/tesseract_common/include/tesseract_common/type_erasure.h
@@ -28,6 +28,7 @@
 
 #include <memory>
 #include <typeindex>
+#include <stdexcept>
 #include <boost/stacktrace.hpp>
 #include <boost/core/demangle.hpp>
 #include <boost/serialization/base_object.hpp>


### PR DESCRIPTION
Include `<stdexcept>` in type_erasure.h to fix MSVC 2019 compiler error in tesseract_command_language.