### PR TITLE
Fix data race on shared location map in collision multi-threaded test

### DIFF
--- a/collision/test_suite/include/tesseract/collision/test_suite/collision_multi_threaded_unit.hpp
+++ b/collision/test_suite/include/tesseract/collision/test_suite/collision_multi_threaded_unit.hpp
@@ -90,13 +90,14 @@ inline void runTest(DiscreteContactManager& checker, bool use_convex_mesh = fals
 
   auto start_time = std::chrono::high_resolution_clock::now();
 
-#pragma omp parallel for num_threads(num_threads) shared(location)
+  const auto& const_location = location;
+#pragma omp parallel for num_threads(num_threads) shared(const_location)
   for (long i = 0; i < num_threads; ++i)  // NOLINT
   {
     const int tn = omp_get_thread_num();
     CONSOLE_BRIDGE_logDebug("Thread (ID: %i): %i of %i", tn, i, num_threads);
     const DiscreteContactManager::Ptr& manager = contact_manager[static_cast<size_t>(tn)];
-    for (const auto& co : location)
+    for (const auto& co : const_location)
     {
       if (tn == 0)
       {


### PR DESCRIPTION
## Summary
- The OpenMP parallel region in `collision_multi_threaded_unit.hpp` declared the caller-mutable `location` map as `shared` and iterated it via non-const `begin()`/`end()` on every thread. Per the C++ memory model, concurrent invocations of non-const member functions on the same object constitute a data race even when the operations don't mutate state.
- Bind a `const auto&` alias to `location` before the parallel region, list it (instead of `location`) in the `shared(...)` clause, and iterate the alias inside the loop so all threads only invoke const member functions on the shared map.

## Test plan
- [x] Build: `./colcon_tesseract.sh --packages-select tesseract`
- [x] Run all 6 `TesseractCollisionMultiThreadedUnit` tests (Bullet simple/BVH, FCL BVH × {sphere, convex hull}) — all pass after the change.