### PR TITLE
Add validate method to ContactManagerConfig

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -64,11 +64,18 @@ jobs:
           target-args: --cmake-args ${{ matrix.env.TARGET_CMAKE_ARGS }}
 
       - name: Upload CodeCov Results
+        if: matrix.job_type == 'codecov'
         shell: bash
         run: |
-          if [[ "${{ matrix.job_type }}" == "codecov" ]]; then
-            source $GITHUB_WORKSPACE/target_ws/install/setup.bash
-            cd $GITHUB_WORKSPACE/target_ws
-            colcon build --cmake-target ccov-all --packages-select tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_srdf tesseract_state_solver tesseract_scene_graph tesseract_urdf
-            bash <(curl -s https://codecov.io/bash) -t 758610a6-d851-4185-a01a-5b9465889b62 -s $GITHUB_WORKSPACE/target_ws/build -f *all-merged.info
-          fi
+          source $GITHUB_WORKSPACE/target_ws/install/setup.bash
+          cd $GITHUB_WORKSPACE/target_ws
+          colcon build --cmake-target ccov-all --packages-select tesseract_collision tesseract_common tesseract_environment tesseract_geometry tesseract_kinematics tesseract_srdf tesseract_state_solver tesseract_scene_graph tesseract_urdf
+          bash <(curl -s https://codecov.io/bash) -t 758610a6-d851-4185-a01a-5b9465889b62 -s $GITHUB_WORKSPACE/target_ws/build -f *all-merged.info
+
+      - name: Upload coverage artifacts
+        if: matrix.job_type == 'codecov'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codecov-raw-info
+          path: ${{ github.workspace }}/target_ws/build/**/all-merged.info
+          retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,9 @@
 codecov:
   require_ci_to_pass: yes
+  disable_default_path_fixes: true
+
+fixes:
+  - "/__w/tesseract/tesseract/target_ws/src/::"
 
 coverage:
   precision: 2

--- a/tesseract_collision/CMakeLists.txt
+++ b/tesseract_collision/CMakeLists.txt
@@ -53,6 +53,8 @@ set(COVERAGE_EXCLUDE
     ${CMAKE_CURRENT_LIST_DIR}/test/*
     ${CMAKE_CURRENT_LIST_DIR}/include/tesseract_collision/test_suite/*
     ${CMAKE_CURRENT_LIST_DIR}/include/tesseract_collision/vhacd/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*
     /*/bullet/LinearMath/*
     /*/bullet/BulletCollision/*

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
@@ -119,6 +119,8 @@ public:
 
   void setDefaultCollisionMarginData(double default_collision_margin) override final;
 
+  void incrementCollisionMarginData(double increment) override final;
+
   void setPairCollisionMarginData(const std::string& name1,
                                   const std::string& name2,
                                   double collision_margin) override final;

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_bvh_manager.h
@@ -113,19 +113,21 @@ public:
 
   const std::vector<std::string>& getActiveCollisionObjects() const override final;
 
-  void setCollisionMarginData(
-      CollisionMarginData collision_margin_data,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) override final;
-
-  void setDefaultCollisionMarginData(double default_collision_margin) override final;
-
-  void incrementCollisionMarginData(double increment) override final;
-
-  void setPairCollisionMarginData(const std::string& name1,
-                                  const std::string& name2,
-                                  double collision_margin) override final;
+  void setCollisionMarginData(CollisionMarginData collision_margin_data) override final;
 
   const CollisionMarginData& getCollisionMarginData() const override final;
+
+  void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) override final;
+
+  void setDefaultCollisionMargin(double default_collision_margin) override final;
+
+  void incrementCollisionMargin(double increment) override final;
+
+  void setCollisionMarginPair(const std::string& name1,
+                              const std::string& name2,
+                              double collision_margin) override final;
 
   void
   setContactAllowedValidator(std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator) override final;

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
@@ -125,6 +125,8 @@ public:
                                   const std::string& name2,
                                   double collision_margin) override final;
 
+  void incrementCollisionMarginData(double increment) override final;
+
   void
   setContactAllowedValidator(std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator) override final;
 

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_cast_simple_manager.h
@@ -113,19 +113,21 @@ public:
 
   const std::vector<std::string>& getActiveCollisionObjects() const override final;
 
-  void setCollisionMarginData(
-      CollisionMarginData collision_margin_data,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) override final;
+  void setCollisionMarginData(CollisionMarginData collision_margin_data) override final;
 
   const CollisionMarginData& getCollisionMarginData() const override final;
 
-  void setDefaultCollisionMarginData(double default_collision_margin) override final;
+  void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) override final;
 
-  void setPairCollisionMarginData(const std::string& name1,
-                                  const std::string& name2,
-                                  double collision_margin) override final;
+  void setDefaultCollisionMargin(double default_collision_margin) override final;
 
-  void incrementCollisionMarginData(double increment) override final;
+  void setCollisionMarginPair(const std::string& name1,
+                              const std::string& name2,
+                              double collision_margin) override final;
+
+  void incrementCollisionMargin(double increment) override final;
 
   void
   setContactAllowedValidator(std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator) override final;

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
@@ -112,6 +112,8 @@ public:
                                   const std::string& name2,
                                   double collision_margin) override final;
 
+  void incrementCollisionMarginData(double increment) override final;
+
   const CollisionMarginData& getCollisionMarginData() const override final;
 
   void

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_bvh_manager.h
@@ -102,19 +102,21 @@ public:
 
   const std::vector<std::string>& getActiveCollisionObjects() const override final;
 
-  void setCollisionMarginData(
-      CollisionMarginData collision_margin_data,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) override final;
-
-  void setDefaultCollisionMarginData(double default_collision_margin) override final;
-
-  void setPairCollisionMarginData(const std::string& name1,
-                                  const std::string& name2,
-                                  double collision_margin) override final;
-
-  void incrementCollisionMarginData(double increment) override final;
+  void setCollisionMarginData(CollisionMarginData collision_margin_data) override final;
 
   const CollisionMarginData& getCollisionMarginData() const override final;
+
+  void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) override final;
+
+  void setDefaultCollisionMargin(double default_collision_margin) override final;
+
+  void setCollisionMarginPair(const std::string& name1,
+                              const std::string& name2,
+                              double collision_margin) override final;
+
+  void incrementCollisionMargin(double increment) override final;
 
   void
   setContactAllowedValidator(std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator) override final;

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
@@ -112,6 +112,8 @@ public:
                                   const std::string& name2,
                                   double collision_margin) override final;
 
+  void incrementCollisionMarginData(double increment) override final;
+
   const CollisionMarginData& getCollisionMarginData() const override final;
 
   void

--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/bullet_discrete_simple_manager.h
@@ -102,19 +102,21 @@ public:
 
   const std::vector<std::string>& getActiveCollisionObjects() const override final;
 
-  void setCollisionMarginData(
-      CollisionMarginData collision_margin_data,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) override final;
-
-  void setDefaultCollisionMarginData(double default_collision_margin) override final;
-
-  void setPairCollisionMarginData(const std::string& name1,
-                                  const std::string& name2,
-                                  double collision_margin) override final;
-
-  void incrementCollisionMarginData(double increment) override final;
+  void setCollisionMarginData(CollisionMarginData collision_margin_data) override final;
 
   const CollisionMarginData& getCollisionMarginData() const override final;
+
+  void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) override final;
+
+  void setDefaultCollisionMargin(double default_collision_margin) override final;
+
+  void setCollisionMarginPair(const std::string& name1,
+                              const std::string& name2,
+                              double collision_margin) override final;
+
+  void incrementCollisionMargin(double increment) override final;
 
   void
   setContactAllowedValidator(std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator) override final;

--- a/tesseract_collision/bullet/src/bullet_cast_bvh_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_cast_bvh_manager.cpp
@@ -427,30 +427,9 @@ void BulletCastBVHManager::setActiveCollisionObjects(const std::vector<std::stri
 
 const std::vector<std::string>& BulletCastBVHManager::getActiveCollisionObjects() const { return active_; }
 
-void BulletCastBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data,
-                                                  CollisionMarginOverrideType override_type)
+void BulletCastBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
-  contact_test_data_.collision_margin_data.apply(collision_margin_data, override_type);
-  onCollisionMarginDataChanged();
-}
-
-void BulletCastBVHManager::setDefaultCollisionMarginData(double default_collision_margin)
-{
-  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletCastBVHManager::incrementCollisionMarginData(double increment)
-{
-  contact_test_data_.collision_margin_data.incrementMargins(increment);
-  onCollisionMarginDataChanged();
-}
-
-void BulletCastBVHManager::setPairCollisionMarginData(const std::string& name1,
-                                                      const std::string& name2,
-                                                      double collision_margin)
-{
-  contact_test_data_.collision_margin_data.setPairCollisionMargin(name1, name2, collision_margin);
+  contact_test_data_.collision_margin_data = std::move(collision_margin_data);
   onCollisionMarginDataChanged();
 }
 
@@ -458,6 +437,34 @@ const CollisionMarginData& BulletCastBVHManager::getCollisionMarginData() const
 {
   return contact_test_data_.collision_margin_data;
 }
+
+void BulletCastBVHManager::setCollisionMarginPairData(const CollisionMarginPairData& pair_margin_data,
+                                                      CollisionMarginPairOverrideType override_type)
+{
+  contact_test_data_.collision_margin_data.apply(pair_margin_data, override_type);
+  onCollisionMarginDataChanged();
+}
+
+void BulletCastBVHManager::setDefaultCollisionMargin(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletCastBVHManager::incrementCollisionMargin(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
+void BulletCastBVHManager::setCollisionMarginPair(const std::string& name1,
+                                                  const std::string& name2,
+                                                  double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setCollisionMargin(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
+}
+
 void BulletCastBVHManager::setContactAllowedValidator(
     std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator)
 {

--- a/tesseract_collision/bullet/src/bullet_cast_bvh_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_cast_bvh_manager.cpp
@@ -440,6 +440,12 @@ void BulletCastBVHManager::setDefaultCollisionMarginData(double default_collisio
   onCollisionMarginDataChanged();
 }
 
+void BulletCastBVHManager::incrementCollisionMarginData(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 void BulletCastBVHManager::setPairCollisionMarginData(const std::string& name1,
                                                       const std::string& name2,
                                                       double collision_margin)

--- a/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
@@ -361,6 +361,12 @@ void BulletCastSimpleManager::setPairCollisionMarginData(const std::string& name
   onCollisionMarginDataChanged();
 }
 
+void BulletCastSimpleManager::incrementCollisionMarginData(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 const CollisionMarginData& BulletCastSimpleManager::getCollisionMarginData() const
 {
   return contact_test_data_.collision_margin_data;

--- a/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_cast_simple_manager.cpp
@@ -340,30 +340,9 @@ void BulletCastSimpleManager::setActiveCollisionObjects(const std::vector<std::s
 
 const std::vector<std::string>& BulletCastSimpleManager::getActiveCollisionObjects() const { return active_; }
 
-void BulletCastSimpleManager::setCollisionMarginData(CollisionMarginData collision_margin_data,
-                                                     CollisionMarginOverrideType override_type)
+void BulletCastSimpleManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
-  contact_test_data_.collision_margin_data.apply(collision_margin_data, override_type);
-  onCollisionMarginDataChanged();
-}
-
-void BulletCastSimpleManager::setDefaultCollisionMarginData(double default_collision_margin)
-{
-  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletCastSimpleManager::setPairCollisionMarginData(const std::string& name1,
-                                                         const std::string& name2,
-                                                         double collision_margin)
-{
-  contact_test_data_.collision_margin_data.setPairCollisionMargin(name1, name2, collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletCastSimpleManager::incrementCollisionMarginData(double increment)
-{
-  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  contact_test_data_.collision_margin_data = std::move(collision_margin_data);
   onCollisionMarginDataChanged();
 }
 
@@ -371,6 +350,34 @@ const CollisionMarginData& BulletCastSimpleManager::getCollisionMarginData() con
 {
   return contact_test_data_.collision_margin_data;
 }
+
+void BulletCastSimpleManager::setCollisionMarginPairData(const CollisionMarginPairData& pair_margin_data,
+                                                         CollisionMarginPairOverrideType override_type)
+{
+  contact_test_data_.collision_margin_data.apply(pair_margin_data, override_type);
+  onCollisionMarginDataChanged();
+}
+
+void BulletCastSimpleManager::setDefaultCollisionMargin(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletCastSimpleManager::setCollisionMarginPair(const std::string& name1,
+                                                     const std::string& name2,
+                                                     double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setCollisionMargin(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletCastSimpleManager::incrementCollisionMargin(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 void BulletCastSimpleManager::setContactAllowedValidator(
     std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator)
 {

--- a/tesseract_collision/bullet/src/bullet_discrete_bvh_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_discrete_bvh_manager.cpp
@@ -248,30 +248,10 @@ void BulletDiscreteBVHManager::setActiveCollisionObjects(const std::vector<std::
 }
 
 const std::vector<std::string>& BulletDiscreteBVHManager::getActiveCollisionObjects() const { return active_; }
-void BulletDiscreteBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data,
-                                                      CollisionMarginOverrideType override_type)
-{
-  contact_test_data_.collision_margin_data.apply(collision_margin_data, override_type);
-  onCollisionMarginDataChanged();
-}
 
-void BulletDiscreteBVHManager::setDefaultCollisionMarginData(double default_collision_margin)
+void BulletDiscreteBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
-  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletDiscreteBVHManager::setPairCollisionMarginData(const std::string& name1,
-                                                          const std::string& name2,
-                                                          double collision_margin)
-{
-  contact_test_data_.collision_margin_data.setPairCollisionMargin(name1, name2, collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletDiscreteBVHManager::incrementCollisionMarginData(double increment)
-{
-  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  contact_test_data_.collision_margin_data = std::move(collision_margin_data);
   onCollisionMarginDataChanged();
 }
 
@@ -279,6 +259,34 @@ const CollisionMarginData& BulletDiscreteBVHManager::getCollisionMarginData() co
 {
   return contact_test_data_.collision_margin_data;
 }
+
+void BulletDiscreteBVHManager::setCollisionMarginPairData(const CollisionMarginPairData& pair_margin_data,
+                                                          CollisionMarginPairOverrideType override_type)
+{
+  contact_test_data_.collision_margin_data.apply(pair_margin_data, override_type);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteBVHManager::setDefaultCollisionMargin(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteBVHManager::setCollisionMarginPair(const std::string& name1,
+                                                      const std::string& name2,
+                                                      double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setCollisionMargin(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteBVHManager::incrementCollisionMargin(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 void BulletDiscreteBVHManager::setContactAllowedValidator(
     std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator)
 {

--- a/tesseract_collision/bullet/src/bullet_discrete_bvh_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_discrete_bvh_manager.cpp
@@ -269,6 +269,12 @@ void BulletDiscreteBVHManager::setPairCollisionMarginData(const std::string& nam
   onCollisionMarginDataChanged();
 }
 
+void BulletDiscreteBVHManager::incrementCollisionMarginData(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 const CollisionMarginData& BulletDiscreteBVHManager::getCollisionMarginData() const
 {
   return contact_test_data_.collision_margin_data;

--- a/tesseract_collision/bullet/src/bullet_discrete_simple_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_discrete_simple_manager.cpp
@@ -247,6 +247,12 @@ void BulletDiscreteSimpleManager::setPairCollisionMarginData(const std::string& 
   onCollisionMarginDataChanged();
 }
 
+void BulletDiscreteSimpleManager::incrementCollisionMarginData(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 const CollisionMarginData& BulletDiscreteSimpleManager::getCollisionMarginData() const
 {
   return contact_test_data_.collision_margin_data;

--- a/tesseract_collision/bullet/src/bullet_discrete_simple_manager.cpp
+++ b/tesseract_collision/bullet/src/bullet_discrete_simple_manager.cpp
@@ -226,30 +226,9 @@ void BulletDiscreteSimpleManager::setActiveCollisionObjects(const std::vector<st
 
 const std::vector<std::string>& BulletDiscreteSimpleManager::getActiveCollisionObjects() const { return active_; }
 
-void BulletDiscreteSimpleManager::setCollisionMarginData(CollisionMarginData collision_margin_data,
-                                                         CollisionMarginOverrideType override_type)
+void BulletDiscreteSimpleManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
-  contact_test_data_.collision_margin_data.apply(collision_margin_data, override_type);
-  onCollisionMarginDataChanged();
-}
-
-void BulletDiscreteSimpleManager::setDefaultCollisionMarginData(double default_collision_margin)
-{
-  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletDiscreteSimpleManager::setPairCollisionMarginData(const std::string& name1,
-                                                             const std::string& name2,
-                                                             double collision_margin)
-{
-  contact_test_data_.collision_margin_data.setPairCollisionMargin(name1, name2, collision_margin);
-  onCollisionMarginDataChanged();
-}
-
-void BulletDiscreteSimpleManager::incrementCollisionMarginData(double increment)
-{
-  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  contact_test_data_.collision_margin_data = std::move(collision_margin_data);
   onCollisionMarginDataChanged();
 }
 
@@ -257,6 +236,34 @@ const CollisionMarginData& BulletDiscreteSimpleManager::getCollisionMarginData()
 {
   return contact_test_data_.collision_margin_data;
 }
+
+void BulletDiscreteSimpleManager::setCollisionMarginPairData(const CollisionMarginPairData& pair_margin_data,
+                                                             CollisionMarginPairOverrideType override_type)
+{
+  contact_test_data_.collision_margin_data.apply(pair_margin_data, override_type);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteSimpleManager::setDefaultCollisionMargin(double default_collision_margin)
+{
+  contact_test_data_.collision_margin_data.setDefaultCollisionMargin(default_collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteSimpleManager::setCollisionMarginPair(const std::string& name1,
+                                                         const std::string& name2,
+                                                         double collision_margin)
+{
+  contact_test_data_.collision_margin_data.setCollisionMargin(name1, name2, collision_margin);
+  onCollisionMarginDataChanged();
+}
+
+void BulletDiscreteSimpleManager::incrementCollisionMargin(double increment)
+{
+  contact_test_data_.collision_margin_data.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 void BulletDiscreteSimpleManager::setContactAllowedValidator(
     std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator)
 {

--- a/tesseract_collision/core/include/tesseract_collision/core/continuous_contact_manager.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/continuous_contact_manager.h
@@ -249,6 +249,12 @@ public:
                                           double collision_margin) = 0;
 
   /**
+   * @brief Increment the collision margin data by some value
+   * @param increment The value to increment the collision margin value
+   */
+  virtual void incrementCollisionMarginData(double increment) = 0;
+
+  /**
    * @brief Get the contact distance threshold
    * @return The contact distance
    */

--- a/tesseract_collision/core/include/tesseract_collision/core/continuous_contact_manager.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/continuous_contact_manager.h
@@ -220,19 +220,31 @@ public:
   virtual const std::vector<std::string>& getActiveCollisionObjects() const = 0;
 
   /**
-   * @brief Set the contact distance thresholds for which collision should be considered on a per pair basis
-   * @param collision_margin_data Contains the data that will replace the current settings
+   * @brief Set the contact distance threshold
+   * @param collision_margin_data The contact distance
+   */
+  virtual void setCollisionMarginData(CollisionMarginData collision_margin_data) = 0;
+
+  /**
+   * @brief Get the contact distance threshold
+   * @return The contact distance
+   */
+  virtual const CollisionMarginData& getCollisionMarginData() const = 0;
+
+  /**
+   * @brief Set the pair contact distance thresholds for which collision should be considered on a per pair basis
+   * @param pair_margin_data Contains the pair collision margins that will replace the current settings
    * @param override_type This determines how the provided CollisionMarginData is applied
    */
-  virtual void
-  setCollisionMarginData(CollisionMarginData collision_margin_data,
-                         CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) = 0;
+  virtual void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) = 0;
 
   /**
    * @brief Set the default collision margin
    * @param default_collision_margin New default collision margin
    */
-  virtual void setDefaultCollisionMarginData(double default_collision_margin) = 0;
+  virtual void setDefaultCollisionMargin(double default_collision_margin) = 0;
 
   /**
    * @brief Set the margin for a given contact pair
@@ -244,21 +256,13 @@ public:
    * @param obj2 The Second object name. Order doesn't matter
    * @param collision_margin contacts with distance < collision_margin are considered in collision
    */
-  virtual void setPairCollisionMarginData(const std::string& name1,
-                                          const std::string& name2,
-                                          double collision_margin) = 0;
+  virtual void setCollisionMarginPair(const std::string& name1, const std::string& name2, double collision_margin) = 0;
 
   /**
    * @brief Increment the collision margin data by some value
    * @param increment The value to increment the collision margin value
    */
-  virtual void incrementCollisionMarginData(double increment) = 0;
-
-  /**
-   * @brief Get the contact distance threshold
-   * @return The contact distance
-   */
-  virtual const CollisionMarginData& getCollisionMarginData() const = 0;
+  virtual void incrementCollisionMargin(double increment) = 0;
 
   /** @brief Set the active function for determining if two links are allowed to be in collision */
   virtual void

--- a/tesseract_collision/core/include/tesseract_collision/core/discrete_contact_manager.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/discrete_contact_manager.h
@@ -202,6 +202,12 @@ public:
                                           double collision_margin) = 0;
 
   /**
+   * @brief Increment the collision margin data by some value
+   * @param increment The value to increment the collision margin value
+   */
+  virtual void incrementCollisionMarginData(double increment) = 0;
+
+  /**
    * @brief Get the contact distance threshold
    * @return The contact distance
    */

--- a/tesseract_collision/core/include/tesseract_collision/core/discrete_contact_manager.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/discrete_contact_manager.h
@@ -173,19 +173,31 @@ public:
   virtual const std::vector<std::string>& getActiveCollisionObjects() const = 0;
 
   /**
+   * @brief Set the contact distance threshold
+   * @param collision_margin_data The contact distance
+   */
+  virtual void setCollisionMarginData(CollisionMarginData collision_margin_data) = 0;
+
+  /**
+   * @brief Get the contact distance threshold
+   * @return The contact distance
+   */
+  virtual const CollisionMarginData& getCollisionMarginData() const = 0;
+
+  /**
    * @brief Set the contact distance thresholds for which collision should be considered on a per pair basis
-   * @param collision_margin_data Contains the data that will replace the current settings
+   * @param pair_margin_data Contains the pair collision margins that will replace the current settings
    * @param override_type This determines how the provided CollisionMarginData is applied
    */
-  virtual void
-  setCollisionMarginData(CollisionMarginData collision_margin_data,
-                         CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) = 0;
+  virtual void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) = 0;
 
   /**
    * @brief Set the default collision margin
    * @param default_collision_margin New default collision margin
    */
