### PR TITLE
Add optional tolerances on calcJacobianTransformErrorDiff

### DIFF
--- a/common/include/tesseract/common/utils.h
+++ b/common/include/tesseract/common/utils.h
@@ -172,16 +172,19 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
 
 /**
  * @brief Apply a per-component dead-band tolerance to an error vector in place.
- * @details Each component is clamped to zero inside `[lower(i), upper(i)]`, set to `v(i) - lower(i)` below the band,
- *          and `v(i) - upper(i)` above. If both tolerance vectors are empty this is a no-op.
+ * @details Each component is clamped to zero inside `[lower(i), upper(i)]`, shifted by `v(i) - lower(i)` below the
+ *          band, and `v(i) - upper(i)` above. The function is a no-op only when both `lower_tolerance` and
+ *          `upper_tolerance` are empty. When non-empty, both tolerance vectors must match `v` in size; otherwise
+ *          std::runtime_error is thrown. A non-empty paired with an empty tolerance is treated as a size mismatch
+ *          and throws.
  * @param v The vector to clamp in place
- * @param lower_tolerance Per-component lower bound, or empty for no-op
- * @param upper_tolerance Per-component upper bound, or empty for no-op. Must match lower_tolerance and v in size when
- *        non-empty; throws std::runtime_error otherwise.
+ * @param lower_tolerance Per-component lower bound (size must equal `v.size()`, or empty when paired with an empty
+ *        upper_tolerance for a no-op)
+ * @param upper_tolerance Per-component upper bound (same size constraints as `lower_tolerance`)
  */
-void applyTolerances(Eigen::VectorXd& v,
-                     const Eigen::VectorXd& lower_tolerance,
-                     const Eigen::VectorXd& upper_tolerance);
+void applyTolerances(Eigen::Ref<Eigen::VectorXd> v,
+                     const Eigen::Ref<const Eigen::VectorXd>& lower_tolerance,
+                     const Eigen::Ref<const Eigen::VectorXd>& upper_tolerance);
 
 /**
  * @brief This computes a random color RGBA [0, 1] with alpha set to 1

--- a/common/include/tesseract/common/utils.h
+++ b/common/include/tesseract/common/utils.h
@@ -137,17 +137,29 @@ Eigen::VectorXd calcTransformError(const Eigen::Isometry3d& t1, const Eigen::Iso
  * @param target The desired transform to express the transform error difference in
  * @param source The current location of the source transform
  * @param source_perturbed The perturbed location of the source transform
- * @param lower_tolerance Optional per-component dead-band lower bound (size 6 or empty). When supplied with
- *        upper_tolerance, err and perturbed_err are clamped inside [lower, upper] before the subtraction.
- *        Empty (default) preserves raw finite-difference behavior.
- * @param upper_tolerance Optional per-component dead-band upper bound. Must match lower_tolerance in size.
+ * @return The change in error represented in the target frame
+ */
+Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
+                                               const Eigen::Isometry3d& source,
+                                               const Eigen::Isometry3d& source_perturbed);
+
+/**
+ * @brief Calculate jacobian transform error difference with optional per-component dead-band tolerances.
+ * @details Same behavior as the 3-argument overload; additionally, after the paired ±π/sign correction the
+ *          err and perturbed_err vectors are clamped inside `[lower_tolerance, upper_tolerance]` before the
+ *          subtraction. Both tolerance vectors must be size 6, or both empty for raw finite-difference behavior.
+ * @param target The desired transform to express the transform error difference in
+ * @param source The current location of the source transform
+ * @param source_perturbed The perturbed location of the source transform
+ * @param lower_tolerance Per-component dead-band lower bound (size 6, or empty for no-op)
+ * @param upper_tolerance Per-component dead-band upper bound (same size constraints as lower_tolerance)
  * @return The change in error represented in the target frame
  */
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
-                                               const Eigen::VectorXd& lower_tolerance = {},
-                                               const Eigen::VectorXd& upper_tolerance = {});
+                                               const Eigen::VectorXd& lower_tolerance,
+                                               const Eigen::VectorXd& upper_tolerance);
 
 /**
  * @brief Calculate jacobian transform error difference expressed in the target frame coordinate system
@@ -157,18 +169,33 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
  * @param target_perturbed The perturbed location of the target transform
  * @param source The current location of the source transform
  * @param source_perturbed The perturbed location of the source transform
- * @param lower_tolerance Optional per-component dead-band lower bound (size 6 or empty). When supplied with
- *        upper_tolerance, err and perturbed_err are clamped inside [lower, upper] before the subtraction.
- *        Empty (default) preserves raw finite-difference behavior.
- * @param upper_tolerance Optional per-component dead-band upper bound. Must match lower_tolerance in size.
+ * @return The change in error represented in the target frame
+ */
+Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
+                                               const Eigen::Isometry3d& target_perturbed,
+                                               const Eigen::Isometry3d& source,
+                                               const Eigen::Isometry3d& source_perturbed);
+
+/**
+ * @brief Calculate jacobian transform error difference (dynamic target) with optional per-component dead-band
+ *        tolerances.
+ * @details Same behavior as the 4-argument overload; additionally, after the paired ±π/sign correction the
+ *          err and perturbed_err vectors are clamped inside `[lower_tolerance, upper_tolerance]` before the
+ *          subtraction. Both tolerance vectors must be size 6, or both empty for raw finite-difference behavior.
+ * @param target The desired transform to express the transform error difference in
+ * @param target_perturbed The perturbed location of the target transform
+ * @param source The current location of the source transform
+ * @param source_perturbed The perturbed location of the source transform
+ * @param lower_tolerance Per-component dead-band lower bound (size 6, or empty for no-op)
+ * @param upper_tolerance Per-component dead-band upper bound (same size constraints as lower_tolerance)
  * @return The change in error represented in the target frame
  */
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& target_perturbed,
                                                const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
