### PR TITLE
Add collision shape caching based on tesseract_geometry::Geometry object

### DIFF
--- a/tesseract_collision/bullet/CMakeLists.txt
+++ b/tesseract_collision/bullet/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   ${PROJECT_NAME}_bullet
   src/bullet_cast_bvh_manager.cpp
   src/bullet_cast_simple_manager.cpp
+  src/bullet_collision_shape_cache.cpp
   src/bullet_discrete_bvh_manager.cpp
   src/bullet_discrete_simple_manager.cpp
   src/bullet_utils.cpp

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_collision_shape_cache.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_collision_shape_cache.h
@@ -1,0 +1,69 @@
+/**
+ * @file bullet_collision_shape_cache.h
+ * @brief This is a static cache mapping tesseract geometry shared pointers to bullet collision shapes to avoid
+ * recreating the same collision object
+ *
+ * @author Levi Armstrong
+ * @date January 25, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COLLISION_BULLET_COLLISION_SHAPE_CACHE_H
+#define TESSERACT_COLLISION_BULLET_COLLISION_SHAPE_CACHE_H
+
+#include <map>
+#include <memory>
+#include <shared_mutex>
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <BulletCollision/CollisionShapes/btCollisionShape.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_geometry/fwd.h>
+
+namespace tesseract_collision::tesseract_collision_bullet
+{
+class BulletCollisionShapeCache
+{
+public:
+  /**
+   * @brief Insert a new entry into the cache
+   * @param key The cache key
+   * @param value The value to store
+   */
+  static void insert(const std::shared_ptr<const tesseract_geometry::Geometry>& key,
+                     const std::shared_ptr<btCollisionShape>& value);
+
+  /**
+   * @brief Retrieve the cache entry by key
+   * @param key The cache key
+   * @return If key exists the entry is returned, otherwise a nullptr is returned
+   */
+  static std::shared_ptr<btCollisionShape> get(const std::shared_ptr<const tesseract_geometry::Geometry>& key);
+
+private:
+  /** @brief The static cache */
+  static std::map<std::shared_ptr<const tesseract_geometry::Geometry>, std::shared_ptr<btCollisionShape>> cache_;
+  /** @brief The shared mutex for thread safety */
+  static std::shared_mutex mutex_;
+};
+}  // namespace tesseract_collision::tesseract_collision_bullet
+
+#endif  // TESSERACT_COLLISION_BULLET_COLLISION_SHAPE_CACHE_H

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_utils.h
@@ -363,13 +363,9 @@ private:
  * @brief Create a bullet collision shape from tesseract collision shape
  * @param geom Tesseract collision shape
  * @param cow The collision object wrapper the collision shape is associated with
- * @param shape_index The collision shapes index within the collision shape wrapper. This can be accessed from the
- * bullet collision shape by calling getUserIndex function.
  * @return Bullet collision shape.
  */