-  virtual void setDefaultCollisionMarginData(double default_collision_margin) = 0;
+  virtual void setDefaultCollisionMargin(double default_collision_margin) = 0;
 
   /**
    * @brief Set the margin for a given contact pair
@@ -197,21 +209,13 @@ public:
    * @param obj2 The Second object name. Order doesn't matter
    * @param collision_margin contacts with distance < collision_margin are considered in collision
    */
-  virtual void setPairCollisionMarginData(const std::string& name1,
-                                          const std::string& name2,
-                                          double collision_margin) = 0;
+  virtual void setCollisionMarginPair(const std::string& name1, const std::string& name2, double collision_margin) = 0;
 
   /**
    * @brief Increment the collision margin data by some value
    * @param increment The value to increment the collision margin value
    */
-  virtual void incrementCollisionMarginData(double increment) = 0;
-
-  /**
-   * @brief Get the contact distance threshold
-   * @return The contact distance
-   */
-  virtual const CollisionMarginData& getCollisionMarginData() const = 0;
+  virtual void incrementCollisionMargin(double increment) = 0;
 
   /** @brief Set the active function for determining if two links are allowed to be in collision */
   virtual void

--- a/tesseract_collision/core/include/tesseract_collision/core/serialization.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/serialization.h
@@ -48,6 +48,12 @@ template <class Archive>
 void serialize(Archive& ar, tesseract_collision::ContactRequest& g, const unsigned int version);  // NOLINT
 
 template <class Archive>
+void save(Archive& ar, const tesseract_collision::ContactManagerConfig& g, const unsigned int version);  // NOLINT
+
+template <class Archive>
+void load(Archive& ar, tesseract_collision::ContactManagerConfig& g, const unsigned int version);  // NOLINT
+
+template <class Archive>
 void serialize(Archive& ar, tesseract_collision::ContactManagerConfig& g, const unsigned int version);  // NOLINT
 
 template <class Archive>

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -428,11 +428,18 @@ struct ContactManagerConfig
   /** @brief Additional AllowedCollisionMatrix to consider for this collision check.  */
   tesseract_common::AllowedCollisionMatrix acm;
   /** @brief Specifies how to combine the ContactAllowedValidator from acm with the one preset in the contact manager */
-  ACMOverrideType acm_override_type{ ACMOverrideType::OR };
+  ACMOverrideType acm_override_type{ ACMOverrideType::NONE };
 
   /** @brief Each key is an object name. Objects will be enabled/disabled based on the value. Objects that aren't in the
    * map are unmodified from the defaults*/
   std::unordered_map<std::string, bool> modify_object_enabled;
+
+  /**
+   * @brief Check for errors and throw exception if they exist
+   * If margin_data_override_type is set to NONE but margin pair data exist or non zero default margin
+   * If acm_override_type is set to NONE but allowed collision entries exist
+   */
+  void validate() const;
 };
 
 /**

--- a/tesseract_collision/core/src/common.cpp
+++ b/tesseract_collision/core/src/common.cpp
@@ -118,7 +118,7 @@ ContactResult* processResult(ContactTestData& cdata,
     return nullptr;
 
   if ((cdata.req.calculate_distance || cdata.req.calculate_penetration) &&
-      (contact.distance > cdata.collision_margin_data.getPairCollisionMargin(key.first, key.second)))
+      (contact.distance > cdata.collision_margin_data.getCollisionMargin(key.first, key.second)))
     return nullptr;
 
   if (!found)

--- a/tesseract_collision/core/src/continuous_contact_manager.cpp
+++ b/tesseract_collision/core/src/continuous_contact_manager.cpp
@@ -31,6 +31,7 @@ namespace tesseract_collision
 {
 void ContinuousContactManager::applyContactManagerConfig(const ContactManagerConfig& config)
 {
+  config.validate();
   setCollisionMarginData(config.margin_data, config.margin_data_override_type);
   applyContactAllowedValidatorOverride(*this, config.acm, config.acm_override_type);
   applyModifyObjectEnabled(*this, config.modify_object_enabled);

--- a/tesseract_collision/core/src/continuous_contact_manager.cpp
+++ b/tesseract_collision/core/src/continuous_contact_manager.cpp
@@ -32,7 +32,11 @@ namespace tesseract_collision
 void ContinuousContactManager::applyContactManagerConfig(const ContactManagerConfig& config)
 {
   config.validate();
-  setCollisionMarginData(config.margin_data, config.margin_data_override_type);
+
+  if (config.default_margin.has_value())
+    setDefaultCollisionMargin(config.default_margin.value());
+
+  setCollisionMarginPairData(config.pair_margin_data, config.pair_margin_override_type);
   applyContactAllowedValidatorOverride(*this, config.acm, config.acm_override_type);
   applyModifyObjectEnabled(*this, config.modify_object_enabled);
 }

--- a/tesseract_collision/core/src/discrete_contact_manager.cpp
+++ b/tesseract_collision/core/src/discrete_contact_manager.cpp
@@ -32,7 +32,11 @@ namespace tesseract_collision
 void DiscreteContactManager::applyContactManagerConfig(const ContactManagerConfig& config)
 {
   config.validate();
-  setCollisionMarginData(config.margin_data, config.margin_data_override_type);
+
+  if (config.default_margin.has_value())
+    setDefaultCollisionMargin(config.default_margin.value());
+
+  setCollisionMarginPairData(config.pair_margin_data, config.pair_margin_override_type);
   applyContactAllowedValidatorOverride(*this, config.acm, config.acm_override_type);
   applyModifyObjectEnabled(*this, config.modify_object_enabled);
 }

--- a/tesseract_collision/core/src/discrete_contact_manager.cpp
+++ b/tesseract_collision/core/src/discrete_contact_manager.cpp
@@ -31,6 +31,7 @@ namespace tesseract_collision
 {
 void DiscreteContactManager::applyContactManagerConfig(const ContactManagerConfig& config)
 {
+  config.validate();
   setCollisionMarginData(config.margin_data, config.margin_data_override_type);
   applyContactAllowedValidatorOverride(*this, config.acm, config.acm_override_type);
   applyModifyObjectEnabled(*this, config.modify_object_enabled);

--- a/tesseract_collision/core/src/serialization.cpp
+++ b/tesseract_collision/core/src/serialization.cpp
@@ -108,19 +108,49 @@ void serialize(Archive& ar, tesseract_collision::ContactRequest& g, const unsign
 }
 
 template <class Archive>
-void serialize(Archive& ar, tesseract_collision::ContactManagerConfig& g, const unsigned int /*version*/)
+void save(Archive& ar, const tesseract_collision::ContactManagerConfig& g, const unsigned int /*version*/)
 {
-  ar& boost::serialization::make_nvp("margin_data_override_type", g.margin_data_override_type);
-  ar& boost::serialization::make_nvp("margin_data", g.margin_data);
+  bool has_default_margin{ g.default_margin.has_value() };
+  double default_margin{ 0 };
+  if (g.default_margin.has_value())
+    default_margin = g.default_margin.value();
+
+  ar& boost::serialization::make_nvp("has_default_margin", has_default_margin);
+  ar& boost::serialization::make_nvp("default_margin", default_margin);
+  ar& boost::serialization::make_nvp("pair_margin_override_type", g.pair_margin_override_type);
+  ar& boost::serialization::make_nvp("pair_margin_data", g.pair_margin_data);
   ar& boost::serialization::make_nvp("acm", g.acm);
   ar& boost::serialization::make_nvp("acm_override_type", g.acm_override_type);
   ar& boost::serialization::make_nvp("modify_object_enabled", g.modify_object_enabled);
 }
 
 template <class Archive>