-                                               const Eigen::VectorXd& lower_tolerance = {},
-                                               const Eigen::VectorXd& upper_tolerance = {});
+                                               const Eigen::VectorXd& lower_tolerance,
+                                               const Eigen::VectorXd& upper_tolerance);
 
 /**
  * @brief Apply a per-component dead-band tolerance to an error vector in place.

--- a/common/include/tesseract/common/utils.h
+++ b/common/include/tesseract/common/utils.h
@@ -158,8 +158,8 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
-                                               const Eigen::VectorXd& lower_tolerance,
-                                               const Eigen::VectorXd& upper_tolerance);
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_tolerance,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_tolerance);
 
 /**
  * @brief Calculate jacobian transform error difference expressed in the target frame coordinate system
@@ -194,8 +194,8 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& target_perturbed,
                                                const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
-                                               const Eigen::VectorXd& lower_tolerance,
-                                               const Eigen::VectorXd& upper_tolerance);
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_tolerance,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_tolerance);
 
 /**
  * @brief Apply a per-component dead-band tolerance to an error vector in place.

--- a/common/include/tesseract/common/utils.h
+++ b/common/include/tesseract/common/utils.h
@@ -132,29 +132,56 @@ Eigen::VectorXd calcTransformError(const Eigen::Isometry3d& t1, const Eigen::Iso
 
 /**
  * @brief Calculate jacobian transform error difference expressed in the target frame coordinate system
- * @details This is used when the target is a fixed frame in the environment
- * @param target Target The desired transform to express the transform error difference in
+ * @details This is used when the target is a fixed frame in the environment. Handles the angle-axis ±π
+ *          discontinuity by computing err and perturbed_err in coordination.
+ * @param target The desired transform to express the transform error difference in
  * @param source The current location of the source transform
  * @param source_perturbed The perturbed location of the source transform
+ * @param lower_tolerance Optional per-component dead-band lower bound (size 6 or empty). When supplied with
+ *        upper_tolerance, err and perturbed_err are clamped inside [lower, upper] before the subtraction.
+ *        Empty (default) preserves raw finite-difference behavior.
+ * @param upper_tolerance Optional per-component dead-band upper bound. Must match lower_tolerance in size.
  * @return The change in error represented in the target frame
  */
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& source,
-                                               const Eigen::Isometry3d& source_perturbed);
+                                               const Eigen::Isometry3d& source_perturbed,
+                                               const Eigen::VectorXd& lower_tolerance = {},
+                                               const Eigen::VectorXd& upper_tolerance = {});
 
 /**
  * @brief Calculate jacobian transform error difference expressed in the target frame coordinate system
- * @details This is used when the target and source are both dynamic links
- * @param target Target The desired transform to express the transform error difference in
+ * @details This is used when the target and source are both dynamic links. Handles the angle-axis ±π
+ *          discontinuity by computing err and perturbed_err in coordination.
+ * @param target The desired transform to express the transform error difference in
  * @param target_perturbed The perturbed location of the target transform
  * @param source The current location of the source transform
  * @param source_perturbed The perturbed location of the source transform
+ * @param lower_tolerance Optional per-component dead-band lower bound (size 6 or empty). When supplied with
+ *        upper_tolerance, err and perturbed_err are clamped inside [lower, upper] before the subtraction.
+ *        Empty (default) preserves raw finite-difference behavior.
+ * @param upper_tolerance Optional per-component dead-band upper bound. Must match lower_tolerance in size.
  * @return The change in error represented in the target frame
  */
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& target_perturbed,
                                                const Eigen::Isometry3d& source,
