### PR TITLE
Check trajectory return contact location

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/fwd.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/fwd.h
@@ -46,6 +46,8 @@ struct ContactTrajectorySubstepResults;
 struct ContactTrajectoryStepResults;
 struct ContactTrajectoryResults;
 class ContactResultValidator;
+struct ContactLocation;
+struct TrajectoryContactResult;
 
 // contact_managers_plugin_factory.h
 class DiscreteContactManagerFactory;

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -485,6 +485,9 @@ struct CollisionCheckConfig
   /** @brief Secifies the mode used when collision checking program/trajectory. Default: ALL */
   CollisionCheckProgramType check_program_mode{ CollisionCheckProgramType::ALL };
 
+  /** @brief If true, the collision check will exit on first state contact. Default: true */
+  bool exit_on_first_contact{ true };
+
   bool operator==(const CollisionCheckConfig& rhs) const;
   bool operator!=(const CollisionCheckConfig& rhs) const;
 };

--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -490,6 +490,166 @@ struct CollisionCheckConfig
 };
 
 /**
+ * @brief Represents a contact occurrence inside a trajectory step.
+ *
+ * A substep value of -1 indicates a contact at the discrete step (no substep).
+ */
+struct ContactLocation
+{
+  int step{ -1 };    /**< The trajectory step index where contact occurred */
+  int substep{ -1 }; /**< The substep index (-1 if not applicable) */
+
+  ContactLocation() = default;
+  ContactLocation(int s) : step(s) {}
+  ContactLocation(int s, int sub_s) : step(s), substep(sub_s) {}
+
+  bool operator==(const ContactLocation& rhs) const { return step == rhs.step && substep == rhs.substep; }
+  bool operator!=(const ContactLocation& rhs) const { return !operator==(rhs); }
+};
+
+/**
+ * @brief Per-step contact information.
+ *
+ * Stores a compact list of substep indices where contacts were detected for a given step.
+ * A stored substep value of -1 represents a contact at the step itself (no substep).
+ */
+struct StepContact
+{
+  int step = -1;
+  std::vector<int> substeps;  // may contain -1 to indicate a step-only contact
+
+  StepContact() = default;
+  explicit StepContact(int s) : step(s) {}
+};
+
+/**
+ * @brief Efficient return type for checkTrajectory functions that replaces boolean return
+ * while tracking contact locations with minimal overhead.
+ *
+ * Implementation uses a per-step container of substeps to avoid large reallocations when many
+ * substep contacts occur between the same two steps. The API remains backward compatible via
+ * an implicit bool conversion and a flattened accessor `getContactLocations()`.
+ */
+struct TrajectoryContactResult
+{
+  /**
+   * @brief Default constructor - no contacts found
+   */
+  TrajectoryContactResult() = default;
+
+  /**
+   * @brief Constructor that reserves space for expected number of steps
+   * @param expected_steps Expected number of trajectory steps to reserve space for
+   */
+  explicit TrajectoryContactResult(std::size_t expected_steps) { step_substeps_.resize(expected_steps); }
+
+  /**
+   * @brief Implicit conversion to bool for backward compatibility
+   * @return true if any contacts were found, false otherwise
+   */
+  operator bool() const { return total_contacts_ > 0; }
+
+  /**
+   * @brief Add a contact location (step only)
+   * @param step The trajectory step index
+   */
+  void addContact(int step)
+  {
+    ensureStepExists(step);
+    step_substeps_[static_cast<std::size_t>(step)].push_back(-1);
+    ++total_contacts_;
+  }
+
+  /**
+   * @brief Add a contact location (step and substep)
+   * @param step The trajectory step index
+   * @param substep The substep index
+   */
+  void addContact(int step, int substep)
+  {
+    ensureStepExists(step);
+    step_substeps_[static_cast<std::size_t>(step)].push_back(substep);
+    ++total_contacts_;
+  }
+
+  /**
+   * @brief Get a flattened list of contact locations (step, substep)
+   * @return Vector of contact locations
+   *
+   * Note: This performs allocations when invoked. Use step-level accessors if possible to avoid
+   * extra allocations during performance critical code paths.
+   */
+  std::vector<ContactLocation> getContactLocations() const
+  {
+    std::vector<ContactLocation> out;
+    out.reserve(total_contacts_);
+    for (std::size_t s = 0; s < step_substeps_.size(); ++s)
+    {
+      const auto& subs = step_substeps_[s];
+      for (int ss : subs)
+        out.emplace_back(static_cast<int>(s), ss);
+    }
+    return out;
+  }
+
+  /**
+   * @brief Get per-step substep vector for random access
+   * @param step The trajectory step index
+   * @return const reference to vector of substeps (may be empty)
+   */
+  const std::vector<int>& getSubstepsForStep(int step) const
+  {
+    static const std::vector<int> empty;
+    if (step < 0 || static_cast<std::size_t>(step) >= step_substeps_.size())
+      return empty;
+    return step_substeps_[static_cast<std::size_t>(step)];
+  }
+
+  /**
+   * @brief Get the total number of recorded contact locations (flattened count)
+   * @return Number of contact locations
+   */
+  std::size_t size() const { return total_contacts_; }
+
+  /**
+   * @brief Check if any contacts were found
+   * @return true if contacts exist, false otherwise
+   */
+  bool empty() const { return total_contacts_ == 0; }
+
+  /**
+   * @brief Clear all contact records
+   */
+  void clear()
+  {
+    for (auto& v : step_substeps_)
+      v.clear();
+    total_contacts_ = 0;
+  }
+
+  /**
+   * @brief Number of tracked steps (capacity of the top-level container)
+   */
+  std::size_t trackedSteps() const { return step_substeps_.size(); }
+
+private:
+  void ensureStepExists(int step)
+  {
+    if (step < 0)
+      return;
+    auto idx = static_cast<std::size_t>(step);
+    if (idx >= step_substeps_.size())
+      step_substeps_.resize(idx + 1);
+  }
+
+  // Per-step list of substeps. An element value of -1 indicates a step-only contact.
+  std::vector<std::vector<int>> step_substeps_;
+
+  // Flattened count of recorded contact locations to allow O(1) size/bool checks.
+  std::size_t total_contacts_{ 0 };
+};
+
+/**
  * @brief The ContactTrajectorySubstepResults struct is the lowest level struct for tracking contacts in a trajectory.
  * This struct is used for substeps between waypoints in a trajectory when a longest valid segment is used, storing the
  * relevant states of the substep.

--- a/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/yaml_extensions.h
@@ -292,6 +292,7 @@ struct convert<tesseract_collision::CollisionCheckConfig>
     node["type"] = rhs.type;
     node["longest_valid_segment_length"] = rhs.longest_valid_segment_length;
     node["check_program_mode"] = rhs.check_program_mode;
+    node["exit_on_first_contact"] = rhs.exit_on_first_contact;
 
     return node;
   }
@@ -306,6 +307,8 @@ struct convert<tesseract_collision::CollisionCheckConfig>
       rhs.longest_valid_segment_length = n.as<double>();
     if (const YAML::Node& n = node["check_program_mode"])
       rhs.check_program_mode = n.as<tesseract_collision::CollisionCheckProgramType>();
+    if (const YAML::Node& n = node["exit_on_first_contact"])
+      rhs.exit_on_first_contact = n.as<bool>();
     return true;
   }
 };

--- a/tesseract_environment/include/tesseract_environment/utils.h
+++ b/tesseract_environment/include/tesseract_environment/utils.h
@@ -105,14 +105,15 @@ void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results
  * @param joint_names JointNames corresponding to the values in traj (must be in same order)
  * @param traj The joint values at each time step
  * @param config CollisionCheckConfig used to specify collision check settings
- * @return True if collision was found, otherwise false.
+ * @return TrajectoryContactResult containing contact locations found.
  */
-bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
-                     tesseract_collision::ContinuousContactManager& manager,
-                     const tesseract_scene_graph::StateSolver& state_solver,
-                     const std::vector<std::string>& joint_names,
-                     const tesseract_common::TrajArray& traj,
-                     const tesseract_collision::CollisionCheckConfig& config);
+tesseract_collision::TrajectoryContactResult
+checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                tesseract_collision::ContinuousContactManager& manager,
+                const tesseract_scene_graph::StateSolver& state_solver,
+                const std::vector<std::string>& joint_names,
+                const tesseract_common::TrajArray& traj,
+                const tesseract_collision::CollisionCheckConfig& config);
 
 /**
  * @brief Should perform a continuous collision check over the trajectory and stop on first collision.
@@ -122,13 +123,14 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
  * @param manip The kinematic joint group
  * @param traj The joint values at each time step
  * @param config CollisionCheckConfig used to specify collision check settings
- * @return True if collision was found, otherwise false.
+ * @return TrajectoryContactResult containing contact locations found.
  */
-bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
-                     tesseract_collision::ContinuousContactManager& manager,
-                     const tesseract_kinematics::JointGroup& manip,
-                     const tesseract_common::TrajArray& traj,
-                     const tesseract_collision::CollisionCheckConfig& config);
+tesseract_collision::TrajectoryContactResult
+checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                tesseract_collision::ContinuousContactManager& manager,
+                const tesseract_kinematics::JointGroup& manip,
+                const tesseract_common::TrajArray& traj,
+                const tesseract_collision::CollisionCheckConfig& config);
 
 /**
  * @brief Should perform a discrete collision check over the trajectory and stop on first collision.
@@ -139,14 +141,15 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
  * @param joint_names JointNames corresponding to the values in traj (must be in same order)
  * @param traj The joint values at each time step
  * @param config CollisionCheckConfig used to specify collision check settings
- * @return True if collision was found, otherwise false.
+ * @return TrajectoryContactResult containing contact locations found.
  */
-bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
-                     tesseract_collision::DiscreteContactManager& manager,
-                     const tesseract_scene_graph::StateSolver& state_solver,
-                     const std::vector<std::string>& joint_names,
-                     const tesseract_common::TrajArray& traj,
-                     const tesseract_collision::CollisionCheckConfig& config);
+tesseract_collision::TrajectoryContactResult
+checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                tesseract_collision::DiscreteContactManager& manager,
+                const tesseract_scene_graph::StateSolver& state_solver,
+                const std::vector<std::string>& joint_names,
+                const tesseract_common::TrajArray& traj,
+                const tesseract_collision::CollisionCheckConfig& config);
 
 /**
  * @brief Should perform a discrete collision check over the trajectory and stop on first collision.
@@ -156,13 +159,14 @@ bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contact
  * @param manip The kinematic joint group
  * @param traj The joint values at each time step
  * @param config CollisionCheckConfig used to specify collision check settings
- * @return True if collision was found, otherwise false.
+ * @return TrajectoryContactResult containing contact locations found.
  */
-bool checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
-                     tesseract_collision::DiscreteContactManager& manager,
-                     const tesseract_kinematics::JointGroup& manip,
-                     const tesseract_common::TrajArray& traj,
-                     const tesseract_collision::CollisionCheckConfig& config);
+tesseract_collision::TrajectoryContactResult
+checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
+                tesseract_collision::DiscreteContactManager& manager,
+                const tesseract_kinematics::JointGroup& manip,
+                const tesseract_common::TrajArray& traj,
+                const tesseract_collision::CollisionCheckConfig& config);
 
 }  // namespace tesseract_environment
 #endif  // TESSERACT_ENVIRONMENT_CORE_UTILS_H

