### PR TITLE
Install tesseract/srdf/configs.h

### DIFF
--- a/srdf/CMakeLists.txt
+++ b/srdf/CMakeLists.txt
@@ -59,6 +59,7 @@ install(
         include/tesseract/srdf/kinematics_information.h
         include/tesseract/srdf/utils.h
         include/tesseract/srdf/fwd.h
+        include/tesseract/srdf/configs.h
   DESTINATION include/tesseract/srdf
   COMPONENT srdf)
 


### PR DESCRIPTION
Related to #1302 

`tesseract/srdf/configs.h` is not being installed. This is needed for loading plugins from Python using the API.