-                                               const Eigen::Isometry3d& source_perturbed);
+                                               const Eigen::Isometry3d& source_perturbed,
+                                               const Eigen::VectorXd& lower_tolerance = {},
+                                               const Eigen::VectorXd& upper_tolerance = {});
+
+/**
+ * @brief Apply a per-component dead-band tolerance to an error vector in place.
+ * @details Each component is clamped to zero inside `[lower(i), upper(i)]`, set to `v(i) - lower(i)` below the band,
+ *          and `v(i) - upper(i)` above. If both tolerance vectors are empty this is a no-op.
+ * @param v The vector to clamp in place
+ * @param lower_tolerance Per-component lower bound, or empty for no-op
+ * @param upper_tolerance Per-component upper bound, or empty for no-op. Must match lower_tolerance and v in size when
+ *        non-empty; throws std::runtime_error otherwise.
+ */
+void applyTolerances(Eigen::VectorXd& v,
+                     const Eigen::VectorXd& lower_tolerance,
+                     const Eigen::VectorXd& upper_tolerance);
 
 /**
  * @brief This computes a random color RGBA [0, 1] with alpha set to 1

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -175,6 +175,13 @@ void applyTolerances(Eigen::Ref<Eigen::VectorXd> v,
 
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& source,
+                                               const Eigen::Isometry3d& source_perturbed)
+{
+  return calcJacobianTransformErrorDiff(target, source, source_perturbed, Eigen::VectorXd{}, Eigen::VectorXd{});
+}
+
+Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
+                                               const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
                                                const Eigen::VectorXd& lower_tolerance,
                                                const Eigen::VectorXd& upper_tolerance)
@@ -211,6 +218,15 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
   applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
 
   return (perturbed_err - err);
+}
+
+Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
+                                               const Eigen::Isometry3d& target_perturbed,
+                                               const Eigen::Isometry3d& source,
+                                               const Eigen::Isometry3d& source_perturbed)
+{
+  return calcJacobianTransformErrorDiff(
+      target, target_perturbed, source, source_perturbed, Eigen::VectorXd{}, Eigen::VectorXd{});
 }
 
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -159,9 +159,23 @@ Eigen::VectorXd calcTransformError(const Eigen::Isometry3d& t1, const Eigen::Iso
   return concat(pose_err.translation(), calcRotationalError(pose_err.rotation()));
 }
 
+void applyTolerances(Eigen::VectorXd& v, const Eigen::VectorXd& lower_tolerance, const Eigen::VectorXd& upper_tolerance)
+{
+  if (lower_tolerance.size() == 0 && upper_tolerance.size() == 0)
+    return;
+  if (lower_tolerance.size() != upper_tolerance.size())
+    throw std::runtime_error("applyTolerances: lower_tolerance and upper_tolerance must have the same size");
+  if (lower_tolerance.size() != v.size())
+    throw std::runtime_error("applyTolerances: tolerance size does not match value size (expected " +
+                             std::to_string(v.size()) + ", got " + std::to_string(lower_tolerance.size()) + ")");
+  v = (v.array() - upper_tolerance.array()).max(0.0) + (v.array() - lower_tolerance.array()).min(0.0);
+}
+
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& source,
-                                               const Eigen::Isometry3d& source_perturbed)
+                                               const Eigen::Isometry3d& source_perturbed,
+                                               const Eigen::VectorXd& lower_tolerance,
+                                               const Eigen::VectorXd& upper_tolerance)
 {
   Eigen::Isometry3d pose_err = target.inverse() * source;
   std::pair<Eigen::Vector3d, double> pose_rotation_err = calcRotationalErrorDecomposed(pose_err.rotation());
@@ -178,7 +192,7 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
     perturbed_pose_rotation_err.second *= -1;
   }
 
-  // Angle axis has a discontinity at PI so need to correctly handle this calculating jacobian difference
+  // Angle axis has a discontinuity at PI so need to correctly handle this calculating jacobian difference
   Eigen::VectorXd perturbed_err;
   if (perturbed_pose_rotation_err.second > M_PI_2 && pose_rotation_err.second < -M_PI_2)
     perturbed_err = concat(perturbed_pose_err.translation(),
@@ -190,13 +204,19 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
     perturbed_err = concat(perturbed_pose_err.translation(),
                            perturbed_pose_rotation_err.first * perturbed_pose_rotation_err.second);
 
+  // Apply tolerances after the paired ±π/sign correction so the clamp sees the same branch on both errors.
+  applyTolerances(err, lower_tolerance, upper_tolerance);
+  applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
+
   return (perturbed_err - err);
 }
 
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& target_perturbed,
                                                const Eigen::Isometry3d& source,
-                                               const Eigen::Isometry3d& source_perturbed)
+                                               const Eigen::Isometry3d& source_perturbed,
+                                               const Eigen::VectorXd& lower_tolerance,
+                                               const Eigen::VectorXd& upper_tolerance)
 {
   Eigen::Isometry3d pose_err = target.inverse() * source;
   std::pair<Eigen::Vector3d, double> pose_rotation_err = calcRotationalErrorDecomposed(pose_err.rotation());
@@ -213,13 +233,12 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
     perturbed_pose_rotation_err.second *= -1;
   }
 
-  // They should always pointing in the same direction
 #ifndef NDEBUG
   if (std::abs(pose_rotation_err.second) > 0.01 && perturbed_pose_rotation_err.first.dot(pose_rotation_err.first) < 0)
     throw std::runtime_error("calcJacobianTransformErrorDiff, angle axes are pointing in oposite directions!");
 #endif
 
-  // Angle axis has a discontinity at PI so need to correctly handle this calculating  jacobian difference
+  // Angle axis has a discontinuity at PI so need to correctly handle this calculating jacobian difference
   Eigen::VectorXd perturbed_err;
   if (perturbed_pose_rotation_err.second > M_PI_2 && pose_rotation_err.second < -M_PI_2)
     perturbed_err = concat(perturbed_pose_err.translation(),
@@ -230,6 +249,10 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
   else
     perturbed_err = concat(perturbed_pose_err.translation(),
                            perturbed_pose_rotation_err.first * perturbed_pose_rotation_err.second);
+
+  // Apply tolerances after the paired ±π/sign correction so the clamp sees the same branch on both errors.
+  applyTolerances(err, lower_tolerance, upper_tolerance);
+  applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
 
   return (perturbed_err - err);
 }

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -235,11 +235,6 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
     perturbed_pose_rotation_err.second *= -1;
   }
 
-#ifndef NDEBUG
-  if (std::abs(pose_rotation_err.second) > 0.01 && perturbed_pose_rotation_err.first.dot(pose_rotation_err.first) < 0)
-    throw std::runtime_error("calcJacobianTransformErrorDiff, angle axes are pointing in oposite directions!");
-#endif
-
   // Angle axis has a discontinuity at PI so need to correctly handle this calculating jacobian difference
   Eigen::VectorXd perturbed_err;
   if (perturbed_pose_rotation_err.second > M_PI_2 && pose_rotation_err.second < -M_PI_2)

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -183,8 +183,8 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
 Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
-                                               const Eigen::VectorXd& lower_tolerance,
-                                               const Eigen::VectorXd& upper_tolerance)
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_tolerance,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_tolerance)
 {
   Eigen::Isometry3d pose_err = target.inverse() * source;
   std::pair<Eigen::Vector3d, double> pose_rotation_err = calcRotationalErrorDecomposed(pose_err.rotation());
@@ -233,8 +233,8 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                                                const Eigen::Isometry3d& target_perturbed,
                                                const Eigen::Isometry3d& source,
                                                const Eigen::Isometry3d& source_perturbed,
-                                               const Eigen::VectorXd& lower_tolerance,
-                                               const Eigen::VectorXd& upper_tolerance)
+                                               const Eigen::Ref<const Eigen::VectorXd>& lower_tolerance,
+                                               const Eigen::Ref<const Eigen::VectorXd>& upper_tolerance)
 {
   Eigen::Isometry3d pose_err = target.inverse() * source;
   std::pair<Eigen::Vector3d, double> pose_rotation_err = calcRotationalErrorDecomposed(pose_err.rotation());

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -159,7 +159,9 @@ Eigen::VectorXd calcTransformError(const Eigen::Isometry3d& t1, const Eigen::Iso
   return concat(pose_err.translation(), calcRotationalError(pose_err.rotation()));
 }
 
-void applyTolerances(Eigen::VectorXd& v, const Eigen::VectorXd& lower_tolerance, const Eigen::VectorXd& upper_tolerance)
+void applyTolerances(Eigen::Ref<Eigen::VectorXd> v,
+                     const Eigen::Ref<const Eigen::VectorXd>& lower_tolerance,
+                     const Eigen::Ref<const Eigen::VectorXd>& upper_tolerance)
 {
   if (lower_tolerance.size() == 0 && upper_tolerance.size() == 0)
     return;

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -214,8 +214,12 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                            perturbed_pose_rotation_err.first * perturbed_pose_rotation_err.second);
 
   // Apply tolerances after the paired ±π/sign correction so the clamp sees the same branch on both errors.
-  applyTolerances(err, lower_tolerance, upper_tolerance);
-  applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
+  // Skip when no tolerances are supplied to keep the no-tolerance forwarding path off applyTolerances.
+  if (lower_tolerance.size() != 0 || upper_tolerance.size() != 0)
+  {
+    applyTolerances(err, lower_tolerance, upper_tolerance);
+    applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
+  }
 
   return (perturbed_err - err);
 }
@@ -264,8 +268,12 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
                            perturbed_pose_rotation_err.first * perturbed_pose_rotation_err.second);
 
   // Apply tolerances after the paired ±π/sign correction so the clamp sees the same branch on both errors.
-  applyTolerances(err, lower_tolerance, upper_tolerance);
-  applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
+  // Skip when no tolerances are supplied to keep the no-tolerance forwarding path off applyTolerances.
+  if (lower_tolerance.size() != 0 || upper_tolerance.size() != 0)
+  {
+    applyTolerances(err, lower_tolerance, upper_tolerance);
+    applyTolerances(perturbed_err, lower_tolerance, upper_tolerance);
+  }
 
   return (perturbed_err - err);
 }

--- a/common/test/tesseract_common_unit.cpp
+++ b/common/test/tesseract_common_unit.cpp
@@ -2990,8 +2990,10 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
   }
 
   // Case 7: dynamic-target — band edge between err and perturbed_err.
-  // err[3] ≈ base_angle = 0.5 (inside [0, 0.55] → 0); perturbed_err[3] ≈ base_angle + big_step + eps ≈ 0.7
-  // (above band → 0.15). Diff[3] ≈ 0.15.
+  // err[3] = target.inv * source X-rotation ≈ base_angle = 0.5, inside [0, 0.55] → clamped to 0.
+  // perturbed_err[3] = target_perturbed.inv * source_perturbed X-rotation ≈ (base_angle + big_step) + eps ≈ 0.7,
+  // where the +eps comes from target_tf_perturbed (the inverse of AngleAxisd(-eps, X) applied on the left of
+  // target_tf) — source_tf_big itself contributes no eps. Above band → clamped to 0.15. Diff[3] ≈ 0.15.
   {
     const double big_step = 0.2;
     Eigen::Isometry3d source_tf_big = identity * Eigen::AngleAxisd(base_angle + big_step, Eigen::Vector3d::UnitX());

--- a/common/test/tesseract_common_unit.cpp
+++ b/common/test/tesseract_common_unit.cpp
@@ -3051,6 +3051,51 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_AxisFlipPath)  // NOLIN
   });
 }
 
+// Direct coverage of the public applyTolerances helper. The toleranced-jacobian tests above
+// only reach applyTolerances through the calcJacobianTransformErrorDiff call sites, which now
+// short-circuit when both tolerance vectors are empty — the empty-both early-return inside
+// applyTolerances is therefore unreachable from those tests but is still part of the documented
+// public API contract for external callers.
+TEST(TesseractCommonUnit, applyTolerances)  // NOLINT
+{
+  using tesseract::common::applyTolerances;
+
+  // Both tolerances empty → no-op (the previously uncovered early-return path).
+  {
+    Eigen::VectorXd v(3);
+    v << -2.0, 0.0, 3.0;
+    const Eigen::VectorXd v_copy = v;
+    applyTolerances(v, Eigen::VectorXd{}, Eigen::VectorXd{});
+    EXPECT_TRUE(v.isApprox(v_copy));
+  }
+
+  // In-band components clamped to zero; below-band shifts by lower; above-band shifts by upper.
+  {
+    Eigen::VectorXd v(4);
+    v << -2.0, -0.25, 0.25, 2.0;
+    Eigen::VectorXd lower(4);
+    lower << -1.0, -0.5, -0.5, -1.0;
+    Eigen::VectorXd upper(4);
+    upper << 1.0, 0.5, 0.5, 1.0;
+    applyTolerances(v, lower, upper);
+    Eigen::VectorXd expected(4);
+    expected << -1.0, 0.0, 0.0, 1.0;
+    EXPECT_TRUE(v.isApprox(expected));
+  }
+
+  // Mismatched lower/upper sizes throw.
+  {
+    Eigen::VectorXd v = Eigen::VectorXd::Zero(3);
+    EXPECT_THROW(applyTolerances(v, Eigen::VectorXd::Zero(2), Eigen::VectorXd::Zero(3)), std::runtime_error);
+  }
+
+  // Tolerance size not matching v throws.
+  {
+    Eigen::VectorXd v = Eigen::VectorXd::Zero(3);
+    EXPECT_THROW(applyTolerances(v, Eigen::VectorXd::Zero(4), Eigen::VectorXd::Zero(4)), std::runtime_error);
+  }
+}
+
 /** @brief Tests calcTransformError */
 TEST(TesseractCommonUnit, computeRandomColor)  // NOLINT
 {

--- a/common/test/tesseract_common_unit.cpp
+++ b/common/test/tesseract_common_unit.cpp
@@ -2957,6 +2957,93 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
     EXPECT_THROW(calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower4, upper4),
                  std::runtime_error);
   }