+void load(Archive& ar, tesseract_collision::ContactManagerConfig& g, const unsigned int /*version*/)
+{
+  bool has_default_margin{ false };
+  ar& boost::serialization::make_nvp("has_default_margin", has_default_margin);
+  if (has_default_margin)
+  {
+    double default_margin{ 0 };
+    ar& boost::serialization::make_nvp("default_margin", default_margin);
+    g.default_margin = default_margin;
+  }
+  ar& boost::serialization::make_nvp("pair_margin_override_type", g.pair_margin_override_type);
+  ar& boost::serialization::make_nvp("pair_margin_data", g.pair_margin_data);
+  ar& boost::serialization::make_nvp("acm", g.acm);
+  ar& boost::serialization::make_nvp("acm_override_type", g.acm_override_type);
+  ar& boost::serialization::make_nvp("modify_object_enabled", g.modify_object_enabled);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tesseract_collision::ContactManagerConfig& g, const unsigned int version)
+{
+  split_free(ar, g, version);
+}
+
+template <class Archive>
 void serialize(Archive& ar, tesseract_collision::CollisionCheckConfig& g, const unsigned int /*version*/)
 {
-  ar& boost::serialization::make_nvp("contact_manager_config", g.contact_manager_config);
   ar& boost::serialization::make_nvp("contact_request", g.contact_request);
   ar& boost::serialization::make_nvp("type", g.type);
   ar& boost::serialization::make_nvp("longest_valid_segment_length", g.longest_valid_segment_length);
@@ -159,7 +189,7 @@ void serialize(Archive& ar, tesseract_collision::ContactTrajectoryResults& g, co
 TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactResult)
 TESSERACT_SERIALIZE_SAVE_LOAD_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactResultMap)
 TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactRequest)
-TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactManagerConfig)
+TESSERACT_SERIALIZE_SAVE_LOAD_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactManagerConfig)
 TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::CollisionCheckConfig)
 TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactTrajectorySubstepResults)
 TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(tesseract_collision::ContactTrajectoryStepResults)

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -360,35 +360,24 @@ ContactTestData::ContactTestData(const std::vector<std::string>& active,
 {
 }
 
-ContactManagerConfig::ContactManagerConfig(double default_margin)
-  : margin_data_override_type(CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN), margin_data(default_margin)
-{
-}
+ContactManagerConfig::ContactManagerConfig(double default_margin) : default_margin(default_margin) {}
 
 void ContactManagerConfig::validate() const
 {
-  if (margin_data_override_type == CollisionMarginOverrideType::NONE)
-  {
-    if (!margin_data.getPairCollisionMargins().empty())
-      throw std::runtime_error("ContactManagerConfig, margin data overide type is NONE but pair collision margins "
-                               "exist!");
-
-    if (!tesseract_common::almostEqualRelativeAndAbs(margin_data.getDefaultCollisionMargin(), 0.0))
-      throw std::runtime_error("ContactManagerConfig, margin data overide type is NONE but has non zero default "
-                               "margin!");
-  }
+  if (pair_margin_override_type == CollisionMarginPairOverrideType::NONE &&
+      !pair_margin_data.getCollisionMargins().empty())
+    throw std::runtime_error("ContactManagerConfig, pair margin override type is NONE but pair collision margins "
+                             "exist!");
 
   if (acm_override_type == ACMOverrideType::NONE && !acm.getAllAllowedCollisions().empty())
-    throw std::runtime_error("ContactManagerConfig, acm overide type is NONE but allowed collision entries exist!");
+    throw std::runtime_error("ContactManagerConfig, acm override type is NONE but allowed collision entries exist!");
 }
 
-CollisionCheckConfig::CollisionCheckConfig(double default_margin,
-                                           ContactRequest request,
+CollisionCheckConfig::CollisionCheckConfig(ContactRequest request,
                                            CollisionEvaluatorType type,
                                            double longest_valid_segment_length,
                                            CollisionCheckProgramType check_program_mode)
-  : contact_manager_config(default_margin)
-  , contact_request(std::move(request))
+  : contact_request(std::move(request))
   , type(type)
   , longest_valid_segment_length(longest_valid_segment_length)
   , check_program_mode(check_program_mode)

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -365,6 +365,23 @@ ContactManagerConfig::ContactManagerConfig(double default_margin)
 {
 }
 
+void ContactManagerConfig::validate() const
+{
+  if (margin_data_override_type == CollisionMarginOverrideType::NONE)
+  {
+    if (!margin_data.getPairCollisionMargins().empty())
+      throw std::runtime_error("ContactManagerConfig, margin data overide type is NONE but pair collision margins "
+                               "exist!");
+
+    if (!tesseract_common::almostEqualRelativeAndAbs(margin_data.getDefaultCollisionMargin(), 0.0))
+      throw std::runtime_error("ContactManagerConfig, margin data overide type is NONE but has non zero default "
+                               "margin!");
+  }
+
+  if (acm_override_type == ACMOverrideType::NONE && !acm.getAllAllowedCollisions().empty())
+    throw std::runtime_error("ContactManagerConfig, acm overide type is NONE but allowed collision entries exist!");
+}
+
 CollisionCheckConfig::CollisionCheckConfig(double default_margin,
                                            ContactRequest request,
                                            CollisionEvaluatorType type,

--- a/tesseract_collision/examples/box_box_example.cpp
+++ b/tesseract_collision/examples/box_box_example.cpp
@@ -144,7 +144,7 @@ int main(int /*argc*/, char** /*argv*/)
 
   // documentation:start:12: Change contact distance threshold
   // Set higher contact distance threshold
-  checker.setDefaultCollisionMarginData(0.25);
+  checker.setDefaultCollisionMargin(0.25);
   // documentation:end:12: Change contact distance threshold
 
   // documentation:start:13: Perform collision check

--- a/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -111,6 +111,8 @@ public:
                                   const std::string& name2,
                                   double collision_margin) override final;
 
+  void incrementCollisionMarginData(double increment) override final;
+
   const CollisionMarginData& getCollisionMarginData() const override final;
 
   void

--- a/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_discrete_managers.h
+++ b/tesseract_collision/fcl/include/tesseract_collision/fcl/fcl_discrete_managers.h
@@ -101,19 +101,21 @@ public:
 
   const std::vector<std::string>& getActiveCollisionObjects() const override final;
 
-  void setCollisionMarginData(
-      CollisionMarginData collision_margin_data,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE) override final;
-
-  void setDefaultCollisionMarginData(double default_collision_margin) override final;
-
-  void setPairCollisionMarginData(const std::string& name1,
-                                  const std::string& name2,
-                                  double collision_margin) override final;
-
-  void incrementCollisionMarginData(double increment) override final;
+  void setCollisionMarginData(CollisionMarginData collision_margin_data) override final;
 
   const CollisionMarginData& getCollisionMarginData() const override final;
+
+  void setCollisionMarginPairData(
+      const CollisionMarginPairData& pair_margin_data,
+      CollisionMarginPairOverrideType override_type = CollisionMarginPairOverrideType::REPLACE) override final;
+
+  void setDefaultCollisionMargin(double default_collision_margin) override final;
+
+  void setCollisionMarginPair(const std::string& name1,
+                              const std::string& name2,
+                              double collision_margin) override final;
+
+  void incrementCollisionMargin(double increment) override final;
 
   void
   setContactAllowedValidator(std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator) override final;

--- a/tesseract_collision/fcl/src/fcl_discrete_managers.cpp
+++ b/tesseract_collision/fcl/src/fcl_discrete_managers.cpp
@@ -287,34 +287,42 @@ void FCLDiscreteBVHManager::setActiveCollisionObjects(const std::vector<std::str
 }
 
 const std::vector<std::string>& FCLDiscreteBVHManager::getActiveCollisionObjects() const { return active_; }
-void FCLDiscreteBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data,
-                                                   CollisionMarginOverrideType override_type)
+
+void FCLDiscreteBVHManager::setCollisionMarginData(CollisionMarginData collision_margin_data)
 {
-  collision_margin_data_.apply(collision_margin_data, override_type);
+  collision_margin_data_ = std::move(collision_margin_data);
   onCollisionMarginDataChanged();
 }
 
-void FCLDiscreteBVHManager::setDefaultCollisionMarginData(double default_collision_margin)
+const CollisionMarginData& FCLDiscreteBVHManager::getCollisionMarginData() const { return collision_margin_data_; }
+
+void FCLDiscreteBVHManager::setCollisionMarginPairData(const CollisionMarginPairData& pair_margin_data,
+                                                       CollisionMarginPairOverrideType override_type)
+{
+  collision_margin_data_.apply(pair_margin_data, override_type);
+  onCollisionMarginDataChanged();
+}
+
+void FCLDiscreteBVHManager::setDefaultCollisionMargin(double default_collision_margin)
 {
   collision_margin_data_.setDefaultCollisionMargin(default_collision_margin);
   onCollisionMarginDataChanged();
 }
 
-void FCLDiscreteBVHManager::setPairCollisionMarginData(const std::string& name1,
-                                                       const std::string& name2,
-                                                       double collision_margin)
+void FCLDiscreteBVHManager::setCollisionMarginPair(const std::string& name1,
+                                                   const std::string& name2,
+                                                   double collision_margin)
 {
-  collision_margin_data_.setPairCollisionMargin(name1, name2, collision_margin);
+  collision_margin_data_.setCollisionMargin(name1, name2, collision_margin);
   onCollisionMarginDataChanged();
 }
 
-void FCLDiscreteBVHManager::incrementCollisionMarginData(double increment)
+void FCLDiscreteBVHManager::incrementCollisionMargin(double increment)
 {
   collision_margin_data_.incrementMargins(increment);
   onCollisionMarginDataChanged();
 }
 
-const CollisionMarginData& FCLDiscreteBVHManager::getCollisionMarginData() const { return collision_margin_data_; }
 void FCLDiscreteBVHManager::setContactAllowedValidator(
     std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator)
 {

--- a/tesseract_collision/fcl/src/fcl_discrete_managers.cpp
+++ b/tesseract_collision/fcl/src/fcl_discrete_managers.cpp
@@ -308,6 +308,12 @@ void FCLDiscreteBVHManager::setPairCollisionMarginData(const std::string& name1,
   onCollisionMarginDataChanged();
 }
 
+void FCLDiscreteBVHManager::incrementCollisionMarginData(double increment)
+{
+  collision_margin_data_.incrementMargins(increment);
+  onCollisionMarginDataChanged();
+}
+
 const CollisionMarginData& FCLDiscreteBVHManager::getCollisionMarginData() const { return collision_margin_data_; }
 void FCLDiscreteBVHManager::setContactAllowedValidator(
     std::shared_ptr<const tesseract_common::ContactAllowedValidator> validator)

--- a/tesseract_collision/test/collision_core_unit.cpp
+++ b/tesseract_collision/test/collision_core_unit.cpp
@@ -6,6 +6,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_collision/core/common.h>
+#include <tesseract_collision/core/types.h>
 #include <tesseract_common/contact_allowed_validator.h>
 #include <tesseract_common/utils.h>
 
@@ -18,6 +19,58 @@ public:
             tesseract_common::makeOrderedLinkPair(s1, s2));
   }
 };
+
+TEST(TesseractCoreUnit, ContactManagerConfig_validateUnit)  // NOLINT
+{
+  {
+    tesseract_collision::ContactManagerConfig config;
+    EXPECT_NO_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config(0.1);
+    EXPECT_NO_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config;
+    config.margin_data.setDefaultCollisionMargin(0.1);
+    EXPECT_ANY_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config;
+    config.margin_data_override_type = tesseract_collision::CollisionMarginOverrideType::MODIFY;
+    config.margin_data.setDefaultCollisionMargin(0.1);
+    EXPECT_NO_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config;
+    config.margin_data.setPairCollisionMargin("a", "b", 0.1);
+    EXPECT_ANY_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config;
+    config.margin_data_override_type = tesseract_collision::CollisionMarginOverrideType::MODIFY;
+    config.margin_data.setPairCollisionMargin("a", "b", 0.1);
+    EXPECT_NO_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config;
+    config.acm.addAllowedCollision("a", "b", "never");
+    EXPECT_ANY_THROW(config.validate());  // NOLINT
+  }
+
+  {
+    tesseract_collision::ContactManagerConfig config;
+    config.acm_override_type = tesseract_collision::ACMOverrideType::OR;
+    config.acm.addAllowedCollision("a", "b", "never");
+    EXPECT_NO_THROW(config.validate());  // NOLINT
+  }
+}
 
 TEST(TesseractCoreUnit, getCollisionObjectPairsUnit)  // NOLINT
 {

--- a/tesseract_collision/test/collision_core_unit.cpp
+++ b/tesseract_collision/test/collision_core_unit.cpp
@@ -34,27 +34,20 @@ TEST(TesseractCoreUnit, ContactManagerConfig_validateUnit)  // NOLINT
 
   {
     tesseract_collision::ContactManagerConfig config;
-    config.margin_data.setDefaultCollisionMargin(0.1);
-    EXPECT_ANY_THROW(config.validate());  // NOLINT
-  }
-
-  {
-    tesseract_collision::ContactManagerConfig config;
-    config.margin_data_override_type = tesseract_collision::CollisionMarginOverrideType::MODIFY;
-    config.margin_data.setDefaultCollisionMargin(0.1);
+    config.default_margin = 0.1;
     EXPECT_NO_THROW(config.validate());  // NOLINT
   }
 
   {
     tesseract_collision::ContactManagerConfig config;
-    config.margin_data.setPairCollisionMargin("a", "b", 0.1);
+    config.pair_margin_data.setCollisionMargin("a", "b", 0.1);
     EXPECT_ANY_THROW(config.validate());  // NOLINT
   }
 
   {
     tesseract_collision::ContactManagerConfig config;
-    config.margin_data_override_type = tesseract_collision::CollisionMarginOverrideType::MODIFY;
-    config.margin_data.setPairCollisionMargin("a", "b", 0.1);
+    config.pair_margin_override_type = tesseract_collision::CollisionMarginPairOverrideType::MODIFY;
+    config.pair_margin_data.setCollisionMargin("a", "b", 0.1);
     EXPECT_NO_THROW(config.validate());  // NOLINT
   }
 
@@ -756,8 +749,7 @@ TEST(TesseractCoreUnit, CollisionCheckConfigUnit)  // NOLINT
 {
   tesseract_collision::ContactRequest request;
   tesseract_collision::CollisionCheckConfig config(
-      5, request, tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE, 0.5);
-  EXPECT_NEAR(config.contact_manager_config.margin_data.getDefaultCollisionMargin(), 5, 1e-6);
+      request, tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE, 0.5);
   EXPECT_EQ(config.type, tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE);
   EXPECT_NEAR(config.longest_valid_segment_length, 0.5, 1e-6);
 }