--- a/tesseract_environment/include/tesseract_environment/utils.h
+++ b/tesseract_environment/include/tesseract_environment/utils.h
@@ -107,7 +107,7 @@ void checkTrajectoryState(tesseract_collision::ContactResultMap& contact_results
  * @param config CollisionCheckConfig used to specify collision check settings
  * @return TrajectoryContactResult containing contact locations found.
  */
-tesseract_collision::TrajectoryContactResult
+tesseract_collision::ContactTrajectoryResults
 checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                 tesseract_collision::ContinuousContactManager& manager,
                 const tesseract_scene_graph::StateSolver& state_solver,
@@ -125,7 +125,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
  * @param config CollisionCheckConfig used to specify collision check settings
  * @return TrajectoryContactResult containing contact locations found.
  */
-tesseract_collision::TrajectoryContactResult
+tesseract_collision::ContactTrajectoryResults
 checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                 tesseract_collision::ContinuousContactManager& manager,
                 const tesseract_kinematics::JointGroup& manip,
@@ -143,7 +143,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
  * @param config CollisionCheckConfig used to specify collision check settings
  * @return TrajectoryContactResult containing contact locations found.
  */
-tesseract_collision::TrajectoryContactResult
+tesseract_collision::ContactTrajectoryResults
 checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                 tesseract_collision::DiscreteContactManager& manager,
                 const tesseract_scene_graph::StateSolver& state_solver,
@@ -161,7 +161,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
  * @param config CollisionCheckConfig used to specify collision check settings
  * @return TrajectoryContactResult containing contact locations found.
  */
-tesseract_collision::TrajectoryContactResult
+tesseract_collision::ContactTrajectoryResults
 checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                 tesseract_collision::DiscreteContactManager& manager,
                 const tesseract_kinematics::JointGroup& manip,

--- a/tesseract_environment/src/utils.cpp
+++ b/tesseract_environment/src/utils.cpp
@@ -305,17 +305,12 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                                                           false);
           }
 
-          if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          if (result && config.exit_on_first_contact)
             break;
         }
         contacts.push_back(state_results);
 
-        if (debug_logging)
-        {
-          traj_contacts->steps[static_cast<size_t>(iStep)] = *step_contacts;
-        }
-
-        if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+        if (result && config.exit_on_first_contact)
           break;
       }
       else
@@ -370,7 +365,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
           traj_contacts->steps[static_cast<size_t>(iStep)] = *step_contacts;
         }
 
-        if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+        if (result && config.exit_on_first_contact)
           break;
       }
     }
@@ -426,7 +421,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
         traj_contacts->steps[static_cast<size_t>(iStep)] = *step_contacts;
       }
 
-      if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+      if (result && config.exit_on_first_contact)
         break;
     }
   }
@@ -652,17 +647,12 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                                                           true);
           }
 
-          if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          if (result && (config.exit_on_first_contact)
             break;
         }
         contacts.push_back(state_results);
 
-        if (debug_logging)
-        {
-          traj_contacts->steps[static_cast<size_t>(iStep)] = *step_contacts;
-        }
-
-        if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          if (result && config.exit_on_first_contact)
           break;
       }
       else
@@ -701,7 +691,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                   sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, true);
             }
 
-            if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+            if (result && config.exit_on_first_contact)
             {
               contacts.push_back(state_results);
               break;
@@ -727,7 +717,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                   sub_state_results, 1, 1, manager.getActiveCollisionObjects(), 1, true);
             }
 
-            if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+            if (result && config.exit_on_first_contact)
             {
               contacts.push_back(state_results);
               break;
@@ -764,7 +754,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
               sub_state_results, 0, 0, manager.getActiveCollisionObjects(), 0, true);
         }
 
-        if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+        if (result && config.exit_on_first_contact)
         {
           contacts.push_back(state_results);
           break;
@@ -796,7 +786,7 @@ checkTrajectory(std::vector<tesseract_collision::ContactResultMap>& contacts,
                 sub_state_results, 1, 1, manager.getActiveCollisionObjects(), 1, true);
           }
 
-          if (result && (config.contact_request.type == tesseract_collision::ContactTestType::FIRST))
+          if (result && config.exit_on_first_contact)
           {
             contacts.push_back(state_results);
             break;

--- a/tesseract_environment/test/tesseract_environment_unit.cpp
+++ b/tesseract_environment/test/tesseract_environment_unit.cpp
@@ -3001,6 +3001,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::ALL;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
@@ -3039,6 +3040,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_END;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3076,6 +3078,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_START;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
@@ -3116,6 +3119,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::INTERMEDIATE_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3152,6 +3156,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::END_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -3177,6 +3182,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::START_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -3202,6 +3208,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 2);
@@ -3222,6 +3229,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
   {
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(
         checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, joint_start_pos.transpose(), config));