+
+  // Dynamic-target overload: small rotation of target frame so the constraint logic is exercised
+  // independently of the fixed-target path.
+  Eigen::Isometry3d target_tf_perturbed = Eigen::AngleAxisd(-eps, Eigen::Vector3d::UnitX()) * target_tf;
+
+  // Case 5: dynamic-target overload — both errors inside band → row clamped to zero.
+  {
+    Eigen::VectorXd lower(6), upper(6);
+    lower << -5.0, -5.0, -5.0, 0.0, -0.5, -0.5;
+    upper << 5.0, 5.0, 5.0, 1.0, 0.5, 0.5;
+    Eigen::VectorXd diff =
+        calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_perturbed, lower, upper);
+    EXPECT_TRUE(diff.isApprox(Eigen::VectorXd::Zero(6), atol));
+  }
+
+  // Case 6: dynamic-target — both errors above the band on component 3 → constant offset cancels,
+  // so the toleranced diff matches the raw FD on that component. Other components have small drift
+  // from the target perturbation that the broader translation band clamps differently, so we
+  // restrict the equality assertion to the clamped component.
+  {
+    const double band_top = base_angle - 0.1;
+    Eigen::VectorXd lower(6), upper(6);
+    lower << -5.0, -5.0, -5.0, band_top - 0.01, -0.5, -0.5;
+    upper << 5.0, 5.0, 5.0, band_top, 0.5, 0.5;
+
+    Eigen::VectorXd diff_raw =
+        calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_perturbed);
+    Eigen::VectorXd diff_tol =
+        calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_perturbed, lower, upper);
+    EXPECT_NEAR(diff_tol(3), diff_raw(3), atol);
+  }
+
+  // Case 7: dynamic-target — band edge between err and perturbed_err.
+  // err[3] ≈ base_angle = 0.5 (inside [0, 0.55] → 0); perturbed_err[3] ≈ base_angle + big_step + eps ≈ 0.7
+  // (above band → 0.15). Diff[3] ≈ 0.15.
+  {
+    const double big_step = 0.2;
+    Eigen::Isometry3d source_tf_big = identity * Eigen::AngleAxisd(base_angle + big_step, Eigen::Vector3d::UnitX());
+
+    Eigen::VectorXd lower(6), upper(6);
+    lower << -5.0, -5.0, -5.0, 0.0, -0.5, -0.5;
+    upper << 5.0, 5.0, 5.0, 0.55, 0.5, 0.5;
+
+    Eigen::VectorXd diff =
+        calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_big, lower, upper);
+    EXPECT_NEAR(diff(3), 0.15, 1e-4);
+  }
+
+  // Case 8: dynamic-target — size-mismatch throws.
+  {
+    Eigen::VectorXd lower3 = Eigen::VectorXd::Zero(3);
+    Eigen::VectorXd upper6 = Eigen::VectorXd::Zero(6);
+    EXPECT_THROW(
+        calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_perturbed, lower3, upper6),
+        std::runtime_error);
+  }
+}
+
+// Exercises the perturbed-axis flip branch in calcJacobianTransformErrorDiff. Pinned so the
+// post-flip NDEBUG check (which is unreachable by construction) can be removed without drift.
+TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_AxisFlipPath)  // NOLINT
+{
+  using tesseract::common::calcJacobianTransformErrorDiff;
+  Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+  const double eps = 1e-4;
+
+  // Near-zero rotation: small symmetric perturbation around zero forces the
+  // perturbed_pose_rotation axis to potentially have opposite sign from pose_rotation,
+  // which is exactly what the flip block in calcJacobianTransformErrorDiff exists to fix.
+  Eigen::Isometry3d target_tf{ identity };
+  target_tf.translation() = Eigen::Vector3d(1, 2, 3);
+  Eigen::Isometry3d source_tf = identity * Eigen::AngleAxisd(eps, Eigen::Vector3d::UnitX());
+  Eigen::Isometry3d source_tf_perturbed = identity * Eigen::AngleAxisd(-eps, Eigen::Vector3d::UnitX());
+
+  // Fixed-target overload.
+  EXPECT_NO_THROW({
+    Eigen::VectorXd diff = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed);
+    EXPECT_EQ(diff.size(), 6);
+  });
+
+  // Dynamic-target overload — same setup with a tiny target perturbation.
+  Eigen::Isometry3d target_tf_perturbed = Eigen::AngleAxisd(eps, Eigen::Vector3d::UnitX()) * target_tf;
+  EXPECT_NO_THROW({
+    Eigen::VectorXd diff =
+        calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_perturbed);
+    EXPECT_EQ(diff.size(), 6);
+  });
 }
 
 /** @brief Tests calcTransformError */

