### PR TITLE
Disable collision shape caching in bullet and fcl

### DIFF
--- a/tesseract_collision/bullet/src/bullet_utils.cpp
+++ b/tesseract_collision/bullet/src/bullet_utils.cpp
@@ -333,10 +333,14 @@ std::shared_ptr<btCollisionShape> createShapePrimitive(const tesseract_geometry:
 
 std::shared_ptr<btCollisionShape> createShapePrimitive(const CollisionShapeConstPtr& geom, CollisionObjectWrapper* cow)
 {
-  std::shared_ptr<btCollisionShape> shape = BulletCollisionShapeCache::get(geom);
-  if (shape != nullptr)
-    return shape;
+  // std::shared_ptr<btCollisionShape> shape = BulletCollisionShapeCache::get(geom);
+  // if (shape != nullptr)
+  // {
+  //   // sleep(1000);
+  //   return shape;
+  // }
 
+  std::shared_ptr<btCollisionShape> shape;
   switch (geom->getType())
   {
     case tesseract_geometry::GeometryType::BOX:
@@ -401,7 +405,7 @@ std::shared_ptr<btCollisionShape> createShapePrimitive(const CollisionShapeConst
       // LCOV_EXCL_STOP
   }
 
-  BulletCollisionShapeCache::insert(geom, shape);
+  // BulletCollisionShapeCache::insert(geom, shape);
   return shape;
 }
 

--- a/tesseract_collision/fcl/src/fcl_utils.cpp
+++ b/tesseract_collision/fcl/src/fcl_utils.cpp
@@ -207,13 +207,13 @@ CollisionGeometryPtr createShapePrimitiveHelper(const CollisionShapeConstPtr& ge
 
 CollisionGeometryPtr createShapePrimitive(const CollisionShapeConstPtr& geom)
 {
-  CollisionGeometryPtr shape = FCLCollisionGeometryCache::get(geom);
-  if (shape != nullptr)
-    return shape;
+  // CollisionGeometryPtr shape = FCLCollisionGeometryCache::get(geom);
+  // if (shape != nullptr)
+  //   return shape;
 
-  shape = createShapePrimitiveHelper(geom);
-  FCLCollisionGeometryCache::insert(geom, shape);
-  return shape;
+  // shape = createShapePrimitiveHelper(geom);
+  // FCLCollisionGeometryCache::insert(geom, shape);
+  return createShapePrimitiveHelper(geom);
 }
 
 bool collisionCallback(fcl::CollisionObjectd* o1, fcl::CollisionObjectd* o2, void* data)


### PR DESCRIPTION
There seems to be an issue with reusing collision shapes in some cases. It odd that this causes issues but multiple clones do not which seem to share collision shapes.