### PR TITLE
Add 'COMPONENT core' to collision header install

### DIFF
--- a/tesseract_collision/core/CMakeLists.txt
+++ b/tesseract_collision/core/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(${PROJECT_NAME}_core PUBLIC "$<BUILD_INTERFACE:${CMAK
 install(
   DIRECTORY include/${PROJECT_NAME}
   DESTINATION include
+  COMPONENT core
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "*.hpp"


### PR DESCRIPTION
Added to fix cpack debian building.