--- a/common/test/tesseract_common_unit.cpp
+++ b/common/test/tesseract_common_unit.cpp
@@ -3017,8 +3017,9 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
   }
 }
 
-// Exercises the perturbed-axis flip branch in calcJacobianTransformErrorDiff. Pinned so the
-// post-flip NDEBUG check (which is unreachable by construction) can be removed without drift.
+// Exercises the perturbed-axis flip branch in calcJacobianTransformErrorDiff: when the perturbed
+// rotation axis is reported with the opposite sign of the unperturbed one (common for near-zero
+// rotations), the function must internally flip it and still produce a well-formed 6-vector diff.
 TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_AxisFlipPath)  // NOLINT
 {
   using tesseract::common::calcJacobianTransformErrorDiff;

--- a/common/test/tesseract_common_unit.cpp
+++ b/common/test/tesseract_common_unit.cpp
@@ -2892,6 +2892,73 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff)  // NOLINT
   runCalcJacobianTransformErrorDiffDynamicTargetTest(2 * M_PI);
 }
 
+// Exercises the optional lower_tolerance / upper_tolerance parameters of calcJacobianTransformErrorDiff.
+TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
+{
+  using tesseract::common::calcJacobianTransformErrorDiff;
+
+  Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+  const double eps = 1e-6;
+  const double atol = 1e-10;
+
+  // Shared geometry: target translated to (1,2,3); source = X-rotation by base_angle; perturbed adds eps.
+  // calcTransformError gives err[3] ≈ base_angle (X-rotation component).
+  Eigen::Isometry3d target_tf{ identity };
+  target_tf.translation() = Eigen::Vector3d(1, 2, 3);
+  const double base_angle = 0.5;
+  Eigen::Isometry3d source_tf = identity * Eigen::AngleAxisd(base_angle, Eigen::Vector3d::UnitX());
+  Eigen::Isometry3d source_tf_perturbed = identity * Eigen::AngleAxisd(base_angle + eps, Eigen::Vector3d::UnitX());
+
+  // Case 1: both err and perturbed_err inside band → row clamped to zero.
+  {
+    Eigen::VectorXd lower(6), upper(6);
+    lower << -5.0, -5.0, -5.0, 0.0, -0.5, -0.5;
+    upper << 5.0, 5.0, 5.0, 1.0, 0.5, 0.5;
+    Eigen::VectorXd diff = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower, upper);
+    EXPECT_TRUE(diff.isApprox(Eigen::VectorXd::Zero(6), atol));
+  }
+
+  // Case 2: both errors above the band → constant offset cancels, diff equals raw FD.
+  {
+    const double band_top = base_angle - 0.1;
+    Eigen::VectorXd lower(6), upper(6);
+    lower << -5.0, -5.0, -5.0, band_top - 0.01, -0.5, -0.5;
+    upper << 5.0, 5.0, 5.0, band_top, 0.5, 0.5;
+
+    Eigen::VectorXd diff_raw = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed);
+    Eigen::VectorXd diff_tol = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower, upper);
+    EXPECT_TRUE(diff_tol.isApprox(diff_raw, atol));
+  }
+
+  // Case 3: band edge between err and perturbed_err → non-zero sub-gradient (the bug-fix scenario).
+  // base_angle=0.5 is inside [0.0, 0.55], base_angle + 0.2 = 0.7 is outside.
+  // Clamped diff[3] = (0.7 - 0.55) - 0.0 = 0.15.
+  {
+    const double big_step = 0.2;
+    Eigen::Isometry3d source_tf_big = identity * Eigen::AngleAxisd(base_angle + big_step, Eigen::Vector3d::UnitX());
+
+    Eigen::VectorXd lower(6), upper(6);
+    lower << -5.0, -5.0, -5.0, 0.0, -0.5, -0.5;
+    upper << 5.0, 5.0, 5.0, 0.55, 0.5, 0.5;
+
+    Eigen::VectorXd diff = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_big, lower, upper);
+    EXPECT_NEAR(diff(3), 0.15, atol);
+  }
+
+  // Case 4: size-mismatch throws.
+  {
+    Eigen::VectorXd lower3 = Eigen::VectorXd::Zero(3);
+    Eigen::VectorXd upper6 = Eigen::VectorXd::Zero(6);
+    EXPECT_THROW(calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower3, upper6),
+                 std::runtime_error);
+
+    Eigen::VectorXd lower4 = Eigen::VectorXd::Zero(4);
+    Eigen::VectorXd upper4 = Eigen::VectorXd::Zero(4);
+    EXPECT_THROW(calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower4, upper4),
+                 std::runtime_error);
+  }
+}
+
 /** @brief Tests calcTransformError */
 TEST(TesseractCommonUnit, computeRandomColor)  // NOLINT
 {

--- a/common/test/tesseract_common_unit.cpp
+++ b/common/test/tesseract_common_unit.cpp
@@ -2899,6 +2899,8 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
 
   Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
   const double eps = 1e-6;
+  // Absolute tolerance: assertions below use isZero / EXPECT_NEAR / cwiseAbs().maxCoeff(),
+  // all of which interpret atol as an absolute bound on the per-component error.
   const double atol = 1e-10;
 
   // Shared geometry: target translated to (1,2,3); source = X-rotation by base_angle; perturbed adds eps.
@@ -2915,7 +2917,7 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
     lower << -5.0, -5.0, -5.0, 0.0, -0.5, -0.5;
     upper << 5.0, 5.0, 5.0, 1.0, 0.5, 0.5;
     Eigen::VectorXd diff = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower, upper);