--- a/tesseract_collision/test/collision_margin_data_unit.cpp
+++ b/tesseract_collision/test/collision_margin_data_unit.cpp
@@ -16,8 +16,8 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     CollisionMarginData data;
     EXPECT_NEAR(data.getDefaultCollisionMargin(), 0, tol);
     EXPECT_NEAR(data.getMaxCollisionMargin(), 0, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), 0, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 0);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), 0, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 0);
   }
 
   {  // Test construction with non zero default distance
@@ -25,8 +25,8 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     CollisionMarginData data(default_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
     EXPECT_NEAR(data.getMaxCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), default_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 0);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), default_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 0);
   }
 
   {  // Test changing default margin
@@ -35,70 +35,70 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     data.setDefaultCollisionMargin(default_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
     EXPECT_NEAR(data.getMaxCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), default_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 0);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), default_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 0);
   }
 
   {  // Test adding pair margin larger than default
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test adding pair margin less than default
     double default_margin = 0.0254;
     double pair_margin = 0.01;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test setting default larger than the current max margin
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
     default_margin = 2 * pair_margin;
     data.setDefaultCollisionMargin(default_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test setting pair_margin larger than default and then set it lower so the max should be the default
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
-    data.setPairCollisionMargin("link_1", "link_2", default_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", default_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
     EXPECT_NEAR(data.getMaxCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), default_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), default_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test setting default larger than pair the change to lower than pair and the max should be the pair
     double default_margin = 0.05;
     double pair_margin = 0.0254;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
     default_margin = 0.0;
     data.setDefaultCollisionMargin(default_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test increment positive
@@ -106,12 +106,12 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     double pair_margin = 0.5;
     double increment = 0.01;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
     data.incrementMargins(increment);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin + increment, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin + increment, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin + increment, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin + increment, pair_margin + increment), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin + increment, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test increment negative
@@ -119,12 +119,12 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     double pair_margin = 0.5;
     double increment = -0.01;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
     data.incrementMargins(increment);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin + increment, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin + increment, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin + increment, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin + increment, pair_margin + increment), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin + increment, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test scale > 1
@@ -132,12 +132,12 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     double pair_margin = 0.5;
     double scale = 1.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
     data.scaleMargins(scale);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin * scale, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * scale, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin * scale, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin * scale, pair_margin * scale), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin * scale, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test scale < 1
@@ -145,143 +145,155 @@ TEST(TesseractCollisionUnit, CollisionMarginDataUnit)  // NOLINT
     double pair_margin = 0.5;
     double scale = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
     data.scaleMargins(scale);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin * scale, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * scale, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin * scale, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin * scale, pair_margin * scale), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin * scale, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test Apply Override Default
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
     default_margin = default_margin * 3;
-    CollisionMarginData override_data(default_margin);
-    data.apply(override_data, CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN);
+    data.setDefaultCollisionMargin(default_margin);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test Apply Override Link Pair
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
+    default_margin = default_margin * 3;
     pair_margin = pair_margin * 3;
-    CollisionMarginData override_data(default_margin * 3);
-    override_data.setPairCollisionMargin("link_1", "link_2", pair_margin);
-    data.apply(override_data, CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN);
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_2", pair_margin);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::MODIFY);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test Apply Override Replace
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
     default_margin = default_margin * 3;
     pair_margin = pair_margin * 3;
-    CollisionMarginData override_data(default_margin);
-    override_data.setPairCollisionMargin("link_1", "link_2", pair_margin);
-    data.apply(override_data, CollisionMarginOverrideType::REPLACE);
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_2", pair_margin);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::REPLACE);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test Apply Override None
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
-    CollisionMarginData override_data(default_margin * 3);
-    override_data.setPairCollisionMargin("link_1", "link_2", pair_margin * 3);
-    data.apply(override_data, CollisionMarginOverrideType::NONE);
+    default_margin = default_margin * 3;
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_2", pair_margin * 3);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::NONE);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 1);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 1);
   }
 
   {  // Test Apply Override Modify
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
-    CollisionMarginData override_data(default_margin * 3);
-    override_data.setPairCollisionMargin("link_1", "link_3", pair_margin * 3);
-    data.apply(override_data, CollisionMarginOverrideType::MODIFY);
-    EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin * 3, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * 3, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 2);
+    default_margin = default_margin * 3;
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_3", pair_margin * 3);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::MODIFY);
+    EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin * 3), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 2);
   }
 
   {  // Test Apply Override Modify with pair that already exists
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
     pair_margin = pair_margin * 3;
-    CollisionMarginData override_data(default_margin * 3);
-    override_data.setPairCollisionMargin("link_1", "link_2", pair_margin);
-    override_data.setPairCollisionMargin("link_1", "link_3", pair_margin * 3);
-    data.apply(override_data, CollisionMarginOverrideType::MODIFY);
-    EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin * 3, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * 3, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 2);
+    default_margin = default_margin * 3;
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_2", pair_margin);
+    override_pair_margins.setCollisionMargin("link_1", "link_3", pair_margin * 3);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::MODIFY);
+    EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin * 3), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 2);
   }
 
   {  // Test Apply Override Modify Pair
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
-    CollisionMarginData override_data(default_margin * 3);
-    override_data.setPairCollisionMargin("link_1", "link_3", pair_margin * 3);
-    data.apply(override_data, CollisionMarginOverrideType::MODIFY_PAIR_MARGIN);
+    default_margin = default_margin * 3;
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_3", pair_margin * 3);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::MODIFY);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * 3, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 2);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin * 3), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 2);
   }
 
   {  // Test Apply Override Modify Pair that already exists
     double default_margin = 0.0254;
     double pair_margin = 0.5;
     CollisionMarginData data(default_margin);
-    data.setPairCollisionMargin("link_1", "link_2", pair_margin);
+    data.setCollisionMargin("link_1", "link_2", pair_margin);
 
     pair_margin = pair_margin * 3;
-    CollisionMarginData override_data(default_margin * 3);
-    override_data.setPairCollisionMargin("link_1", "link_2", pair_margin);
-    override_data.setPairCollisionMargin("link_1", "link_3", pair_margin * 3);
-    data.apply(override_data, CollisionMarginOverrideType::MODIFY_PAIR_MARGIN);
+    default_margin = default_margin * 3;
+    CollisionMarginPairData override_pair_margins;
+    override_pair_margins.setCollisionMargin("link_1", "link_2", pair_margin);
+    override_pair_margins.setCollisionMargin("link_1", "link_3", pair_margin * 3);
+    data.setDefaultCollisionMargin(default_margin);
+    data.apply(override_pair_margins, CollisionMarginPairOverrideType::MODIFY);
     EXPECT_NEAR(data.getDefaultCollisionMargin(), default_margin, tol);
-    EXPECT_NEAR(data.getMaxCollisionMargin(), pair_margin * 3, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_2"), pair_margin, tol);
-    EXPECT_NEAR(data.getPairCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
-    EXPECT_EQ(data.getPairCollisionMargins().size(), 2);
+    EXPECT_NEAR(data.getMaxCollisionMargin(), std::max(default_margin, pair_margin * 3), tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_2"), pair_margin, tol);
+    EXPECT_NEAR(data.getCollisionMargin("link_1", "link_3"), pair_margin * 3, tol);
+    EXPECT_EQ(data.getCollisionMarginPairData().getCollisionMargins().size(), 2);
   }
 }
 

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_box_cast_unit.hpp
@@ -131,7 +131,7 @@ inline void runTest(ContinuousContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.1);
+  checker.setDefaultCollisionMargin(0.1);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
   // Set the collision object transforms

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_box_unit.hpp
@@ -138,7 +138,7 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
   checker.setCollisionMarginData(CollisionMarginData(0.1));
-  EXPECT_NEAR(checker.getCollisionMarginData().getPairCollisionMargin("box_link", "second_box_link"), 0.1, 1e-5);
+  EXPECT_NEAR(checker.getCollisionMarginData().getCollisionMargin("box_link", "second_box_link"), 0.1, 1e-5);
 
   // Set the collision object transforms
   tesseract_common::TransformMap location;
@@ -203,11 +203,11 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
   ////////////////////////////////////////////////
   {
     CollisionMarginData data = checker.getCollisionMarginData();
-    data.setPairCollisionMargin("not_box_link", "also_not_box_link", 1.7);
+    data.setCollisionMargin("not_box_link", "also_not_box_link", 1.7);
     checker.setCollisionMarginData(data);
 
     EXPECT_EQ(checker.getCollisionMarginData().getMaxCollisionMargin(), 1.7);
-    EXPECT_NEAR(checker.getCollisionMarginData().getPairCollisionMargin("box_link", "second_box_link"), 0.1, 1e-5);
+    EXPECT_NEAR(checker.getCollisionMarginData().getCollisionMargin("box_link", "second_box_link"), 0.1, 1e-5);
     location["box_link"].translation() = Eigen::Vector3d(1.60, 0, 0);
     result.clear();
     result_vector.clear();
@@ -229,10 +229,10 @@ inline void runTestTyped(DiscreteContactManager& checker, ContactTestType test_t
     result_vector.clear();
 
     CollisionMarginData data(0.1);
-    data.setPairCollisionMargin("box_link", "second_box_link", 0.25);
+    data.setCollisionMargin("box_link", "second_box_link", 0.25);
 
     checker.setCollisionMarginData(data);
-    EXPECT_NEAR(checker.getCollisionMarginData().getPairCollisionMargin("box_link", "second_box_link"), 0.25, 1e-5);
+    EXPECT_NEAR(checker.getCollisionMarginData().getCollisionMargin("box_link", "second_box_link"), 0.25, 1e-5);
     EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.25, 1e-5);
     checker.contactTest(result, ContactRequest(test_type));
     result.flattenCopyResults(result_vector);

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_capsule_unit.hpp
@@ -117,7 +117,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.1);
+  checker.setDefaultCollisionMargin(0.1);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
   // Set the collision object transforms

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_cone_unit.hpp
@@ -123,7 +123,7 @@ inline void runTest(DiscreteContactManager& checker)
   checker.setCollisionMarginData(CollisionMarginData(0.5));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
 
-  checker.setPairCollisionMarginData("box_link", "cone_link", 0.1);
+  checker.setCollisionMarginPair("box_link", "cone_link", 0.1);
 
   // Set the collision object transforms
   tesseract_common::TransformMap location;

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_box_sphere_unit.hpp
@@ -137,7 +137,7 @@ inline void runTestPrimitive(DiscreteContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.1);
+  checker.setDefaultCollisionMargin(0.1);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
   // Set the collision object transforms
@@ -250,7 +250,7 @@ inline void runTestConvex(DiscreteContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.1);
+  checker.setDefaultCollisionMargin(0.1);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
   // Set the collision object transforms

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_clone_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_clone_unit.hpp
@@ -133,7 +133,7 @@ runTest(DiscreteContactManager& checker, double dist_tol = 0.001, double nearest
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_FALSE(checker.isCollisionObjectEnabled("thin_box_link"));
 
-  checker.setPairCollisionMarginData("sphere_link", "sphere1_link", 0.1);
+  checker.setCollisionMarginPair("sphere_link", "sphere1_link", 0.1);
 
   // Test when object is inside another
   tesseract_common::TransformMap location;

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_compound_compound_unit.hpp
@@ -123,7 +123,7 @@ inline void runTestCompound(ContinuousContactManager& checker)
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
 
   // Set Pair
-  checker.setPairCollisionMarginData("octomap1_link", "octomap2_link", 0.25);
+  checker.setCollisionMarginPair("octomap1_link", "octomap2_link", 0.25);
 
   // Set the collision object transforms
   tesseract_common::TransformMap location;

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_compound_mesh_sphere_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_compound_mesh_sphere_unit.hpp
@@ -130,7 +130,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.1);
+  checker.setDefaultCollisionMargin(0.1);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
   // Set the collision object transforms

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_mesh_mesh_unit.hpp
@@ -136,7 +136,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0);
+  checker.setDefaultCollisionMargin(0);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.0, 1e-5);
 
   // Test when object is inside another

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_octomap_mesh_unit.hpp
@@ -89,7 +89,7 @@ inline void runTest(DiscreteContactManager& checker, const std::string& file_pat
   checker.setCollisionMarginData(CollisionMarginData(0.5));
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
 
-  checker.setPairCollisionMarginData("octomap_link", "plane_link", 0.1);
+  checker.setCollisionMarginPair("octomap_link", "plane_link", 0.1);
 
   // Set the collision object transforms
   tesseract_common::TransformMap location;

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/collision_octomap_sphere_unit.hpp
@@ -97,7 +97,7 @@ inline void runTestTyped(DiscreteContactManager& checker, double tol, ContactTes
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.1);
+  checker.setDefaultCollisionMargin(0.1);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
   // Set the collision object transforms

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/contact_manager_config_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/contact_manager_config_unit.hpp
@@ -133,14 +133,14 @@ inline void runTest(DiscreteContactManager& checker)
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_TRUE(checker.isCollisionObjectEnabled("thin_box_link"));
 
-  ContactManagerConfig config(0.1);
-  config.margin_data_override_type = CollisionMarginOverrideType::NONE;
+  ContactManagerConfig config;
   config.modify_object_enabled["thin_box_link"] = false;
 
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_FALSE(checker.isCollisionObjectEnabled("thin_box_link"));
 
+  config.margin_data.setDefaultCollisionMargin(0.1);
   config.margin_data_override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN;
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
@@ -241,14 +241,14 @@ inline void runTest(ContinuousContactManager& checker)
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_TRUE(checker.isCollisionObjectEnabled("thin_box_link"));
 
-  ContactManagerConfig config(0.1);
-  config.margin_data_override_type = CollisionMarginOverrideType::NONE;
+  ContactManagerConfig config;
   config.modify_object_enabled["thin_box_link"] = false;
 
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_FALSE(checker.isCollisionObjectEnabled("thin_box_link"));
 
+  config.margin_data.setDefaultCollisionMargin(0.1);
   config.margin_data_override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN;
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);

--- a/tesseract_collision/test_suite/include/tesseract_collision/test_suite/contact_manager_config_unit.hpp
+++ b/tesseract_collision/test_suite/include/tesseract_collision/test_suite/contact_manager_config_unit.hpp
@@ -129,7 +129,7 @@ inline void runTest(DiscreteContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.5);
+  checker.setDefaultCollisionMargin(0.5);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_TRUE(checker.isCollisionObjectEnabled("thin_box_link"));
 
@@ -140,8 +140,7 @@ inline void runTest(DiscreteContactManager& checker)
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_FALSE(checker.isCollisionObjectEnabled("thin_box_link"));
 
-  config.margin_data.setDefaultCollisionMargin(0.1);
-  config.margin_data_override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN;
+  config.default_margin = 0.1;
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 
@@ -237,7 +236,7 @@ inline void runTest(ContinuousContactManager& checker)
 
   EXPECT_TRUE(checker.getContactAllowedValidator() == nullptr);
 
-  checker.setDefaultCollisionMarginData(0.5);
+  checker.setDefaultCollisionMargin(0.5);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_TRUE(checker.isCollisionObjectEnabled("thin_box_link"));
 
@@ -248,8 +247,7 @@ inline void runTest(ContinuousContactManager& checker)
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.5, 1e-5);
   EXPECT_FALSE(checker.isCollisionObjectEnabled("thin_box_link"));
 
-  config.margin_data.setDefaultCollisionMargin(0.1);
-  config.margin_data_override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN;
+  config.default_margin = 0.1;
   checker.applyContactManagerConfig(config);
   EXPECT_NEAR(checker.getCollisionMarginData().getMaxCollisionMargin(), 0.1, 1e-5);
 

--- a/tesseract_common/CMakeLists.txt
+++ b/tesseract_common/CMakeLists.txt
@@ -74,6 +74,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 

--- a/tesseract_common/include/tesseract_common/collision_margin_data.h
+++ b/tesseract_common/include/tesseract_common/collision_margin_data.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
 #include <string>
 #include <unordered_map>
