### PR TITLE
Implement a condensed summary for ContactTrajectoryResults

### DIFF
--- a/tesseract_collision/core/include/tesseract_collision/core/types.h
+++ b/tesseract_collision/core/include/tesseract_collision/core/types.h
@@ -632,6 +632,8 @@ struct ContactTrajectoryResults
 
   std::stringstream collisionFrequencyPerLink() const;
 
+  std::stringstream condensedSummary() const;
+
   std::vector<ContactTrajectoryStepResults> steps;
   std::vector<std::string> joint_names;
   int total_steps = 0;

--- a/tesseract_collision/core/src/types.cpp
+++ b/tesseract_collision/core/src/types.cpp
@@ -1056,7 +1056,7 @@ std::stringstream ContactTrajectoryResults::condensedSummary() const
           continue;
 
         // Calculate the step with substep decimal
-        double step_with_substep = static_cast<double>(step.step);
+        auto step_with_substep = static_cast<double>(step.step);
         if (step.total_substeps > 0)
         {
           step_with_substep += static_cast<double>(substep.substep) / static_cast<double>(step.total_substeps);

--- a/tesseract_collision/test/collision_core_unit.cpp
+++ b/tesseract_collision/test/collision_core_unit.cpp
@@ -1533,6 +1533,23 @@ TEST(TesseractCoreUnit, ContactTrajectoryResultsUnit)  // NOLINT
 
     EXPECT_TRUE(static_cast<bool>(results));
     EXPECT_FALSE(freq_ss.str().find("No contacts detected") != std::string::npos);
+
+    // Test condensed summary method
+    EXPECT_NO_THROW(results.condensedSummary());
+
+    std::stringstream condensed_ss = results.condensedSummary();
+    EXPECT_FALSE(condensed_ss.str().empty());
+    EXPECT_FALSE(condensed_ss.str().find("No contacts detected") != std::string::npos);
+
+    // Check that the condensed summary contains expected format: "step.substep: [link1, link2]->distance"
+    std::string condensed_output = condensed_ss.str();
+    std::cout << "Condensed Summary Output:\n" << condensed_output;
+
+    // Should contain "0.0: [link1, link2]" for first collision at step 0, substep 0
+    EXPECT_TRUE(condensed_output.find("0.0: [link1, link2]") != std::string::npos);
+
+    // Should contain "1.3: [link3, link4]" for first collision at step 1, substep 1 (1/3 = 0.3, so 1.3)
+    EXPECT_TRUE(condensed_output.find("1.3: [link3, link4]") != std::string::npos);
   }
 
   // Test with no contacts
@@ -1563,6 +1580,13 @@ TEST(TesseractCoreUnit, ContactTrajectoryResultsUnit)  // NOLINT
     std::stringstream freq_ss = results.collisionFrequencyPerLink();
     EXPECT_FALSE(freq_ss.str().empty());
     EXPECT_TRUE(freq_ss.str().find("No contacts detected") != std::string::npos);
+
+    // Test condensed summary method with no contacts
+    EXPECT_NO_THROW(results.condensedSummary());
+
+    std::stringstream condensed_ss = results.condensedSummary();
+    EXPECT_FALSE(condensed_ss.str().empty());
+    EXPECT_TRUE(condensed_ss.str().find("No contacts detected") != std::string::npos);
 
     EXPECT_FALSE(static_cast<bool>(results));
   }


### PR DESCRIPTION
Print a condensed summary of contacts over a trajectory. Report the first contact observed at each step, regardless of if multiple contacts and substeps with contacts are present. Useful for quick, but informative, debugging.

Of the form

```
Step 14.4: [link_a, link_b]->0.001
```

This means link_a and link_b colliding 40% of the way from step 14 to step 15 and the contact distance observed was 0.001