-    EXPECT_TRUE(diff.isApprox(Eigen::VectorXd::Zero(6), atol));
+    EXPECT_TRUE(diff.isZero(atol));
   }
 
   // Case 2: both errors above the band → constant offset cancels, diff equals raw FD.
@@ -2927,7 +2929,7 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
 
     Eigen::VectorXd diff_raw = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed);
     Eigen::VectorXd diff_tol = calcJacobianTransformErrorDiff(target_tf, source_tf, source_tf_perturbed, lower, upper);
-    EXPECT_TRUE(diff_tol.isApprox(diff_raw, atol));
+    EXPECT_LT((diff_tol - diff_raw).cwiseAbs().maxCoeff(), atol);
   }
 
   // Case 3: band edge between err and perturbed_err → non-zero sub-gradient (the bug-fix scenario).
@@ -2969,7 +2971,7 @@ TEST(TesseractCommonUnit, calcJacobianTransformErrorDiff_Toleranced)  // NOLINT
     upper << 5.0, 5.0, 5.0, 1.0, 0.5, 0.5;
     Eigen::VectorXd diff =
         calcJacobianTransformErrorDiff(target_tf, target_tf_perturbed, source_tf, source_tf_perturbed, lower, upper);
-    EXPECT_TRUE(diff.isApprox(Eigen::VectorXd::Zero(6), atol));
+    EXPECT_TRUE(diff.isZero(atol));
   }
 
   // Case 6: dynamic-target — both errors above the band on component 3 → constant offset cancels,