+#include <optional>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/types.h>
@@ -47,32 +48,107 @@ class access;
 namespace tesseract_common
 {
 /** @brief Identifies how the provided contact margin data should be applied */
-enum class CollisionMarginOverrideType : std::uint8_t
+enum class CollisionMarginPairOverrideType : std::uint8_t
 {
   /** @brief Do not apply contact margin data */
   NONE,
-  /** @brief Replace the contact manager's CollisionMarginData */
+  /** @brief Replace the contact manager's CollisionMarginPairData */
   REPLACE,
   /**
-   * @brief Modify the contact managers default margin and pair margins
+   * @brief Modify the contact managers pair margins
    * @details This will preserve existing pairs not being modified by the provided margin data.
    * If a pair already exist it will be updated with the provided margin data.
    */
-  MODIFY,
-  /** @brief Override the contact managers default margin only */
-  OVERRIDE_DEFAULT_MARGIN,
-  /** @brief Override the contact managers pair margin only. This does not preserve any existing pair margin data */
-  OVERRIDE_PAIR_MARGIN,
-  /**
-   * @brief Modify the contact managers pair margin only.
-   * @details This will preserve existing pairs not being modified by the provided margin data.
-   * If a pair already exist it will be updated with the provided margin data.
-   */
-  MODIFY_PAIR_MARGIN
+  MODIFY
 };
 
 using PairsCollisionMarginData =
     std::unordered_map<tesseract_common::LinkNamesPair, double, tesseract_common::PairHash>;
+
+class CollisionMarginPairData
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  /**
+   * @brief Set the margin for a given contact pair
+   *        * The order of the object names does not matter, that is handled internal to
+   * the class.
+   *        * @param obj1 The first object name. Order doesn't matter
+   * @param obj2 The Second object name. Order doesn't matter
+   * @param margin contacts with distance < collision_margin are considered in collision
+   */
+  void setCollisionMargin(const std::string& obj1, const std::string& obj2, double margin);
+
+  /**
+   * @brief Get the pairs collision margin data
+   *
+   * If a collision margin for the request pair does not exist it returns the default collision margin data.
+   *
+   * @param obj1 The first object name
+   * @param obj2 The second object name
+   * @return A link pair contact margin if exists
+   */
+  std::optional<double> getCollisionMargin(const std::string& obj1, const std::string& obj2) const;
+
+  /**
+   * @brief Get the largest pair collision margin
+   * @return Max pair contact distance threshold
+   */
+  double getMaxCollisionMargin() const;
+
+  /**
+   * @brief Get Collision Margin Data for stored pairs
+   * @return A map of link pairs collision margin data
+   */
+  const PairsCollisionMarginData& getCollisionMargins() const;
+
+  /**
+   * @brief Increment all margins by input amount. Useful for inflating or reducing margins
+   * @param increment Amount to increment margins
+   */
+  void incrementMargins(double increment);
+
+  /**
+   * @brief Scale all margins by input value
+   * @param scale Value by which all margins are multiplied
+   */
+  void scaleMargins(double scale);
+
+  /**
+   * @brief Check if empty
+   * @return True if empty otherwise false
+   */
+  bool empty() const;
+
+  /**
+   * @brief Clear/Reset the data structure
+   */
+  void clear();
+
+  /**
+   * @brief Apply the contents of the provide CollisionMarginPairData based on the override type
+   * @param pair_margin_data The collision margin pair data to apply
+   * @param override_type The type indicating how the provided data should be applied.
+   */
+  void apply(const CollisionMarginPairData& pair_margin_data, CollisionMarginPairOverrideType override_type);
+
+  bool operator==(const CollisionMarginPairData& rhs) const;
+  bool operator!=(const CollisionMarginPairData& rhs) const;
+
+private:
+  /** @brief A map of link pair names to contact distance */
+  PairsCollisionMarginData lookup_table_;
+
+  /** @brief Stores the largest collision margin */
+  double max_collision_margin_{ std::numeric_limits<double>::lowest() };
+
+  /** @brief Recalculate the max margin */
+  void updateCollisionMarginMax();
+
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version);  // NOLINT
+};
 
 /** @brief Stores information about how the margins allowed between collision objects */
 class CollisionMarginData
@@ -84,8 +160,8 @@ public:
   using ConstPtr = std::shared_ptr<const CollisionMarginData>;
 
   CollisionMarginData(double default_collision_margin = 0);
-  CollisionMarginData(double default_collision_margin, PairsCollisionMarginData pair_collision_margins);
-  CollisionMarginData(PairsCollisionMarginData pair_collision_margins);
+  CollisionMarginData(double default_collision_margin, CollisionMarginPairData pair_collision_margins);
+  CollisionMarginData(CollisionMarginPairData pair_collision_margins);
 
   /**
    * @brief Set the default collision margin
@@ -109,7 +185,7 @@ public:
    * @param obj2 The Second object name. Order doesn't matter
    * @param collision_margin contacts with distance < collision_margin are considered in collision
    */
-  void setPairCollisionMargin(const std::string& obj1, const std::string& obj2, double collision_margin);
+  void setCollisionMargin(const std::string& obj1, const std::string& obj2, double collision_margin);
 
   /**
    * @brief Get the pairs collision margin data
@@ -120,13 +196,13 @@ public:
    * @param obj2 The second object name
    * @return A Vector2d[Contact Distance Threshold, Coefficient]
    */
-  double getPairCollisionMargin(const std::string& obj1, const std::string& obj2) const;
+  double getCollisionMargin(const std::string& obj1, const std::string& obj2) const;
 
   /**
    * @brief Get Collision Margin Data for stored pairs
    * @return A map of link pairs collision margin data
    */
-  const PairsCollisionMarginData& getPairCollisionMargins() const;
+  const CollisionMarginPairData& getCollisionMarginPairData() const;
 
   /**
    * @brief Get the largest collision margin
@@ -150,11 +226,11 @@ public:
   void scaleMargins(double scale);
 
   /**
-   * @brief Apply the contents of the provide CollisionMarginData based on the override type
-   * @param collision_margin_data The collision margin data to apply
+   * @brief Apply the contents of the provide CollisionMarginPairData based on the override type
+   * @param pair_margin_data The collision margin pair data to apply
    * @param override_type The type indicating how the provided data should be applied.
    */
-  void apply(const CollisionMarginData& collision_margin_data, CollisionMarginOverrideType override_type);
+  void apply(const CollisionMarginPairData& pair_margin_data, CollisionMarginPairOverrideType override_type);
 
   bool operator==(const CollisionMarginData& rhs) const;
   bool operator!=(const CollisionMarginData& rhs) const;
@@ -163,19 +239,15 @@ private:
   /** @brief Stores the collision margin used if no pair-specific one is set */
   double default_collision_margin_{ 0 };
 
-  /** @brief Stores the largest collision margin */
-  double max_collision_margin_{ 0 };
-
   /** @brief A map of link pair names to contact distance */
-  PairsCollisionMarginData lookup_table_;
-
-  /** @brief Update the max collision margin */
-  void updateMaxCollisionMargin();
+  CollisionMarginPairData pair_margins_;
 
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 };
 }  // namespace tesseract_common
+
+BOOST_CLASS_EXPORT_KEY(tesseract_common::CollisionMarginPairData)
 BOOST_CLASS_EXPORT_KEY(tesseract_common::CollisionMarginData)
 #endif  // TESSERACT_COMMON_COLLISION_MARGIN_DATA_H

--- a/tesseract_common/src/collision_margin_data.cpp
+++ b/tesseract_common/src/collision_margin_data.cpp
@@ -39,42 +39,15 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_common
 {
-CollisionMarginData::CollisionMarginData(double default_collision_margin)
-  : default_collision_margin_(default_collision_margin), max_collision_margin_(default_collision_margin)
-{
-}
-
-CollisionMarginData::CollisionMarginData(double default_collision_margin,
-                                         PairsCollisionMarginData pair_collision_margins)
-  : default_collision_margin_(default_collision_margin), lookup_table_(std::move(pair_collision_margins))
-{
-  updateMaxCollisionMargin();
-}
-
-CollisionMarginData::CollisionMarginData(PairsCollisionMarginData pair_collision_margins)
-  : lookup_table_(std::move(pair_collision_margins))
-{
-  updateMaxCollisionMargin();
-}
-
-void CollisionMarginData::setDefaultCollisionMargin(double default_collision_margin)
-{
-  default_collision_margin_ = default_collision_margin;
-  updateMaxCollisionMargin();
-}
-
-double CollisionMarginData::getDefaultCollisionMargin() const { return default_collision_margin_; }
-
-void CollisionMarginData::setPairCollisionMargin(const std::string& obj1,
-                                                 const std::string& obj2,
-                                                 double collision_margin)
+void CollisionMarginPairData::setCollisionMargin(const std::string& obj1, const std::string& obj2, double margin)
 {
   auto key = tesseract_common::makeOrderedLinkPair(obj1, obj2);
-  lookup_table_[key] = collision_margin;
-  updateMaxCollisionMargin();
+  lookup_table_[key] = margin;
+  updateCollisionMarginMax();
 }
 
-double CollisionMarginData::getPairCollisionMargin(const std::string& obj1, const std::string& obj2) const
+std::optional<double> CollisionMarginPairData::getCollisionMargin(const std::string& obj1,
+                                                                  const std::string& obj2) const
 {
   thread_local LinkNamesPair key;
   tesseract_common::makeOrderedLinkPair(key, obj1, obj2);
@@ -83,88 +56,76 @@ double CollisionMarginData::getPairCollisionMargin(const std::string& obj1, cons
   if (it != lookup_table_.end())
     return it->second;
 
-  return default_collision_margin_;
+  return {};
 }
 
-const PairsCollisionMarginData& CollisionMarginData::getPairCollisionMargins() const { return lookup_table_; }
+double CollisionMarginPairData::getMaxCollisionMargin() const { return max_collision_margin_; }
 
-double CollisionMarginData::getMaxCollisionMargin() const { return max_collision_margin_; }
+const PairsCollisionMarginData& CollisionMarginPairData::getCollisionMargins() const { return lookup_table_; }
 
-void CollisionMarginData::incrementMargins(double increment)
+void CollisionMarginPairData::incrementMargins(double increment)
 {
-  default_collision_margin_ += increment;
+  if (lookup_table_.empty())
+    return;
+
   max_collision_margin_ += increment;
   for (auto& pair : lookup_table_)
     pair.second += increment;
 }
 
-void CollisionMarginData::scaleMargins(double scale)
+void CollisionMarginPairData::scaleMargins(double scale)
 {
-  default_collision_margin_ *= scale;
+  if (lookup_table_.empty())
+    return;
+
   max_collision_margin_ *= scale;
   for (auto& pair : lookup_table_)
     pair.second *= scale;
 }
 
-void CollisionMarginData::apply(const CollisionMarginData& collision_margin_data,
-                                CollisionMarginOverrideType override_type)
+bool CollisionMarginPairData::empty() const { return lookup_table_.empty(); }
+
+void CollisionMarginPairData::clear()
+{
+  lookup_table_.clear();
+  max_collision_margin_ = std::numeric_limits<double>::lowest();
+}
+
+void CollisionMarginPairData::updateCollisionMarginMax()
+{
+  max_collision_margin_ = std::numeric_limits<double>::lowest();
+  for (const auto& pair : lookup_table_)
+    max_collision_margin_ = std::max(max_collision_margin_, pair.second);
+}
+
+void CollisionMarginPairData::apply(const CollisionMarginPairData& pair_margin_data,
+                                    CollisionMarginPairOverrideType override_type)
 {
   switch (override_type)
   {
-    case CollisionMarginOverrideType::REPLACE:
+    case CollisionMarginPairOverrideType::REPLACE:
     {
-      *this = collision_margin_data;
+      *this = pair_margin_data;
       break;
     }
-    case CollisionMarginOverrideType::MODIFY:
+    case CollisionMarginPairOverrideType::MODIFY:
     {
-      default_collision_margin_ = collision_margin_data.default_collision_margin_;
-
-      for (const auto& p : collision_margin_data.lookup_table_)
+      for (const auto& p : pair_margin_data.lookup_table_)
         lookup_table_[p.first] = p.second;
 
-      updateMaxCollisionMargin();
+      updateCollisionMarginMax();
       break;
     }
-    case CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN:
-    {
-      default_collision_margin_ = collision_margin_data.default_collision_margin_;
-      updateMaxCollisionMargin();
-      break;
-    }
-    case CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN:
-    {
-      lookup_table_ = collision_margin_data.lookup_table_;
-      updateMaxCollisionMargin();
-      break;
-    }
-    case CollisionMarginOverrideType::MODIFY_PAIR_MARGIN:
-    {
-      for (const auto& p : collision_margin_data.lookup_table_)
-        lookup_table_[p.first] = p.second;
-
-      updateMaxCollisionMargin();
-      break;
-    }
-    case CollisionMarginOverrideType::NONE:
+    case CollisionMarginPairOverrideType::NONE:
     {
       break;
     }
   }
 }
 
-void CollisionMarginData::updateMaxCollisionMargin()
-{
-  max_collision_margin_ = default_collision_margin_;
-  for (const auto& p : lookup_table_)
-    max_collision_margin_ = std::max(p.second, max_collision_margin_);
-}
-
-bool CollisionMarginData::operator==(const CollisionMarginData& rhs) const
+bool CollisionMarginPairData::operator==(const CollisionMarginPairData& rhs) const
 {
   bool ret_val = true;
-  ret_val &=
-      (tesseract_common::almostEqualRelativeAndAbs(default_collision_margin_, rhs.default_collision_margin_, 1e-5));
   ret_val &= (tesseract_common::almostEqualRelativeAndAbs(max_collision_margin_, rhs.max_collision_margin_, 1e-5));
   ret_val &= (lookup_table_.size() == rhs.lookup_table_.size());
   if (ret_val)
@@ -184,17 +145,101 @@ bool CollisionMarginData::operator==(const CollisionMarginData& rhs) const
   return ret_val;
 }
 
+bool CollisionMarginPairData::operator!=(const CollisionMarginPairData& rhs) const { return !operator==(rhs); }
+
+template <class Archive>
+void CollisionMarginPairData::serialize(Archive& ar, const unsigned int /*version*/)
+{
+  ar& BOOST_SERIALIZATION_NVP(lookup_table_);
+  ar& BOOST_SERIALIZATION_NVP(max_collision_margin_);
+}
+
+CollisionMarginData::CollisionMarginData(double default_collision_margin)
+  : default_collision_margin_(default_collision_margin)
+{
+}
+
+CollisionMarginData::CollisionMarginData(double default_collision_margin,
+                                         CollisionMarginPairData pair_collision_margins)
+  : default_collision_margin_(default_collision_margin), pair_margins_(std::move(pair_collision_margins))
+{
+}
+
+CollisionMarginData::CollisionMarginData(CollisionMarginPairData pair_collision_margins)
+  : pair_margins_(std::move(pair_collision_margins))
+{
+}
+
+void CollisionMarginData::setDefaultCollisionMargin(double default_collision_margin)
+{
+  default_collision_margin_ = default_collision_margin;
+}
+
+double CollisionMarginData::getDefaultCollisionMargin() const { return default_collision_margin_; }
+
+void CollisionMarginData::setCollisionMargin(const std::string& obj1, const std::string& obj2, double margin)
+{
+  pair_margins_.setCollisionMargin(obj1, obj2, margin);
+}
+
+double CollisionMarginData::getCollisionMargin(const std::string& obj1, const std::string& obj2) const
+{
+  std::optional<double> margin = pair_margins_.getCollisionMargin(obj1, obj2);
+  if (margin.has_value())
+    return margin.value();
+
+  return default_collision_margin_;
+}
+
+const CollisionMarginPairData& CollisionMarginData::getCollisionMarginPairData() const { return pair_margins_; }
+
+double CollisionMarginData::getMaxCollisionMargin() const
+{
+  if (pair_margins_.empty())
+    return default_collision_margin_;
+
+  return std::max(default_collision_margin_, pair_margins_.getMaxCollisionMargin());
+}
+
+void CollisionMarginData::incrementMargins(double increment)
+{
+  default_collision_margin_ += increment;
+  pair_margins_.incrementMargins(increment);
+}
+
+void CollisionMarginData::scaleMargins(double scale)
+{
+  default_collision_margin_ *= scale;
+  pair_margins_.scaleMargins(scale);
+}
+
+void CollisionMarginData::apply(const CollisionMarginPairData& pair_margin_data,
+                                CollisionMarginPairOverrideType override_type)
+{
+  pair_margins_.apply(pair_margin_data, override_type);
+}
+
+bool CollisionMarginData::operator==(const CollisionMarginData& rhs) const
+{
+  bool ret_val = true;
+  ret_val &=
+      (tesseract_common::almostEqualRelativeAndAbs(default_collision_margin_, rhs.default_collision_margin_, 1e-5));
+  ret_val &= (pair_margins_ == rhs.pair_margins_);
+  return ret_val;
+}
+
 bool CollisionMarginData::operator!=(const CollisionMarginData& rhs) const { return !operator==(rhs); }
 
 template <class Archive>
 void CollisionMarginData::serialize(Archive& ar, const unsigned int /*version*/)
 {
   ar& BOOST_SERIALIZATION_NVP(default_collision_margin_);
-  ar& BOOST_SERIALIZATION_NVP(max_collision_margin_);
-  ar& BOOST_SERIALIZATION_NVP(lookup_table_);
+  ar& BOOST_SERIALIZATION_NVP(pair_margins_);
 }
 }  // namespace tesseract_common
 
 #include <tesseract_common/serialization.h>
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_common::CollisionMarginPairData)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_common::CollisionMarginPairData)
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_common::CollisionMarginData)
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_common::CollisionMarginData)