-std::shared_ptr<btCollisionShape> createShapePrimitive(const CollisionShapeConstPtr& geom,
-                                                       CollisionObjectWrapper* cow,
-                                                       int shape_index);
+std::shared_ptr<btCollisionShape> createShapePrimitive(const CollisionShapeConstPtr& geom, CollisionObjectWrapper* cow);
 
 /**
  * @brief Update a collision objects filters

--- a/tesseract_collision/bullet/src/bullet_collision_shape_cache.cpp
+++ b/tesseract_collision/bullet/src/bullet_collision_shape_cache.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file bullet_collision_shape_cache.cpp
+ * @brief This is a static cache mapping tesseract geometry shared pointers to bullet collision shapes to avoid
+ * recreating the same collision object
+ *
+ * @author Levi Armstrong
+ * @date January 25, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_collision/bullet/bullet_collision_shape_cache.h>
+#include <tesseract_geometry/geometry.h>
+#include <mutex>
+
+namespace tesseract_collision::tesseract_collision_bullet
+{
+// Static member definitions
+std::map<std::shared_ptr<const tesseract_geometry::Geometry>, std::shared_ptr<btCollisionShape>>
+    BulletCollisionShapeCache::cache_;
+std::shared_mutex BulletCollisionShapeCache::mutex_;
+
+void BulletCollisionShapeCache::insert(const std::shared_ptr<const tesseract_geometry::Geometry>& key,
+                                       const std::shared_ptr<btCollisionShape>& value)
+{
+  std::unique_lock lock(mutex_);
+  cache_[key] = value;
+}
+
+std::shared_ptr<btCollisionShape>
+BulletCollisionShapeCache::get(const std::shared_ptr<const tesseract_geometry::Geometry>& key)
+{
+  std::shared_lock lock(mutex_);
+  auto it = cache_.find(key);
+  return ((it != cache_.end()) ? it->second : nullptr);
+}
+
+}  // namespace tesseract_collision::tesseract_collision_bullet

--- a/tesseract_collision/fcl/CMakeLists.txt
+++ b/tesseract_collision/fcl/CMakeLists.txt
@@ -1,7 +1,12 @@
 find_package(fcl 0.6 REQUIRED)
 
 # Create target for FCL implementation
-add_library(${PROJECT_NAME}_fcl src/fcl_discrete_managers.cpp src/fcl_utils.cpp src/fcl_collision_object_wrapper.cpp)
+add_library(
+  ${PROJECT_NAME}_fcl
+  src/fcl_collision_geometry_cache.cpp
+  src/fcl_discrete_managers.cpp
+  src/fcl_utils.cpp
+  src/fcl_collision_object_wrapper.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_fcl
   PUBLIC ${PROJECT_NAME}_core

--- a/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_collision_geometry_cache.h
+++ b/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_collision_geometry_cache.h
@@ -1,0 +1,69 @@
+/**
+ * @file fcl_collision_geometry_cache.h
+ * @brief This is a static cache mapping tesseract geometry shared pointers to fcl collision geometry to avoid
+ * recreating the same collision object
+ *
+ * @author Levi Armstrong
+ * @date January 25, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_COLLISION_FCL_COLLISION_GEOMETRY_CACHE_H
+#define TESSERACT_COLLISION_FCL_COLLISION_GEOMETRY_CACHE_H
+
+#include <map>
+#include <memory>
+#include <shared_mutex>
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <fcl/geometry/collision_geometry.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_geometry/fwd.h>
+
+namespace tesseract_collision::tesseract_collision_fcl
+{
+class FCLCollisionGeometryCache
+{
+public:
+  /**
+   * @brief Insert a new entry into the cache
+   * @param key The cache key
+   * @param value The value to store
+   */
+  static void insert(const std::shared_ptr<const tesseract_geometry::Geometry>& key,
+                     const std::shared_ptr<fcl::CollisionGeometryd>& value);
+
+  /**
+   * @brief Retrieve the cache entry by key
+   * @param key The cache key
+   * @return If key exists the entry is returned, otherwise a nullptr is returned
+   */
+  static std::shared_ptr<fcl::CollisionGeometryd> get(const std::shared_ptr<const tesseract_geometry::Geometry>& key);
+
+private:
+  /** @brief The static cache */
+  static std::map<std::shared_ptr<const tesseract_geometry::Geometry>, std::shared_ptr<fcl::CollisionGeometryd>> cache_;
+  /** @brief The shared mutex for thread safety */
+  static std::shared_mutex mutex_;
+};
+}  // namespace tesseract_collision::tesseract_collision_fcl
+
+#endif  // TESSERACT_COLLISION_FCL_COLLISION_GEOMETRY_CACHE_H