### PR DESCRIPTION
 ## Summary

  - Add optional `lower_tolerance` / `upper_tolerance` args (defaulted empty) to both `tesseract::common::calcJacobianTransformErrorDiff` overloads. When supplied, `err` and `perturbed_err` are clamped to a per-component dead-band
  before subtraction, keeping the FD Jacobian consistent with toleranced error functions.
  - Expose `tesseract::common::applyTolerances` as a public in-place dead-band helper.
  - Empty defaults preserve raw FD behavior — existing callers are unaffected.

  ## Context

  `calcJacobianTransformErrorDiff` is used to build the analytical Jacobian of toleranced Cartesian-pose error functions. Pre-fix, the FD Jacobian subtracted `err` and `perturbed_err` raw — without applying the tolerance clamp the error
   function itself uses — so whenever both fell inside the band the row collapsed to zero, and SQP solvers absorbed it as wasted band slack.

  The clamp is applied after the paired ±π / sign correction so both errors see the same angle-axis branch. When one error is inside and one outside the band, the per-component clamp preserves a non-zero sub-gradient — the descent
  direction a solver needs to cross the band edge.

  ## Test plan

  The new `TesseractCommonUnit.calcJacobianTransformErrorDiff_Toleranced` test covers in-band (diff row collapses to zero), out-of-band (constant offset cancels — result equals raw FD), band-edge (non-zero sub-gradient row), and
  size-mismatch (throws). The existing `calcJacobianTransformErrorDiff` test continues to verify the no-tolerance path. Full `tesseract_common_unit` suite passes locally.