### PR TITLE
Make printouts during convex decomposition optional at compute time

### DIFF
--- a/tesseract_collision/bullet/include/tesseract_collision/bullet/convex_decomposition_hacd.h
+++ b/tesseract_collision/bullet/include/tesseract_collision/bullet/convex_decomposition_hacd.h
@@ -55,7 +55,8 @@ public:
   ConvexDecompositionHACD(const HACDParameters& params);
 
   std::vector<std::shared_ptr<tesseract_geometry::ConvexMesh>> compute(const tesseract_common::VectorVector3d& vertices,
-                                                                       const Eigen::VectorXi& faces) const override;
+                                                                       const Eigen::VectorXi& faces,
+                                                                       bool verbose = true) const override;
 
 private:
   HACDParameters params_;

--- a/tesseract_collision/bullet/src/convex_decomposition_hacd.cpp
+++ b/tesseract_collision/bullet/src/convex_decomposition_hacd.cpp
@@ -17,9 +17,12 @@ namespace tesseract_collision
 ConvexDecompositionHACD::ConvexDecompositionHACD(const HACDParameters& params) : params_(params) {}
 
 std::vector<tesseract_geometry::ConvexMesh::Ptr>
-ConvexDecompositionHACD::compute(const tesseract_common::VectorVector3d& vertices, const Eigen::VectorXi& faces) const
+ConvexDecompositionHACD::compute(const tesseract_common::VectorVector3d& vertices,
+                                 const Eigen::VectorXi& faces,
+                                 bool verbose) const
 {
-  params_.print();
+  if (verbose)
+    params_.print();
 
   std::vector<HACD::Vec3<HACD::Real>> points_local;
   points_local.reserve(vertices.size());

--- a/tesseract_collision/core/include/tesseract_collision/core/convex_decomposition.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/convex_decomposition.h
@@ -53,7 +53,9 @@ public:
    * @return
    */
   virtual std::vector<std::shared_ptr<tesseract_geometry::ConvexMesh>>
-  compute(const tesseract_common::VectorVector3d& vertices, const Eigen::VectorXi& faces) const = 0;
+  compute(const tesseract_common::VectorVector3d& vertices,
+          const Eigen::VectorXi& faces,
+          bool verbose = true) const = 0;
 };
 
 }  // namespace tesseract_collision

--- a/tesseract_collision/vhacd/include/tesseract_collision/vhacd/convex_decomposition_vhacd.h
+++ b/tesseract_collision/vhacd/include/tesseract_collision/vhacd/convex_decomposition_vhacd.h
@@ -73,7 +73,8 @@ public:
   ConvexDecompositionVHACD(const VHACDParameters& params);
 
   std::vector<std::shared_ptr<tesseract_geometry::ConvexMesh>> compute(const tesseract_common::VectorVector3d& vertices,
-                                                                       const Eigen::VectorXi& faces) const override;
+                                                                       const Eigen::VectorXi& faces,
+                                                                       bool verbose = true) const override;
 
 private:
   VHACDParameters params_;


### PR DESCRIPTION
Currently whenever running a convex decomposition there is a lot of print outs to the terminal through cout. This change gives users the ability to suppress the printouts when running the `compute` operation. The default behavior will be to keep the printouts unless explicitly ignored.