### PR TITLE
Optimize package dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -39,8 +39,7 @@
   <depend>yaml-cpp</depend>
   <depend>boost_plugin_loader</depend>
   <depend>liboctomap-dev</depend>
-  <build_depend>cereal</build_depend>
-  <build_export_depend>cereal</build_export_depend>
+  <depend>cereal</depend>
   <build_depend>assimp-dev</build_depend>
   <build_export_depend>assimp-dev</build_export_depend>
   <exec_depend>assimp</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -30,28 +30,33 @@
 
   <!-- PCL -->
   <build_depend>libpcl-all-dev</build_depend>
-  <build_export_depend>libpcl-all-dev</build_export_depend>
-  <exec_depend>libpcl-all</exec_depend>
+  <exec_depend>libpcl-common</exec_depend>
+  <exec_depend>libpcl-io</exec_depend>
 
   <!-- Core dependencies -->
   <depend>libconsole-bridge-dev</depend>
   <depend>tinyxml2</depend>
   <depend>yaml-cpp</depend>
   <depend>boost_plugin_loader</depend>
-  <depend>cereal</depend>
-  <depend>assimp-dev</depend>
   <depend>liboctomap-dev</depend>
-  <depend>boost</depend>
-  <depend>liborocos-kdl-dev</depend>
+  <build_depend>cereal</build_depend>
+  <build_export_depend>cereal</build_export_depend>
+  <build_depend>assimp-dev</build_depend>
+  <build_export_depend>assimp-dev</build_export_depend>
+  <exec_depend>assimp</exec_depend>
+  <build_depend>liborocos-kdl-dev</build_depend>
+  <build_export_depend>liborocos-kdl-dev</build_export_depend>
+  <exec_depend>liborocos-kdl</exec_depend>
 
   <!-- Collision -->
   <depend>bullet</depend>
   <depend>bullet-extras</depend>
-  <depend>fcl</depend>
-  <depend>libfcl-dev</depend>
+  <build_depend>libfcl-dev</build_depend>
+  <exec_depend>libfcl</exec_depend>
 
   <!-- Kinematics -->
-  <depend>opw_kinematics</depend>
+  <build_depend>opw_kinematics</build_depend>
+  <build_export_depend>opw_kinematics</build_export_depend>
 
   <!-- Test dependencies -->
   <test_depend>gtest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -52,6 +52,7 @@
   <depend>bullet</depend>
   <depend>bullet-extras</depend>
   <build_depend>libfcl-dev</build_depend>
+  <build_export_depend>libfcl-dev</build_export_depend>
   <exec_depend>libfcl</exec_depend>
 
   <!-- Kinematics -->

--- a/package.xml
+++ b/package.xml
@@ -39,7 +39,8 @@
   <depend>yaml-cpp</depend>
   <depend>boost_plugin_loader</depend>
   <depend>liboctomap-dev</depend>
-  <depend>cereal</depend>
+  <build_depend>libcereal-dev</build_depend>
+  <build_export_depend>libcereal-dev</build_export_depend>
   <build_depend>assimp-dev</build_depend>
   <build_export_depend>assimp-dev</build_export_depend>
   <exec_depend>assimp</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -56,8 +56,7 @@
   <exec_depend>libfcl</exec_depend>
 
   <!-- Kinematics -->
-  <build_depend>opw_kinematics</build_depend>
-  <build_export_depend>opw_kinematics</build_export_depend>
+  <depend>opw_kinematics</depend>
 
   <!-- Test dependencies -->
   <test_depend>gtest</test_depend>


### PR DESCRIPTION
Optimize dependencies:

* Mark header-only libraries as `build_depend` (and `build_export_depend` when they are public).
* Use `-dev` dependencies for `build` and the normal onces for `exec` when they are available through `rosdep`
* Only define used `pcl` components for `exec` to avoid installing complete `pcl` when not needed