### PR TITLE
Add missing stdexcept include to any_poly.h

### DIFF
--- a/common/include/tesseract/common/any_poly.h
+++ b/common/include/tesseract/common/any_poly.h
@@ -30,6 +30,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <memory>
+#include <stdexcept>
 #include <typeindex>
 #include <unordered_map>
 


### PR DESCRIPTION
any_poly.h uses std::runtime_error in four cast-checking methods of AnyPoly, but never includes the <stdexcept> header that defines it. This compiles successfully on toolchains where <stdexcept> is pulled in transitively through other headers, but fails on stricter or newer compiler/stdlib configurations where that transitive include is not guaranteed.

Change:

Added #include <stdexcept> to common/include/tesseract/common/any_poly.h alongside the other standard library includes.

Why it was missing:

The file relies on <boost/stacktrace.hpp> and <boost/core/demangle.hpp>, which on some platforms happen to transitively include <stdexcept>. This masked the missing direct include until a build environment without that transitive dependency surfaced the error.

Impact:

No behavioral change — this is a header-only fix to satisfy the include-what-you-use principle and ensure portability across all conforming toolchains.