### PR TITLE
Improve processYamlIncludeDirective peformance

### DIFF
--- a/tesseract_collision/core/src/contact_managers_plugin_factory.cpp
+++ b/tesseract_collision/core/src/contact_managers_plugin_factory.cpp
@@ -78,7 +78,7 @@ ContactManagersPluginFactory::ContactManagersPluginFactory(YAML::Node config,
                                                            const tesseract_common::ResourceLocator& locator)
   : ContactManagersPluginFactory()
 {
-  config = tesseract_common::processYamlIncludeDirective(config, locator);
+  tesseract_common::processYamlIncludeDirective(config, locator);
   loadConfig(config);
 }
 

--- a/tesseract_collision/test/contact_managers_factory_unit.cpp
+++ b/tesseract_collision/test/contact_managers_factory_unit.cpp
@@ -41,8 +41,8 @@ void runContactManagersFactoryTest(const std::filesystem::path& config_path)
 {
   tesseract_common::GeneralResourceLocator locator;
   ContactManagersPluginFactory factory(config_path, locator);
-  YAML::Node plugin_config =
-      tesseract_common::processYamlIncludeDirective(YAML::LoadFile(config_path.string()), locator);
+  YAML::Node plugin_config = YAML::LoadFile(config_path.string());
+  tesseract_common::processYamlIncludeDirective(plugin_config, locator);
 
   const YAML::Node& plugin_info = plugin_config["contact_manager_plugins"];
   const YAML::Node& search_paths = plugin_info["search_paths"];

--- a/tesseract_kinematics/core/src/kinematics_plugin_factory.cpp
+++ b/tesseract_kinematics/core/src/kinematics_plugin_factory.cpp
@@ -76,7 +76,7 @@ void KinematicsPluginFactory::loadConfig(const YAML::Node& config)
 KinematicsPluginFactory::KinematicsPluginFactory(YAML::Node config, const tesseract_common::ResourceLocator& locator)
   : KinematicsPluginFactory()
 {
-  config = tesseract_common::processYamlIncludeDirective(config, locator);
+  tesseract_common::processYamlIncludeDirective(config, locator);
   loadConfig(config);
 }
 

--- a/tesseract_srdf/src/configs.cpp
+++ b/tesseract_srdf/src/configs.cpp
@@ -71,7 +71,8 @@ tesseract_common::CalibrationInfo parseCalibrationConfig(const tesseract_scene_g
   YAML::Node config;
   try
   {
-    config = tesseract_common::processYamlIncludeDirective(YAML::LoadFile(cal_config_file_path.string()), locator);
+    config = YAML::LoadFile(cal_config_file_path.string());
+    tesseract_common::processYamlIncludeDirective(config, locator);
   }
   // LCOV_EXCL_START
   catch (...)
@@ -103,7 +104,8 @@ tesseract_common::KinematicsPluginInfo parseKinematicsPluginConfig(const tessera
   YAML::Node config;
   try
   {
-    config = tesseract_common::processYamlIncludeDirective(YAML::LoadFile(kin_plugin_file_path.string()), locator);
+    config = YAML::LoadFile(kin_plugin_file_path.string());
+    tesseract_common::processYamlIncludeDirective(config, locator);
   }
   // LCOV_EXCL_START
   catch (...)
@@ -128,7 +130,8 @@ parseContactManagersPluginConfig(const tesseract_common::ResourceLocator& locato
   YAML::Node config;
   try
   {
-    config = tesseract_common::processYamlIncludeDirective(YAML::LoadFile(cm_plugin_file_path.string()), locator);
+    config = YAML::LoadFile(cm_plugin_file_path.string());
+    tesseract_common::processYamlIncludeDirective(config, locator);
   }
   // LCOV_EXCL_START
   catch (...)


### PR DESCRIPTION
There was performance issues with the processYamlIncludeDirective utility function for process yaml include directive described [here](https://github.com/tesseract-robotics/tesseract_planning/issues/631). The issues was related to it was make a lot of copies and temporary variable leading to performance issues. The utility function was switched to perform an in place modification to avoid the copying and temporary variables. Running @marrts tests showed significant improvement in performance. The increase time with subseqent calls to this function providing the same root yaml node that @marrts was seeing with the original version was not a bug but dues to the copying leading to memory fragmentation. Improved performance was seen if the root yaml node was copied for each call to this utility function because it avoided further fragmentation by subsequent calls. This eliminates all of the performance issues. 

``` bash
[ RUN      ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimes
LoadFromYAMLNode - Iteration 0: 0.0025129 seconds
LoadFromYAMLNode - Iteration 1: 0.00246715 seconds
LoadFromYAMLNode - Iteration 2: 0.00245628 seconds
LoadFromYAMLNode - Iteration 3: 0.00252871 seconds
LoadFromYAMLNode - Iteration 4: 0.00241525 seconds
LoadFromYAMLNode - Iteration 5: 0.00244365 seconds
LoadFromYAMLNode - Iteration 6: 0.00248993 seconds
LoadFromYAMLNode - Iteration 7: 0.00245497 seconds
LoadFromYAMLNode - Iteration 8: 0.00245399 seconds
LoadFromYAMLNode - Iteration 9: 0.00245424 seconds
[       OK ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimes (39 ms)
[ RUN      ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesInLambda
LoadFromYAMLNodeInLambda - Iteration 0: 0.0112949 seconds
LoadFromYAMLNodeInLambda - Iteration 1: 0.0108168 seconds
LoadFromYAMLNodeInLambda - Iteration 2: 0.00995502 seconds
LoadFromYAMLNodeInLambda - Iteration 3: 0.0100914 seconds
LoadFromYAMLNodeInLambda - Iteration 4: 0.00988284 seconds
LoadFromYAMLNodeInLambda - Iteration 5: 0.00991026 seconds
LoadFromYAMLNodeInLambda - Iteration 6: 0.00981341 seconds
LoadFromYAMLNodeInLambda - Iteration 7: 0.0098652 seconds
LoadFromYAMLNodeInLambda - Iteration 8: 0.00987714 seconds
LoadFromYAMLNodeInLambda - Iteration 9: 0.00982666 seconds
[       OK ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesInLambda (108 ms)
[ RUN      ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromFile
LoadFromFile - Iteration 0: 0.00968818 seconds
LoadFromFile - Iteration 1: 0.00994258 seconds
LoadFromFile - Iteration 2: 0.00987963 seconds
LoadFromFile - Iteration 3: 0.00986209 seconds
LoadFromFile - Iteration 4: 0.0098535 seconds
LoadFromFile - Iteration 5: 0.00988402 seconds
LoadFromFile - Iteration 6: 0.00991647 seconds
LoadFromFile - Iteration 7: 0.00983936 seconds
LoadFromFile - Iteration 8: 0.00983395 seconds
LoadFromFile - Iteration 9: 0.0098544 seconds
[       OK ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromFile (105 ms)
[ RUN      ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromString
LoadFromString - Iteration 0: 0.00960518 seconds
LoadFromString - Iteration 1: 0.00983733 seconds
LoadFromString - Iteration 2: 0.0098431 seconds
LoadFromString - Iteration 3: 0.00982748 seconds
LoadFromString - Iteration 4: 0.00983228 seconds
LoadFromString - Iteration 5: 0.00987957 seconds
LoadFromString - Iteration 6: 0.00984989 seconds
LoadFromString - Iteration 7: 0.00980705 seconds
LoadFromString - Iteration 8: 0.00981286 seconds
LoadFromString - Iteration 9: 0.00981619 seconds
[       OK ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromString (108 ms)
[ RUN      ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromFileWithLoadYamlFile
LoadFromFileWithLoadYamlFile - Iteration 0: 0.0121618 seconds
LoadFromFileWithLoadYamlFile - Iteration 1: 0.0124574 seconds
LoadFromFileWithLoadYamlFile - Iteration 2: 0.0122788 seconds
LoadFromFileWithLoadYamlFile - Iteration 3: 0.0124815 seconds
LoadFromFileWithLoadYamlFile - Iteration 4: 0.0121901 seconds
LoadFromFileWithLoadYamlFile - Iteration 5: 0.0123093 seconds
LoadFromFileWithLoadYamlFile - Iteration 6: 0.0131223 seconds
LoadFromFileWithLoadYamlFile - Iteration 7: 0.0123557 seconds
LoadFromFileWithLoadYamlFile - Iteration 8: 0.0123174 seconds
LoadFromFileWithLoadYamlFile - Iteration 9: 0.0123413 seconds
[       OK ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromFileWithLoadYamlFile (131 ms)
[ RUN      ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromFileWithLoadYamlFileOutside
LoadFromFileWithLoadYamlFileOutside - Iteration 0: 0.00272064 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 1: 0.00268493 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 2: 0.00255984 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 3: 0.00254237 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 4: 0.00259301 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 5: 0.0025772 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 6: 0.00256622 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 7: 0.00262096 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 8: 0.00266498 seconds
LoadFromFileWithLoadYamlFileOutside - Iteration 9: 0.00254694 seconds
[       OK ] TesseractTaskComposerFactoryUnit.LoadTaskComposerPluginFactoryMultiTimesFromFileWithLoadYamlFileOutside (43 ms)
```