@@ -3236,6 +3244,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::ALL;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3296,6 +3305,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_END;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3353,6 +3363,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_START;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3408,6 +3419,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::INTERMEDIATE_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3460,6 +3472,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::END_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(1));
@@ -3487,6 +3500,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::START_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(1));
@@ -3514,6 +3528,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 2);
@@ -3535,6 +3550,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::ALL;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3577,6 +3593,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_END;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3619,6 +3636,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_START;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3661,6 +3679,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::INTERMEDIATE_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3703,6 +3722,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::END_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(1));
@@ -3729,6 +3749,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.check_program_mode = CollisionCheckProgramType::START_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(1));
@@ -3753,6 +3774,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
   {
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows()));
@@ -3780,6 +3802,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), 2);
@@ -3800,6 +3823,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
   {
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::DISCRETE;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *discrete_manager, *joint_group, joint_start_pos.transpose(), config));
     EXPECT_EQ(contacts.size(), 1);
@@ -3812,6 +3836,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3838,6 +3863,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), 2);
@@ -3858,6 +3884,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
   {
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_DISCRETE;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *discrete_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3886,6 +3913,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::ALL;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3924,6 +3952,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_END;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 2));
@@ -3959,6 +3988,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_START;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -3995,6 +4025,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::INTERMEDIATE_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 2));
@@ -4023,6 +4054,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::END_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4046,6 +4078,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::START_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4069,6 +4102,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4091,6 +4125,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::ALL;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4130,6 +4165,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_END;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 2));
@@ -4166,6 +4202,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_START;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4203,6 +4240,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::INTERMEDIATE_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 2));
@@ -4232,6 +4270,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::END_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4256,6 +4295,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
     config.check_program_mode = CollisionCheckProgramType::START_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4280,6 +4320,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4301,6 +4342,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::ALL;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4338,6 +4380,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_END;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4374,6 +4417,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::ALL_EXCEPT_START;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4412,6 +4456,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::INTERMEDIATE_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4449,6 +4494,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::END_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4472,6 +4518,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.check_program_mode = CollisionCheckProgramType::START_ONLY;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_FALSE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4494,6 +4541,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
   {
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4521,6 +4569,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::CONTINUOUS;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4542,6 +4591,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
@@ -4570,6 +4620,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
     config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
     config.longest_valid_segment_length = std::numeric_limits<double>::max();
+    config.exit_on_first_contact = true;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), 1);
@@ -4590,6 +4641,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
   {
     tesseract_collision::CollisionCheckConfig config;
     config.type = CollisionEvaluatorType::LVS_CONTINUOUS;
+    config.exit_on_first_contact = false;
     std::vector<tesseract_collision::ContactResultMap> contacts;
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *joint_group, traj, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));


### PR DESCRIPTION
The goal here is to return where in the trajectory a contact occurred. Now you can get detailed information about between which steps and at which substep a contact occurred, including the actual joint states at those values.

In creating this I also discovered that the `ContactTestType type` in `ContactRequest` was being used both for the individual contact checks AND dictated the trajectory collision checking behavior. This meant that if you used `ContactTestType::ALL` it would always check every state with the `ALL` setting, but it also would continue to contact check other states in the trajectory after a contact had been found. On the other hand, if you used `ContactTestType::FIRST` it would stop checking states once a contact was found. 

With this new change I'm introducing it may be useful to find all states that are in collision, but you may want to do that quickly using the `FIRST` methodology. There was no way to do that, so I added a field to `CollisionCheckConfig` called `exit_on_first_contact` which defaults to `true`.

I benchmarked this new one against the previous version of the code and go the following graph, virtually no chnage in performance (it appears to actually be slightly more efficient in DEBUG mode than it was before because of how it creates objects now):
<img width="3840" height="1277" alt="CheckTrajBenchmark" src="https://github.com/user-attachments/assets/0dbc0c09-9cac-4746-8823-b002df45e0e8" />
