### PR TITLE
Fix kdl_sub_tree_builder crash on non-empty floating joints

### DIFF
--- a/scene_graph/src/kdl_parser.cpp
+++ b/scene_graph/src/kdl_parser.cpp
@@ -306,7 +306,7 @@ struct kdl_sub_tree_builder : public boost::dfs_visitor<>
     : data_(data), joint_names_(joint_names), joint_values_(joint_values), floating_joint_values_(floating_joint_values)
   {
     for (const auto& floating_joint_value : floating_joint_values)
-      data_.floating_joint_values.at(floating_joint_value.first) = floating_joint_value.second;
+      data_.floating_joint_values[floating_joint_value.first] = floating_joint_value.second;
   }
 
   template <class u, class g>

--- a/scene_graph/test/tesseract_scene_graph_unit.cpp
+++ b/scene_graph/test/tesseract_scene_graph_unit.cpp
@@ -1290,6 +1290,32 @@ TEST(TesseractSceneGraphUnit, LoadSubKDLUnit)  // NOLINT
   }
 }
 
+// Exercises the sub-tree builder when the provided floating_joint_values map is non-empty.
+TEST(TesseractSceneGraphUnit, KDLParserSubTreeFloatingJointUnit)  // NOLINT
+{
+  using namespace tesseract::scene_graph;
+  SceneGraph g = buildTestSceneGraph();
+
+  std::vector<Joint::ConstPtr> active_joints = g.getActiveJoints();
+  const std::vector<std::string> subset{ "joint_1", "joint_2", "joint_4" };
+
+  std::unordered_map<std::string, double> joint_values;
+  for (const auto& j : active_joints)
+    joint_values[j->getName()] = 0.0;
+
+  tesseract::common::TransformMap floating;
+  Eigen::Isometry3d fj_tf = Eigen::Isometry3d::Identity();
+  fj_tf.translation().x() = 0.75;
+  fj_tf.translation().y() = -0.25;
+  floating["joint_3"] = fj_tf;
+
+  KDLTreeData data = parseSceneGraph(g, subset, joint_values, floating);
+
+  ASSERT_EQ(data.floating_joint_values.count("joint_3"), 1U);
+  EXPECT_TRUE(data.floating_joint_values["joint_3"].isApprox(fj_tf));
+  EXPECT_EQ(data.tree.getNrOfJoints(), subset.size());
+}
+
 TEST(TesseractSceneGraphUnit, TestChangeJointOrigin)  // NOLINT
 {
   using namespace tesseract::scene_graph;


### PR DESCRIPTION
## Summary

`kdl_sub_tree_builder`'s constructor copied caller-supplied floating-joint transforms into a freshly-default-constructed `KDLTreeData::floating_joint_values` using `.at(key)`, which requires the key to already exist. The destination map is always empty at that point, so any non-empty `floating_joint_values` argument threw `std::out_of_range`. Swap to `operator[]` (insert-or-assign), matching the sibling full-tree builder a few lines up.

Production impact: `JointGroup` construction threw on any scene with a floating joint. No existing test covered the path — the two existing `parseSceneGraph` sub-tree calls in `tesseract_scene_graph_unit.cpp` pass an empty `TransformMap()`, so the constructor's loop body never ran.

## Test plan

Added `KDLParserSubTreeFloatingJointUnit` (TDD-verified):

- [x] Pre-fix: test fails with `unordered_map::at` thrown from `parseSceneGraph`.
- [x] Post-fix: test passes — `data.floating_joint_values["joint_3"]` matches the supplied transform and the sub-tree contains the expected joint count.
- [x] Full `tesseract_scene_graph_unit` suite (56 tests): all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)