--- a/tesseract_common/test/tesseract_common_serialization_unit.cpp
+++ b/tesseract_common/test/tesseract_common_serialization_unit.cpp
@@ -126,10 +126,10 @@ TEST(TesseractCommonSerializeUnit, CollisionMarginData)  // NOLINT
 {
   auto object = std::make_shared<CollisionMarginData>();
   tesseract_common::testSerialization<CollisionMarginData>(*object, "EmptyCollisionMarginData");
-  object->setPairCollisionMargin("link_1", "link2", 1.1);
-  object->setPairCollisionMargin("link_2", "link1", 2.2);
-  object->setPairCollisionMargin("link_4", "link3", 3.3);
-  object->setPairCollisionMargin("link_5", "link2", -4.4);
+  object->setCollisionMargin("link_1", "link2", 1.1);
+  object->setCollisionMargin("link_2", "link1", 2.2);
+  object->setCollisionMargin("link_4", "link3", 3.3);
+  object->setCollisionMargin("link_5", "link2", -4.4);
   tesseract_common::testSerialization<CollisionMarginData>(*object, "CollisionMarginData");
 }
 

--- a/tesseract_common/test/tesseract_common_unit.cpp
+++ b/tesseract_common/test/tesseract_common_unit.cpp
@@ -2607,9 +2607,9 @@ TEST(TesseractCommonUnit, CollisionMarginDataCompare)  // NOLINT
 
   {  // EQUAL with pair data
     tesseract_common::CollisionMarginData margin_data1;
-    margin_data1.setPairCollisionMargin("link_1", "link_2", 1);
+    margin_data1.setCollisionMargin("link_1", "link_2", 1);
     tesseract_common::CollisionMarginData margin_data2;
-    margin_data2.setPairCollisionMargin("link_1", "link_2", 1);
+    margin_data2.setCollisionMargin("link_1", "link_2", 1);
 
     EXPECT_TRUE(margin_data1 == margin_data2);
   }
@@ -2623,28 +2623,28 @@ TEST(TesseractCommonUnit, CollisionMarginDataCompare)  // NOLINT
 
   {  // Not EQUAL with pair data
     tesseract_common::CollisionMarginData margin_data1;
-    margin_data1.setPairCollisionMargin("link_1", "link_2", 1);
+    margin_data1.setCollisionMargin("link_1", "link_2", 1);
     tesseract_common::CollisionMarginData margin_data2;
-    margin_data2.setPairCollisionMargin("link_1", "link_2", 1);
-    margin_data2.setPairCollisionMargin("link_1", "link_3", 1);
+    margin_data2.setCollisionMargin("link_1", "link_2", 1);
+    margin_data2.setCollisionMargin("link_1", "link_3", 1);
 
     EXPECT_FALSE(margin_data1 == margin_data2);
   }
 
   {  // Not EQUAL with pair data
     tesseract_common::CollisionMarginData margin_data1;
-    margin_data1.setPairCollisionMargin("link_1", "link_2", 1);
+    margin_data1.setCollisionMargin("link_1", "link_2", 1);
     tesseract_common::CollisionMarginData margin_data2;
-    margin_data2.setPairCollisionMargin("link_1", "link_2", 2);
+    margin_data2.setCollisionMargin("link_1", "link_2", 2);
 
     EXPECT_FALSE(margin_data1 == margin_data2);
   }
 
   {  // Not EQUAL with pair data
     tesseract_common::CollisionMarginData margin_data1;
-    margin_data1.setPairCollisionMargin("link_1", "link_2", 1);
+    margin_data1.setCollisionMargin("link_1", "link_2", 1);
     tesseract_common::CollisionMarginData margin_data2;
-    margin_data2.setPairCollisionMargin("link_1", "link_3", 1);
+    margin_data2.setCollisionMargin("link_1", "link_3", 1);
 
     EXPECT_FALSE(margin_data1 == margin_data2);
   }

