### PR TITLE
Restore Cereal template registration in compiled cpp files instead of…

### DIFF
--- a/.github/workflows/conda/recipe/build.sh
+++ b/.github/workflows/conda/recipe/build.sh
@@ -2,6 +2,13 @@ set -e
 
 # ln -s $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-gcc $BUILD_PREFIX/bin/gcc
 
+# conda's clang adds -fvisibility-inlines-hidden, hiding Cereal's visibility("default")
+# registration singleton; with Mach-O's two-level namespace each dylib gets its own registry
+# and consumers throw "unregistered polymorphic type". Strip it so the registry is shared.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  export CXXFLAGS="${CXXFLAGS//-fvisibility-inlines-hidden/}"
+fi
+
 colcon build --merge-install --install-base="$PREFIX/opt/tesseract_robotics" \
    --event-handlers console_direct+ \
    --packages-ignore gtest osqp osqp_eigen tesseract_examples trajopt_ifopt trajopt_sqp \

--- a/collision/core/CMakeLists.txt
+++ b/collision/core/CMakeLists.txt
@@ -8,6 +8,10 @@ add_library(
   src/types.cpp
   src/utils.cpp)
 add_library(tesseract::collision ALIAS collision)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(collision PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(collision PROPERTIES OUTPUT_NAME tesseract_collision)
 target_link_libraries(
   collision

--- a/collision/core/include/tesseract/collision/cereal_serialization.h
+++ b/collision/core/include/tesseract/collision/cereal_serialization.h
@@ -141,6 +141,12 @@ void serialize(Archive& ar, tesseract::collision::ContactTrajectoryResults& g)
 }
 }  // namespace tesseract::collision
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/collision/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_collision_cereal)
+#endif
 
 #endif  // TESSERACT_COLLISION_CEREAL_SERIALIZATION_H

--- a/collision/core/src/cereal_serialization.cpp
+++ b/collision/core/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/collision/cereal_serialization.h>
+#include <tesseract/collision/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_collision_cereal)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -57,6 +57,10 @@ add_library(
   src/timer.cpp
   src/yaml_utils.cpp)
 add_library(tesseract::common ALIAS common)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(common PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(common PROPERTIES OUTPUT_NAME tesseract_common)
 target_link_libraries(
   common

--- a/common/include/tesseract/common/cereal_serialization.h
+++ b/common/include/tesseract/common/cereal_serialization.h
@@ -225,6 +225,12 @@ void serialize(Archive& ar, ProfileDictionary& obj)
 
 }  // namespace tesseract::common
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/common/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_common_cereal)
+#endif
 
 #endif  // TESSERACT_COMMON_CEREAL_SERIALIZATION_H

--- a/common/src/cereal_serialization.cpp
+++ b/common/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/common/cereal_serialization.h>
+#include <tesseract/common/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_common_cereal)

--- a/environment/CMakeLists.txt
+++ b/environment/CMakeLists.txt
@@ -32,6 +32,10 @@ add_library(
   src/commands/set_active_continuous_contact_manager_command.cpp
   src/commands/set_active_discrete_contact_manager_command.cpp)
 add_library(tesseract::environment ALIAS environment)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(environment PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(environment PROPERTIES OUTPUT_NAME tesseract_environment)
 target_link_libraries(
   environment

--- a/environment/include/tesseract/environment/cereal_serialization.h
+++ b/environment/include/tesseract/environment/cereal_serialization.h
@@ -244,6 +244,12 @@ void serialize(Archive& ar, Environment& obj)
 
 }  // namespace tesseract::environment
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/environment/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_environment_cereal)
+#endif
 
 #endif  // TESSERACT_ENVIRONMENT_CEREAL_SERIALIZATION_H

--- a/environment/src/cereal_serialization.cpp
+++ b/environment/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/environment/cereal_serialization.h>
+#include <tesseract/environment/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_environment_cereal)

--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -42,6 +42,10 @@ add_library(
   src/geometries/sdf_mesh.cpp
   src/geometries/sphere.cpp)
 add_library(tesseract::geometry ALIAS geometry)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(geometry PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(geometry PROPERTIES OUTPUT_NAME tesseract_geometry)
 target_link_libraries(
   geometry

--- a/geometry/include/tesseract/geometry/cereal_serialization.h
+++ b/geometry/include/tesseract/geometry/cereal_serialization.h
@@ -166,6 +166,12 @@ void serialize(Archive& ar, CompoundMesh& obj)
 
 }  // namespace tesseract::geometry
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/geometry/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_geometry_cereal)
+#endif
 
 #endif  // TESSERACT_GEOMETRY_CEREAL_SERIALIZATION_H

--- a/geometry/src/cereal_serialization.cpp
+++ b/geometry/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/geometry/cereal_serialization.h>
+#include <tesseract/geometry/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_geometry_cereal)


### PR DESCRIPTION
… via _impl headers for non-Windows builds.

PR #1273 caused a massive regression in build memory usage and build times. Reason was the heavy Cereal template instantiation whenever these headers were included. This PR reverts the template registration to cpp files for non-Windows builds.

This also adds [CEREAL_FORCE_DYNAMIC_INIT](https://uscilab.github.io/cereal/assets/doxygen/polymorphic_8hpp.html#a8e0d5df9830c0ed7c60451cf2f873ff5) in the header (non-Windows) to match CEREAL_REGISTER_DYNAMIC_INIT in the cpp (fixes conda-mac CI).

Windows builds are not affected, the fix of the mentioned PR is still in place for that platform.