### PR TITLE
Add path API functions to GeneralResourceLocator

### DIFF
--- a/tesseract_common/include/tesseract_common/resource_locator.h
+++ b/tesseract_common/include/tesseract_common/resource_locator.h
@@ -36,6 +36,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/export.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_common/filesystem.h>
+
 namespace boost::serialization
 {
 class access;
@@ -82,7 +84,23 @@ class GeneralResourceLocator : public ResourceLocator
 public:
   using Ptr = std::shared_ptr<GeneralResourceLocator>;
   using ConstPtr = std::shared_ptr<const GeneralResourceLocator>;
-  GeneralResourceLocator();
+  /**
+   * @brief Construct a new General Resource Locator object using the TESSERACT_RESOURCE_PATH environment variable
+   *
+   * @param environment_variables A vector of environment variables to search for paths
+   */
+  GeneralResourceLocator(const std::vector<std::string>& environment_variables = { "TESSERACT_RESOURCE_PATH",
+                                                                                   "ROS_PACKAGE_PATH" });
+  /**
+   * @brief Construct a new General Resource Locator object using the provided paths and/or the TESSERACT_RESOURCE_PATH
+   * environment variable
+   *
+   * @param paths A vector of paths to search for resources
+   * @param environment_variables A vector of environment variables to search for paths
+   */
+  GeneralResourceLocator(const std::vector<tesseract_common::fs::path>& paths,
+                         const std::vector<std::string>& environment_variables = { "TESSERACT_RESOURCE_PATH",
+                                                                                   "ROS_PACKAGE_PATH" });
   GeneralResourceLocator(const GeneralResourceLocator&) = default;
   GeneralResourceLocator& operator=(const GeneralResourceLocator&) = default;
   GeneralResourceLocator(GeneralResourceLocator&&) = default;
@@ -93,6 +111,24 @@ public:
 
   bool operator==(const GeneralResourceLocator& rhs) const;
   bool operator!=(const GeneralResourceLocator& rhs) const;
+
+  /**
+   * @brief Add path to the resource locator
+   *
+   * @param path The path to add. Must be a directory
+   * @return true Success
+   * @return false Directory does not exist
+   */
+  bool addPath(const tesseract_common::fs::path& path);
+
+  /**
+   * @brief Load paths from an environment variable
+   *
+   * @param environment_variable The environment variable to load paths from
+   * @return true Success
+   * @return false Environment variable does not exist
+   */
+  bool loadEnvironmentVariable(const std::string& environment_variable);
 
 private:
   friend class boost::serialization::access;


### PR DESCRIPTION
This PR adds API functions to GeneralResourceLocator to add paths to the locator using a constructor overload or the new `addPath()` function.