--- a/tesseract_environment/CMakeLists.txt
+++ b/tesseract_environment/CMakeLists.txt
@@ -41,6 +41,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*
     /*/bullet/LinearMath/*
     /*/bullet/BulletCollision/*)

--- a/tesseract_environment/include/tesseract_environment/commands/change_collision_margins_command.h
+++ b/tesseract_environment/include/tesseract_environment/commands/change_collision_margins_command.h
@@ -29,6 +29,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
+#include <optional>
 #include <boost/serialization/export.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -42,9 +43,8 @@ class access;
 
 namespace tesseract_environment
 {
-using CollisionMarginData = tesseract_common::CollisionMarginData;
-using CollisionMarginOverrideType = tesseract_common::CollisionMarginOverrideType;
-using PairsCollisionMarginData = tesseract_common::PairsCollisionMarginData;
+using CollisionMarginPairData = tesseract_common::CollisionMarginPairData;
+using CollisionMarginPairOverrideType = tesseract_common::CollisionMarginPairOverrideType;
 
 class ChangeCollisionMarginsCommand : public Command
 {
@@ -54,28 +54,37 @@ public:
 
   ChangeCollisionMarginsCommand();
 
+  ChangeCollisionMarginsCommand(double default_margin);
+
+  ChangeCollisionMarginsCommand(
+      CollisionMarginPairData pair_margins,
+      CollisionMarginPairOverrideType pair_override_type = CollisionMarginPairOverrideType::MODIFY);
+
   ChangeCollisionMarginsCommand(
       double default_margin,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN);
+      CollisionMarginPairData pair_margins,
+      CollisionMarginPairOverrideType pair_override_type = CollisionMarginPairOverrideType::MODIFY);
 
-  ChangeCollisionMarginsCommand(
-      PairsCollisionMarginData pairs_margin,
-      CollisionMarginOverrideType override_type = CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN);
-
-  ChangeCollisionMarginsCommand(CollisionMarginData collision_margin_data,
-                                CollisionMarginOverrideType override_type = CollisionMarginOverrideType::REPLACE);
-
-  tesseract_common::CollisionMarginData getCollisionMarginData() const;
-  tesseract_common::CollisionMarginOverrideType getCollisionMarginOverrideType() const;
+  std::optional<double> getDefaultCollisionMargin() const;
+  CollisionMarginPairData getCollisionMarginPairData() const;
+  CollisionMarginPairOverrideType getCollisionMarginPairOverrideType() const;
 
   bool operator==(const ChangeCollisionMarginsCommand& rhs) const;
   bool operator!=(const ChangeCollisionMarginsCommand& rhs) const;
 
 private:
-  CollisionMarginData collision_margin_data_;
-  CollisionMarginOverrideType collision_margin_override_{ CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN };
+  std::optional<double> default_margin_;
+  CollisionMarginPairData pair_margins_;
+  CollisionMarginPairOverrideType pair_override_type_{ CollisionMarginPairOverrideType::NONE };
 
   friend class boost::serialization::access;
+
+  template <class Archive>
+  void load(Archive& ar, const unsigned int version);  // NOLINT
+
+  template <class Archive>
+  void save(Archive& ar, const unsigned int version) const;  // NOLINT
+
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 };

--- a/tesseract_environment/include/tesseract_environment/utils.h
+++ b/tesseract_environment/include/tesseract_environment/utils.h
@@ -58,20 +58,6 @@ void getActiveLinkNamesRecursive(std::vector<std::string>& active_links,
                                  bool active);
 
 /**
- * @brief Should perform a continuous collision check between two states configuring the manager with the config
- * @param contact_results The contact results to populate. It does not get cleared
- * @param manager A continuous contact manager
- * @param state0 First environment state
- * @param state1 Second environment state
- * @param config CollisionCheckConfig used to specify collision check settings
- */
-void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_results,
-                            tesseract_collision::ContinuousContactManager& manager,
-                            const tesseract_common::TransformMap& state0,
-                            const tesseract_common::TransformMap& state1,
-                            const tesseract_collision::CollisionCheckConfig& config);
-
-/**
  * @brief Should perform a continuous collision check between two states only passing along the contact_request to the
  * manager
  * @param contact_results The contact results to populate. It does not get cleared
@@ -85,18 +71,6 @@ void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_resul
                             const tesseract_common::TransformMap& state0,
                             const tesseract_common::TransformMap& state1,
                             const tesseract_collision::ContactRequest& contact_request);
-
-/**
- * @brief Should perform a discrete collision check a state first configuring manager with config
- * @param contact_results The contact results to populate. It does not get cleared
- * @param manager A discrete contact manager
- * @param state First environment state
- * @param config CollisionCheckConfig used to specify collision check settings
- */
-void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
-                          tesseract_collision::DiscreteContactManager& manager,
-                          const tesseract_common::TransformMap& state,
-                          const tesseract_collision::CollisionCheckConfig& config);
 
 /**
  * @brief Should perform a discrete collision check a state first configuring manager with config

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -78,31 +78,12 @@ void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_resul
                             tesseract_collision::ContinuousContactManager& manager,
                             const tesseract_common::TransformMap& state0,
                             const tesseract_common::TransformMap& state1,
-                            const tesseract_collision::CollisionCheckConfig& config)
-{
-  manager.applyContactManagerConfig(config.contact_manager_config);
-  checkTrajectorySegment(contact_results, manager, state0, state1, config.contact_request);
-}
-
-void checkTrajectorySegment(tesseract_collision::ContactResultMap& contact_results,
-                            tesseract_collision::ContinuousContactManager& manager,
-                            const tesseract_common::TransformMap& state0,
-                            const tesseract_common::TransformMap& state1,
                             const tesseract_collision::ContactRequest& contact_request)
 {
   for (const auto& link_name : manager.getActiveCollisionObjects())
     manager.setCollisionObjectsTransform(link_name, state0.at(link_name), state1.at(link_name));
 
   manager.contactTest(contact_results, contact_request);
-}
-
-void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
-                          tesseract_collision::DiscreteContactManager& manager,
-                          const tesseract_common::TransformMap& state,
-                          const tesseract_collision::CollisionCheckConfig& config)
-{
-  manager.applyContactManagerConfig(config.contact_manager_config);
-  checkTrajectoryState(contact_results, manager, state, config.contact_request);
 }
 
 void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results,
@@ -190,8 +171,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
   if (traj.rows() < 2)
     throw std::runtime_error("checkTrajectory was given continuous contact manager with a trajectory that only has one "
                              "state.");
-
-  manager.applyContactManagerConfig(config.contact_manager_config);
 
   bool debug_logging = console_bridge::getLogLevel() < console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO;
 
@@ -495,8 +474,6 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
 
   if (traj.rows() == 0)
     throw std::runtime_error("checkTrajectory was given continuous contact manager with empty trajectory.");
-
-  manager.applyContactManagerConfig(config.contact_manager_config);
 
   bool debug_logging = console_bridge::getLogLevel() < console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO;
 

--- a/tesseract_environment/test/tesseract_environment_collision.cpp
+++ b/tesseract_environment/test/tesseract_environment_collision.cpp
@@ -105,12 +105,12 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentDiscreteCollisionTest)  //
   auto env = getEnvironment();
 
   // Setup collision margin data
-  CollisionCheckConfig mCollisionCheckConfig;
-  mCollisionCheckConfig.longest_valid_segment_length = 0.1;
-  mCollisionCheckConfig.contact_request.type = tesseract_collision::ContactTestType::FIRST;
-  mCollisionCheckConfig.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
-  tesseract_collision::CollisionMarginData margin_data(0.0);
-  mCollisionCheckConfig.contact_manager_config.margin_data = margin_data;
+  CollisionCheckConfig collision_check_config;
+  collision_check_config.longest_valid_segment_length = 0.1;
+  collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+  collision_check_config.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
+
+  ContactManagerConfig contact_manager_config(0.0);
 
   {  // Setup collision checker
     DiscreteContactManager::Ptr manager = env->getDiscreteContactManager();
@@ -118,18 +118,18 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentDiscreteCollisionTest)  //
       tesseract_collision::ContactResultMap collision;
       std::vector<std::string> active_links = { "link_n1" };
       manager->setActiveCollisionObjects(active_links);
-      manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+      manager->contactTest(collision, collision_check_config.contact_request);
       EXPECT_FALSE(collision.empty());
     }
 
     auto pose = Eigen::Isometry3d::Identity();
     pose.translation() = Eigen::Vector3d(0, 0, 1.5);
     manager->setCollisionObjectsTransform("link_n1", pose);
-    manager->setCollisionMarginData(mCollisionCheckConfig.contact_manager_config.margin_data);
+    manager->applyContactManagerConfig(contact_manager_config);
 
     // Check for collisions
     tesseract_collision::ContactResultMap collision;
-    manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+    manager->contactTest(collision, collision_check_config.contact_request);
 
     EXPECT_FALSE(collision.empty());
   }
@@ -142,18 +142,18 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentDiscreteCollisionTest)  //
       tesseract_collision::ContactResultMap collision;
       std::vector<std::string> active_links = { "link_n1" };
       manager->setActiveCollisionObjects(active_links);
-      manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+      manager->contactTest(collision, collision_check_config.contact_request);
       EXPECT_FALSE(collision.empty());
     }
 
     auto pose = Eigen::Isometry3d::Identity();
     pose.translation() = Eigen::Vector3d(0, 0, 1.5);
     manager->setCollisionObjectsTransform("link_n1", pose);
-    manager->setCollisionMarginData(mCollisionCheckConfig.contact_manager_config.margin_data);
+    manager->applyContactManagerConfig(contact_manager_config);
 
     // Check for collisions
     tesseract_collision::ContactResultMap collision;
-    manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+    manager->contactTest(collision, collision_check_config.contact_request);
 
     EXPECT_FALSE(collision.empty());
   }
@@ -165,12 +165,12 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentContinuousCollisionTest)  
   auto env = getEnvironment();
 
   // Setup collision margin data
-  CollisionCheckConfig mCollisionCheckConfig;
-  mCollisionCheckConfig.longest_valid_segment_length = 0.1;
-  mCollisionCheckConfig.contact_request.type = tesseract_collision::ContactTestType::FIRST;
-  mCollisionCheckConfig.type = tesseract_collision::CollisionEvaluatorType::CONTINUOUS;
-  tesseract_collision::CollisionMarginData margin_data(0.0);
-  mCollisionCheckConfig.contact_manager_config.margin_data = margin_data;
+  CollisionCheckConfig collision_check_config;
+  collision_check_config.longest_valid_segment_length = 0.1;
+  collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+  collision_check_config.type = tesseract_collision::CollisionEvaluatorType::CONTINUOUS;
+
+  ContactManagerConfig contact_manager_config(0.0);
 
   // Setup collision checker
   ContinuousContactManager::Ptr manager = env->getContinuousContactManager();
@@ -178,7 +178,7 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentContinuousCollisionTest)  
     tesseract_collision::ContactResultMap collision;
     std::vector<std::string> active_links = { "link_n1" };
     manager->setActiveCollisionObjects(active_links);
-    manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+    manager->contactTest(collision, collision_check_config.contact_request);
     EXPECT_FALSE(collision.empty());
   }
 
@@ -187,11 +187,11 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentContinuousCollisionTest)  
   auto pose2 = Eigen::Isometry3d::Identity();
   pose2.translation() = Eigen::Vector3d(0, 2, 1.5);
   manager->setCollisionObjectsTransform("link_n1", pose1, pose2);
-  manager->setCollisionMarginData(mCollisionCheckConfig.contact_manager_config.margin_data);
+  manager->applyContactManagerConfig(contact_manager_config);
 
   // Check for collisions
   tesseract_collision::ContactResultMap collision;
-  manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+  manager->contactTest(collision, collision_check_config.contact_request);
 
   EXPECT_FALSE(collision.empty());
 }
@@ -203,12 +203,12 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentClearDiscreteCollisionTest
   env->clearCachedDiscreteContactManager();
 
   // Setup collision margin data
-  CollisionCheckConfig mCollisionCheckConfig;
-  mCollisionCheckConfig.longest_valid_segment_length = 0.1;
-  mCollisionCheckConfig.contact_request.type = tesseract_collision::ContactTestType::FIRST;
-  mCollisionCheckConfig.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
-  tesseract_collision::CollisionMarginData margin_data(0.0);
-  mCollisionCheckConfig.contact_manager_config.margin_data = margin_data;
+  CollisionCheckConfig collision_check_config;
+  collision_check_config.longest_valid_segment_length = 0.1;
+  collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+  collision_check_config.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
+
+  ContactManagerConfig contact_manager_config(0.0);
 
   // Setup collision checker
   DiscreteContactManager::Ptr manager = env->getDiscreteContactManager();
@@ -216,18 +216,18 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentClearDiscreteCollisionTest
     tesseract_collision::ContactResultMap collision;
     std::vector<std::string> active_links = { "link_n1" };
     manager->setActiveCollisionObjects(active_links);
-    manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+    manager->contactTest(collision, collision_check_config.contact_request);
     EXPECT_FALSE(collision.empty());
   }
 
   auto pose = Eigen::Isometry3d::Identity();
   pose.translation() = Eigen::Vector3d(0, 0, 1.5);
   manager->setCollisionObjectsTransform("link_n1", pose);
-  manager->setCollisionMarginData(mCollisionCheckConfig.contact_manager_config.margin_data);
+  manager->applyContactManagerConfig(contact_manager_config);
 
   // Check for collisions
   tesseract_collision::ContactResultMap collision;
-  manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+  manager->contactTest(collision, collision_check_config.contact_request);
 
   EXPECT_FALSE(collision.empty());
 }
@@ -239,12 +239,12 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentClearContinuousCollisionTe
   env->clearCachedContinuousContactManager();
 
   // Setup collision margin data
-  CollisionCheckConfig mCollisionCheckConfig;
-  mCollisionCheckConfig.longest_valid_segment_length = 0.1;
-  mCollisionCheckConfig.contact_request.type = tesseract_collision::ContactTestType::FIRST;
-  mCollisionCheckConfig.type = tesseract_collision::CollisionEvaluatorType::CONTINUOUS;
-  tesseract_collision::CollisionMarginData margin_data(0.0);
-  mCollisionCheckConfig.contact_manager_config.margin_data = margin_data;
+  CollisionCheckConfig collision_check_config;
+  collision_check_config.longest_valid_segment_length = 0.1;
+  collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+  collision_check_config.type = tesseract_collision::CollisionEvaluatorType::CONTINUOUS;
+
+  ContactManagerConfig contact_manager_config(0.0);
 
   // Setup collision checker
   ContinuousContactManager::Ptr manager = env->getContinuousContactManager();
@@ -252,7 +252,7 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentClearContinuousCollisionTe
     tesseract_collision::ContactResultMap collision;
     std::vector<std::string> active_links = { "link_n1" };
     manager->setActiveCollisionObjects(active_links);
-    manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+    manager->contactTest(collision, collision_check_config.contact_request);
     EXPECT_FALSE(collision.empty());
   }
 
@@ -261,11 +261,11 @@ TEST(TesseractEnvironmentCollisionUnit, runEnvironmentClearContinuousCollisionTe
   auto pose2 = Eigen::Isometry3d::Identity();
   pose2.translation() = Eigen::Vector3d(0, 2, 1.5);
   manager->setCollisionObjectsTransform("link_n1", pose1, pose2);
-  manager->setCollisionMarginData(mCollisionCheckConfig.contact_manager_config.margin_data);
+  manager->applyContactManagerConfig(contact_manager_config);
 
   // Check for collisions
   tesseract_collision::ContactResultMap collision;
-  manager->contactTest(collision, mCollisionCheckConfig.contact_request);
+  manager->contactTest(collision, collision_check_config.contact_request);
 
   EXPECT_FALSE(collision.empty());
 }

--- a/tesseract_environment/test/tesseract_environment_serialization_unit.cpp
+++ b/tesseract_environment/test/tesseract_environment_serialization_unit.cpp
@@ -176,9 +176,10 @@ TEST(EnvironmentCommandsSerializeUnit, AddSceneGraphCommand)  // NOLINT
 
 TEST(EnvironmentCommandsSerializeUnit, ChangeCollisionMarginsCommand)  // NOLINT
 {
-  CollisionMarginData collision_margin_data = getEnvironment()->getCollisionMarginData();
-  auto object = std::make_shared<ChangeCollisionMarginsCommand>(collision_margin_data,
-                                                                CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN);
+  CollisionMarginPairData pair_margin_data;
+  pair_margin_data.setCollisionMargin("a", "b", 0.2);
+  auto object =
+      std::make_shared<ChangeCollisionMarginsCommand>(0.1, pair_margin_data, CollisionMarginPairOverrideType::MODIFY);
   testSerialization<ChangeCollisionMarginsCommand>(*object, "ChangeCollisionMarginsCommand");
   testSerializationDerivedClass<Command, ChangeCollisionMarginsCommand>(object, "ChangeCollisionMarginsCommand");
 }

--- a/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -1377,55 +1377,52 @@ TEST(TesseractEnvironmentUnit, EnvChangeCollisionMarginsCommandUnit)  // NOLINT
     EXPECT_EQ(env->getRevision(), 3);
     EXPECT_EQ(env->getInitRevision(), 3);
     EXPECT_EQ(env->getCommandHistory().size(), 3);
-    EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0.0,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0.0,
-        1e-6);
+    EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                0.0,
+                1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                0.0,
+                1e-6);
 
     // Test MODIFY_PAIR_MARGIN
-    tesseract_common::CollisionMarginData collision_margin_data;
-    collision_margin_data.setPairCollisionMargin(link_name1, link_name2, margin);
-    tesseract_common::CollisionMarginOverrideType overrid_type =
-        tesseract_common::CollisionMarginOverrideType::MODIFY_PAIR_MARGIN;
+    tesseract_common::CollisionMarginPairData pair_margin_data;
+    pair_margin_data.setCollisionMargin(link_name1, link_name2, margin);
+    tesseract_common::CollisionMarginPairOverrideType overrid_type =
+        tesseract_common::CollisionMarginPairOverrideType::MODIFY;
 
-    auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(collision_margin_data, overrid_type);
+    auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(pair_margin_data, overrid_type);
     EXPECT_TRUE(cmd != nullptr);
     EXPECT_EQ(cmd->getType(), CommandType::CHANGE_COLLISION_MARGINS);
-    EXPECT_EQ(cmd->getCollisionMarginData(), collision_margin_data);
-    EXPECT_EQ(cmd->getCollisionMarginOverrideType(), tesseract_common::CollisionMarginOverrideType::MODIFY_PAIR_MARGIN);
+    EXPECT_FALSE(cmd->getDefaultCollisionMargin().has_value());
+    EXPECT_EQ(cmd->getCollisionMarginPairData(), pair_margin_data);
+    EXPECT_EQ(cmd->getCollisionMarginPairOverrideType(), tesseract_common::CollisionMarginPairOverrideType::MODIFY);
     EXPECT_TRUE(env->applyCommand(cmd));
 
     EXPECT_EQ(env->getRevision(), 4);
     EXPECT_EQ(env->getInitRevision(), 3);
     EXPECT_EQ(env->getCommandHistory().size(), 4);
     EXPECT_EQ(env->getCommandHistory().back(), cmd);
-    EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        margin,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        margin,
-        1e-6);
+    EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                margin,
+                1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                margin,
+                1e-6);
 
     // Test
     std::string link_name3 = "link_3";
     std::string link_name4 = "link_4";
     margin = 0.2;
-    collision_margin_data = tesseract_common::CollisionMarginData();
-    collision_margin_data.setPairCollisionMargin(link_name3, link_name4, margin);
-    overrid_type = tesseract_common::CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN;
+    pair_margin_data = tesseract_common::CollisionMarginPairData();
+    pair_margin_data.setCollisionMargin(link_name3, link_name4, margin);
+    overrid_type = tesseract_common::CollisionMarginPairOverrideType::REPLACE;
 
-    cmd = std::make_shared<ChangeCollisionMarginsCommand>(collision_margin_data, overrid_type);
+    cmd = std::make_shared<ChangeCollisionMarginsCommand>(pair_margin_data, overrid_type);
     EXPECT_TRUE(cmd != nullptr);
     EXPECT_EQ(cmd->getType(), CommandType::CHANGE_COLLISION_MARGINS);
-    EXPECT_EQ(cmd->getCollisionMarginData(), collision_margin_data);
-    EXPECT_EQ(cmd->getCollisionMarginOverrideType(),
-              tesseract_common::CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN);
+    EXPECT_FALSE(cmd->getDefaultCollisionMargin().has_value());
+    EXPECT_EQ(cmd->getCollisionMarginPairData(), pair_margin_data);
+    EXPECT_EQ(cmd->getCollisionMarginPairOverrideType(), tesseract_common::CollisionMarginPairOverrideType::REPLACE);
     EXPECT_TRUE(env->applyCommand(cmd));
 
     EXPECT_EQ(env->getRevision(), 5);
@@ -1434,21 +1431,16 @@ TEST(TesseractEnvironmentUnit, EnvChangeCollisionMarginsCommandUnit)  // NOLINT
     EXPECT_EQ(env->getCommandHistory().back(), cmd);
     // Link1 and Link2 should be reset
     EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0,
-        1e-6);
-    EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name3, link_name4),
-        margin,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name3, link_name4),
-        margin,
-        1e-6);
+        env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2), 0, 1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                0,
+                1e-6);
+    EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name3, link_name4),
+                margin,
+                1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name3, link_name4),
+                margin,
+                1e-6);
   }
 
   {  // OVERRIDE_DEFAULT_MARGIN Unit Test
@@ -1459,16 +1451,14 @@ TEST(TesseractEnvironmentUnit, EnvChangeCollisionMarginsCommandUnit)  // NOLINT
     EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getDefaultCollisionMargin(), 0.0, 1e-6);
     EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getDefaultCollisionMargin(), 0.0, 1e-6);
 
-    tesseract_common::CollisionMarginData collision_margin_data(0.1);
-    tesseract_common::CollisionMarginOverrideType overrid_type =
-        tesseract_common::CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN;
-
-    auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(collision_margin_data, overrid_type);
+    const double defaut_margin{ 0.1 };
+    auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(defaut_margin);
     EXPECT_TRUE(cmd != nullptr);
     EXPECT_EQ(cmd->getType(), CommandType::CHANGE_COLLISION_MARGINS);
-    EXPECT_EQ(cmd->getCollisionMarginData(), collision_margin_data);
-    EXPECT_EQ(cmd->getCollisionMarginOverrideType(),
-              tesseract_common::CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN);
+    EXPECT_TRUE(cmd->getDefaultCollisionMargin().has_value());
+    EXPECT_NEAR(cmd->getDefaultCollisionMargin().value(), defaut_margin, 0.0001);  // NOLINT
+    EXPECT_TRUE(cmd->getCollisionMarginPairData().empty());
+    EXPECT_EQ(cmd->getCollisionMarginPairOverrideType(), tesseract_common::CollisionMarginPairOverrideType::NONE);
     EXPECT_TRUE(env->applyCommand(cmd));
 
     EXPECT_EQ(env->getRevision(), 4);
@@ -1488,57 +1478,51 @@ TEST(TesseractEnvironmentUnit, EnvChangeCollisionMarginsCommandUnit)  // NOLINT
     EXPECT_EQ(env->getRevision(), 3);
     EXPECT_EQ(env->getInitRevision(), 3);
     EXPECT_EQ(env->getCommandHistory().size(), 3);
-    EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0.0,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0.0,
-        1e-6);
+    EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                0.0,
+                1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                0.0,
+                1e-6);
 
     // Test MODIFY_PAIR_MARGIN constructor
-    PairsCollisionMarginData pcmd;
-    auto key = tesseract_common::makeOrderedLinkPair(link_name1, link_name2);
-    pcmd[key] = margin;
-    tesseract_common::CollisionMarginOverrideType overrid_type =
-        tesseract_common::CollisionMarginOverrideType::MODIFY_PAIR_MARGIN;
+    CollisionMarginPairData pcmd;
+    pcmd.setCollisionMargin(link_name1, link_name2, margin);
+    auto overrid_type = tesseract_common::CollisionMarginPairOverrideType::MODIFY;
 
     auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(pcmd, overrid_type);
     EXPECT_TRUE(cmd != nullptr);
     EXPECT_EQ(cmd->getType(), CommandType::CHANGE_COLLISION_MARGINS);
-    EXPECT_EQ(cmd->getCollisionMarginData().getPairCollisionMargins(), pcmd);
-    EXPECT_EQ(cmd->getCollisionMarginOverrideType(), tesseract_common::CollisionMarginOverrideType::MODIFY_PAIR_MARGIN);
+    EXPECT_FALSE(cmd->getDefaultCollisionMargin().has_value());
+    EXPECT_EQ(cmd->getCollisionMarginPairData(), pcmd);
+    EXPECT_EQ(cmd->getCollisionMarginPairOverrideType(), overrid_type);
     EXPECT_TRUE(env->applyCommand(cmd));
 
     EXPECT_EQ(env->getRevision(), 4);
     EXPECT_EQ(env->getInitRevision(), 3);
     EXPECT_EQ(env->getCommandHistory().size(), 4);
     EXPECT_EQ(env->getCommandHistory().back(), cmd);
-    EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        margin,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        margin,
-        1e-6);
+    EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                margin,
+                1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                margin,
+                1e-6);
 
     // Test
     std::string link_name3 = "link_3";
     std::string link_name4 = "link_4";
     margin = 0.2;
     pcmd.clear();
-    key = tesseract_common::makeOrderedLinkPair(link_name3, link_name4);
-    pcmd[key] = margin;
-    overrid_type = tesseract_common::CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN;
+    pcmd.setCollisionMargin(link_name3, link_name4, margin);
+    overrid_type = tesseract_common::CollisionMarginPairOverrideType::REPLACE;
 
     cmd = std::make_shared<ChangeCollisionMarginsCommand>(pcmd, overrid_type);
     EXPECT_TRUE(cmd != nullptr);
     EXPECT_EQ(cmd->getType(), CommandType::CHANGE_COLLISION_MARGINS);
-    EXPECT_EQ(cmd->getCollisionMarginData().getPairCollisionMargins(), pcmd);
-    EXPECT_EQ(cmd->getCollisionMarginOverrideType(),
-              tesseract_common::CollisionMarginOverrideType::OVERRIDE_PAIR_MARGIN);
+    EXPECT_FALSE(cmd->getDefaultCollisionMargin().has_value());
+    EXPECT_EQ(cmd->getCollisionMarginPairData(), pcmd);
+    EXPECT_EQ(cmd->getCollisionMarginPairOverrideType(), overrid_type);
     EXPECT_TRUE(env->applyCommand(cmd));
 
     EXPECT_EQ(env->getRevision(), 5);
@@ -1547,21 +1531,16 @@ TEST(TesseractEnvironmentUnit, EnvChangeCollisionMarginsCommandUnit)  // NOLINT
     EXPECT_EQ(env->getCommandHistory().back(), cmd);
     // Link1 and Link2 should be reset
     EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name1, link_name2),
-        0,
-        1e-6);
-    EXPECT_NEAR(
-        env->getDiscreteContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name3, link_name4),
-        margin,
-        1e-6);
-    EXPECT_NEAR(
-        env->getContinuousContactManager()->getCollisionMarginData().getPairCollisionMargin(link_name3, link_name4),
-        margin,
-        1e-6);
+        env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2), 0, 1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name1, link_name2),
+                0,
+                1e-6);
+    EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getCollisionMargin(link_name3, link_name4),
+                margin,
+                1e-6);
+    EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getCollisionMargin(link_name3, link_name4),
+                margin,
+                1e-6);
   }
 
   {  // OVERRIDE_DEFAULT_MARGIN Constructor Unit Test
@@ -1572,15 +1551,12 @@ TEST(TesseractEnvironmentUnit, EnvChangeCollisionMarginsCommandUnit)  // NOLINT
     EXPECT_NEAR(env->getDiscreteContactManager()->getCollisionMarginData().getDefaultCollisionMargin(), 0.0, 1e-6);
     EXPECT_NEAR(env->getContinuousContactManager()->getCollisionMarginData().getDefaultCollisionMargin(), 0.0, 1e-6);
 
-    tesseract_common::CollisionMarginOverrideType overrid_type =
-        tesseract_common::CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN;
-
-    auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(0.1, overrid_type);
+    auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(0.1);
     EXPECT_TRUE(cmd != nullptr);
     EXPECT_EQ(cmd->getType(), CommandType::CHANGE_COLLISION_MARGINS);
-    EXPECT_EQ(cmd->getCollisionMarginData().getDefaultCollisionMargin(), 0.1);
-    EXPECT_EQ(cmd->getCollisionMarginOverrideType(),
-              tesseract_common::CollisionMarginOverrideType::OVERRIDE_DEFAULT_MARGIN);
+    EXPECT_NEAR(cmd->getDefaultCollisionMargin().value(), 0.1, 0.00001);  // NOLINT
+    EXPECT_TRUE(cmd->getCollisionMarginPairData().empty());
+    EXPECT_EQ(cmd->getCollisionMarginPairOverrideType(), tesseract_common::CollisionMarginPairOverrideType::NONE);
     EXPECT_TRUE(env->applyCommand(cmd));
 
     EXPECT_EQ(env->getRevision(), 4);
@@ -2370,11 +2346,11 @@ TEST(TesseractEnvironmentUnit, EnvClone)  // NOLINT
   EXPECT_FALSE(env->getEventCallbacks().empty());
 
   // Modifying collision margin from default
-  tesseract_common::CollisionMarginData collision_margin_data(0.1);
-  collision_margin_data.setPairCollisionMargin("link_1", "link_2", 0.1);
-  tesseract_common::CollisionMarginOverrideType overrid_type = tesseract_common::CollisionMarginOverrideType::REPLACE;
+  tesseract_common::CollisionMarginPairData pair_margin_data;
+  pair_margin_data.setCollisionMargin("link_1", "link_2", 0.1);
+  auto overrid_type = tesseract_common::CollisionMarginPairOverrideType::REPLACE;
 
-  auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(collision_margin_data, overrid_type);
+  auto cmd = std::make_shared<ChangeCollisionMarginsCommand>(0.1, pair_margin_data, overrid_type);
   env->applyCommand(cmd);
   auto timestamp = env->getTimestamp();
   auto current_state_timestamp = env->getCurrentStateTimestamp();

--- a/tesseract_environment/test/tesseract_environment_utils.cpp
+++ b/tesseract_environment/test/tesseract_environment_utils.cpp
@@ -58,9 +58,7 @@ void checkIsAllowedFnOverride(std::unique_ptr<ManagerType> manager)
     // Manager currently allows: a
     config.contact_manager_config.acm.addAllowedCollision("allowed_link_1b", "allowed_link_2b", "Unit test");
     config.contact_manager_config.acm_override_type = ACMOverrideType::NONE;
-    manager->applyContactManagerConfig(config.contact_manager_config);
-    auto fn = manager->getContactAllowedValidator();
-    EXPECT_FALSE((*fn)("allowed_link_1b", "allowed_link_2b"));
+    EXPECT_ANY_THROW(manager->applyContactManagerConfig(config.contact_manager_config));  // NOLINT
   }
 
   // OR

--- a/tesseract_geometry/CMakeLists.txt
+++ b/tesseract_geometry/CMakeLists.txt
@@ -58,6 +58,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 

--- a/tesseract_kinematics/CMakeLists.txt
+++ b/tesseract_kinematics/CMakeLists.txt
@@ -38,6 +38,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*
     /*/bullet/LinearMath/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})

