### PR TITLE
Remove -mno-avx gcc compiler flag

### DIFF
--- a/.github/workflows/windows_dependencies.repos
+++ b/.github/workflows/windows_dependencies.repos
@@ -9,4 +9,4 @@
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
-    version: 0.5.3
+    version: 0.5.5

--- a/common/cmake/tesseract_macros.cmake
+++ b/common/cmake/tesseract_macros.cmake
@@ -84,21 +84,6 @@ macro(tesseract_variables)
           -Wsign-conversion
           -Wno-sign-compare
           -Wnon-virtual-dtor)
-      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
-      if(NOT
-         CMAKE_SYSTEM_NAME2
-         MATCHES
-         "aarch64"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "armv7l"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "unknown")
-        set(TESSERACT_COMPILE_OPTIONS_PUBLIC -mno-avx)
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TESSERACT_COMPILE_OPTIONS_PRIVATE
           -Wall
@@ -123,21 +108,6 @@ macro(tesseract_variables)
           -Werror=sign-conversion
           -Wno-sign-compare
           -Werror=non-virtual-dtor)
-      execute_process(COMMAND uname -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
-      if(NOT
-         CMAKE_SYSTEM_NAME2
-         MATCHES
-         "aarch64"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "armv7l"
-         AND NOT
-             CMAKE_SYSTEM_NAME2
-             MATCHES
-             "unknown")
-        set(TESSERACT_COMPILE_OPTIONS_PUBLIC -mno-avx)
-      endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
       set(TESSERACT_COMPILE_OPTIONS_PRIVATE
           -Werror=all

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -9,7 +9,7 @@
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
-    version: 0.5.3
+    version: 0.5.5
 - git:
     local-name: cereal
     uri: https://github.com/Levi-Armstrong/cereal.git

--- a/dependencies_focal.repos
+++ b/dependencies_focal.repos
@@ -9,7 +9,7 @@
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
-    version: 0.5.3
+    version: 0.5.5
 - git:
     local-name: fcl
     uri: https://github.com/flexible-collision-library/fcl.git

--- a/dependencies_with_ext.repos
+++ b/dependencies_with_ext.repos
@@ -13,7 +13,7 @@
 - git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
-    version: 0.5.3
+    version: 0.5.5
 - git:
     local-name: cereal
     uri: https://github.com/Levi-Armstrong/cereal.git


### PR DESCRIPTION
The `-mno-avx` gcc compiler flag does not appear to be necessary with modern gcc versions.