--- a/tesseract_collision/fcl/src/fcl_collision_geometry_cache.cpp
+++ b/tesseract_collision/fcl/src/fcl_collision_geometry_cache.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file fcl_collision_geometry_cache.cpp
+ * @brief This is a static cache mapping tesseract geometry shared pointers to fcl collision geometry to avoid
+ * recreating the same collision object
+ *
+ * @author Levi Armstrong
+ * @date January 25, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_collision/fcl/fcl_collision_geometry_cache.h>
+#include <tesseract_geometry/geometry.h>
+#include <mutex>
+
+namespace tesseract_collision::tesseract_collision_fcl
+{
+// Static member definitions
+std::map<std::shared_ptr<const tesseract_geometry::Geometry>, std::shared_ptr<fcl::CollisionGeometryd>>
+    FCLCollisionGeometryCache::cache_;
+std::shared_mutex FCLCollisionGeometryCache::mutex_;
+
+void FCLCollisionGeometryCache::insert(const std::shared_ptr<const tesseract_geometry::Geometry>& key,
+                                       const std::shared_ptr<fcl::CollisionGeometryd>& value)
+{
+  std::unique_lock lock(mutex_);
+  cache_[key] = value;
+}
+
+std::shared_ptr<fcl::CollisionGeometryd>
+FCLCollisionGeometryCache::get(const std::shared_ptr<const tesseract_geometry::Geometry>& key)
+{
+  std::shared_lock lock(mutex_);
+  auto it = cache_.find(key);
+  return ((it != cache_.end()) ? it->second : nullptr);
+}
+
+}  // namespace tesseract_collision::tesseract_collision_fcl

--- a/tesseract_collision/fcl/src/fcl_utils.cpp
+++ b/tesseract_collision/fcl/src/fcl_utils.cpp
@@ -54,6 +54,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_collision/fcl/fcl_utils.h>
+#include <tesseract_collision/fcl/fcl_collision_geometry_cache.h>
 #include <tesseract_geometry/geometries.h>
 
 namespace tesseract_collision::tesseract_collision_fcl
@@ -151,7 +152,7 @@ CollisionGeometryPtr createShapePrimitive(const tesseract_geometry::Octree::Cons
   }
 }
 
-CollisionGeometryPtr createShapePrimitive(const CollisionShapeConstPtr& geom)
+CollisionGeometryPtr createShapePrimitiveHelper(const CollisionShapeConstPtr& geom)
 {
   switch (geom->getType())
   {
@@ -202,6 +203,17 @@ CollisionGeometryPtr createShapePrimitive(const CollisionShapeConstPtr& geom)
       return nullptr;
     }
   }
+}
+
+CollisionGeometryPtr createShapePrimitive(const CollisionShapeConstPtr& geom)
+{
+  CollisionGeometryPtr shape = FCLCollisionGeometryCache::get(geom);
+  if (shape != nullptr)
+    return shape;
+
+  shape = createShapePrimitiveHelper(geom);
+  FCLCollisionGeometryCache::insert(geom, shape);
+  return shape;
 }
 
 bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -83,13 +83,12 @@ inline void addCollisionObjects(DiscreteContactManager& checker, bool use_convex
   /////////////////////////////////////////////
   // Add box and remove
   /////////////////////////////////////////////
-  CollisionShapePtr remove_box = std::make_shared<tesseract_geometry::Box>(0.1, 1, 1);
   Eigen::Isometry3d remove_box_pose;
   remove_box_pose.setIdentity();
 
   CollisionShapesConst obj4_shapes;
   tesseract_common::VectorIsometry3d obj4_poses;
-  obj4_shapes.push_back(remove_box);
+  obj4_shapes.push_back(thin_box);
   obj4_poses.push_back(remove_box_pose);
 
   checker.addCollisionObject("remove_box_link", 0, obj4_shapes, obj4_poses);


### PR DESCRIPTION
This avoid creating duplicate underlying collision shapes for bullet and fcl when provided the collision geometry shared pointer. This speeds up things like leveraging the environment command for adding trajectory as a collision link. 