--- a/tesseract_scene_graph/CMakeLists.txt
+++ b/tesseract_scene_graph/CMakeLists.txt
@@ -37,6 +37,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 

--- a/tesseract_srdf/CMakeLists.txt
+++ b/tesseract_srdf/CMakeLists.txt
@@ -37,6 +37,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*
     /*/bullet/LinearMath/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})

--- a/tesseract_srdf/src/collision_margins.cpp
+++ b/tesseract_srdf/src/collision_margins.cpp
@@ -43,8 +43,6 @@ tesseract_common::CollisionMarginData::Ptr parseCollisionMargins(const tesseract
                                                                  const std::array<int, 3>& /*version*/)
 {
   double default_margin{ 0 };
-  tesseract_common::PairsCollisionMarginData pair_margins;
-
   const tinyxml2::XMLElement* xml_element = srdf_xml->FirstChildElement("collision_margins");
   if (xml_element == nullptr)
     return nullptr;
@@ -54,6 +52,7 @@ tesseract_common::CollisionMarginData::Ptr parseCollisionMargins(const tesseract
     std::throw_with_nested(std::runtime_error("CollisionMargins: collision_margins missing attribute "
                                               "'default_margin'."));
 
+  auto margin_data = std::make_shared<tesseract_common::CollisionMarginData>(default_margin);
   for (const tinyxml2::XMLElement* xml_pair_element = xml_element->FirstChildElement("pair_margin");
        xml_pair_element != nullptr;
        xml_pair_element = xml_pair_element->NextSiblingElement("pair_margin"))
@@ -84,10 +83,9 @@ tesseract_common::CollisionMarginData::Ptr parseCollisionMargins(const tesseract
       std::throw_with_nested(std::runtime_error("parseCollisionMargins: failed to parse link pair 'margin' "
                                                 "attribute."));
 
-    auto key = tesseract_common::makeOrderedLinkPair(link1_name, link2_name);
-    pair_margins[key] = link_pair_margin;
+    margin_data->setCollisionMargin(link1_name, link2_name, link_pair_margin);
   }
 
-  return std::make_shared<tesseract_common::CollisionMarginData>(default_margin, pair_margins);
+  return margin_data;
 }
 }  // namespace tesseract_srdf

--- a/tesseract_srdf/src/srdf_model.cpp
+++ b/tesseract_srdf/src/srdf_model.cpp
@@ -395,7 +395,7 @@ bool SRDFModel::saveToFile(const std::string& file_path) const
   {
     tinyxml2::XMLElement* xml_cm_entry = doc.NewElement("collision_margins");
     xml_cm_entry->SetAttribute("default_margin", collision_margin_data->getDefaultCollisionMargin());
-    for (const auto& entry : collision_margin_data->getPairCollisionMargins())
+    for (const auto& entry : collision_margin_data->getCollisionMarginPairData().getCollisionMargins())
     {
       tinyxml2::XMLElement* xml_cm_pair_entry = doc.NewElement("pair_margin");
       xml_cm_pair_entry->SetAttribute("link1", entry.first.first.c_str());

--- a/tesseract_srdf/test/tesseract_srdf_unit.cpp
+++ b/tesseract_srdf/test/tesseract_srdf_unit.cpp
@@ -762,9 +762,9 @@ TEST(TesseractSRDFUnit, LoadSRDFSaveUnit)  // NOLINT
   EXPECT_TRUE(srdf.collision_margin_data != nullptr);
   EXPECT_NEAR(srdf.collision_margin_data->getDefaultCollisionMargin(), 0.025, 1e-6);
   EXPECT_NEAR(srdf.collision_margin_data->getMaxCollisionMargin(), 0.025, 1e-6);
-  EXPECT_EQ(srdf.collision_margin_data->getPairCollisionMargins().size(), 2);
-  EXPECT_NEAR(srdf.collision_margin_data->getPairCollisionMargin("link_5", "link_6"), 0.01, 1e-6);
-  EXPECT_NEAR(srdf.collision_margin_data->getPairCollisionMargin("link_5", "link_4"), 0.015, 1e-6);
+  EXPECT_EQ(srdf.collision_margin_data->getCollisionMarginPairData().getCollisionMargins().size(), 2);
+  EXPECT_NEAR(srdf.collision_margin_data->getCollisionMargin("link_5", "link_6"), 0.01, 1e-6);
+  EXPECT_NEAR(srdf.collision_margin_data->getCollisionMargin("link_5", "link_4"), 0.015, 1e-6);
 
   // Calibration failure joint does not exist
   yaml_calibration_string =
@@ -1573,9 +1573,9 @@ TEST(TesseractSRDFUnit, SRDFCollisionMarginsUnit)  // NOLINT
     EXPECT_TRUE(margin_data != nullptr);
     EXPECT_NEAR(margin_data->getDefaultCollisionMargin(), 0.025, 1e-6);
     EXPECT_NEAR(margin_data->getMaxCollisionMargin(), 0.025, 1e-6);
-    EXPECT_EQ(margin_data->getPairCollisionMargins().size(), 2);
-    EXPECT_NEAR(margin_data->getPairCollisionMargin("link_5", "link_6"), 0.01, 1e-6);
-    EXPECT_NEAR(margin_data->getPairCollisionMargin("link_5", "link_4"), 0.015, 1e-6);
+    EXPECT_EQ(margin_data->getCollisionMarginPairData().getCollisionMargins().size(), 2);
+    EXPECT_NEAR(margin_data->getCollisionMargin("link_5", "link_6"), 0.01, 1e-6);
+    EXPECT_NEAR(margin_data->getCollisionMargin("link_5", "link_4"), 0.015, 1e-6);
   }
 
   {  // Test only having default margin
@@ -1595,7 +1595,7 @@ TEST(TesseractSRDFUnit, SRDFCollisionMarginsUnit)  // NOLINT
     EXPECT_TRUE(margin_data != nullptr);
     EXPECT_NEAR(margin_data->getDefaultCollisionMargin(), 0.025, 1e-6);
     EXPECT_NEAR(margin_data->getMaxCollisionMargin(), 0.025, 1e-6);
-    EXPECT_EQ(margin_data->getPairCollisionMargins().size(), 0);
+    EXPECT_EQ(margin_data->getCollisionMarginPairData().getCollisionMargins().size(), 0);
   }
 
   {  // Testing having negative default margin and pair margin
@@ -1618,9 +1618,9 @@ TEST(TesseractSRDFUnit, SRDFCollisionMarginsUnit)  // NOLINT
     EXPECT_TRUE(margin_data != nullptr);
     EXPECT_NEAR(margin_data->getDefaultCollisionMargin(), -0.025, 1e-6);
     EXPECT_NEAR(margin_data->getMaxCollisionMargin(), -0.01, 1e-6);
-    EXPECT_EQ(margin_data->getPairCollisionMargins().size(), 2);
-    EXPECT_NEAR(margin_data->getPairCollisionMargin("link_5", "link_6"), -0.01, 1e-6);
-    EXPECT_NEAR(margin_data->getPairCollisionMargin("link_5", "link_4"), -0.015, 1e-6);
+    EXPECT_EQ(margin_data->getCollisionMarginPairData().getCollisionMargins().size(), 2);
+    EXPECT_NEAR(margin_data->getCollisionMargin("link_5", "link_6"), -0.01, 1e-6);
+    EXPECT_NEAR(margin_data->getCollisionMargin("link_5", "link_4"), -0.015, 1e-6);
   }
 
   {  // Test not having collision margin data

--- a/tesseract_state_solver/CMakeLists.txt
+++ b/tesseract_state_solver/CMakeLists.txt
@@ -37,6 +37,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*
     /*/bullet/LinearMath/*
     /*/bullet/BulletCollision/*)

--- a/tesseract_urdf/CMakeLists.txt
+++ b/tesseract_urdf/CMakeLists.txt
@@ -39,6 +39,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*
     /*/bullet/LinearMath/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})

--- a/tesseract_visualization/CMakeLists.txt
+++ b/tesseract_visualization/CMakeLists.txt
@@ -53,6 +53,8 @@ set(COVERAGE_EXCLUDE
     /usr/*
     /opt/*
     ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
     /*/gtest/*)
 add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 


### PR DESCRIPTION
This adds a validate method to the ContactManagerConfig which is used in the contact manager's apply config method. This check for common issues where a users sets data but does not set the override type for either margin data or the allowed collision matrix. If a discrepancy is found it throws an exception.

Note: The default acm_override_type has been changed to NONE to allow validations requiring the user to set the override type when providing acm data.