### PR TITLE
Fix broken cereal install on jammy

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -34,7 +34,8 @@ jobs:
         uses: tesseract-robotics/colcon-action@v14
         with:
           ccache-prefix: benchmarks
-          vcs-file: dependencies.repos
+          vcs-file: dependencies_jammy.repos
+          rosdep-install-args: -iry --skip-keys=libcereal-dev
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Release -DTESSERACT_ENABLE_TESTING=OFF -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF -DBENCHMARK_ARGS=CI_ONLY

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -68,9 +68,9 @@ jobs:
         uses: tesseract-robotics/colcon-action@v14
         with:
           ccache-prefix: ${{ matrix.distro }}
-          vcs-file: dependencies.repos
+          vcs-file: dependencies_jammy.repos
           run-tests: false
-          rosdep-install-args: -iry --skip-keys=libomp-dev
+          rosdep-install-args: -iry --skip-keys=libomp-dev --skip-keys=libcereal-dev
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args ${{ matrix.env.TARGET_CMAKE_ARGS }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [jammy, noble]
+        include:
+          - distro: jammy
+            vcs_file: dependencies_jammy.repos
+            rosdep_skip_keys: libcereal-dev
+          - distro: noble
+            vcs_file: dependencies.repos
+            rosdep_skip_keys: cereal
     container:
       image: ubuntu:${{ matrix.distro }}
       env:
@@ -41,7 +47,8 @@ jobs:
         uses: tesseract-robotics/colcon-action@v14
         with:
           ccache-prefix: ${{ matrix.distro }}
-          vcs-file: dependencies.repos
+          vcs-file: ${{ matrix.vcs_file }}
+          rosdep-install-args: -iry --skip-keys ${{ matrix.rosdep_skip_keys }}
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -19,7 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [jammy, noble]
+        include:
+          - distro: jammy
+            vcs_file: dependencies_jammy.repos
+            rosdep_skip_keys: libcereal-dev
+          - distro: noble
+            vcs_file: dependencies.repos
+            rosdep_skip_keys: cereal
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -37,7 +43,8 @@ jobs:
         uses: tesseract-robotics/colcon-action@v14
         with:
           ccache-enabled: false
-          vcs-file: dependencies.repos
+          vcs-file: ${{ matrix.vcs_file }}
+          rosdep-install-args: -iry --skip-keys ${{ matrix.rosdep_skip_keys }}
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Release -DTESSERACT_PACKAGE=ON

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -35,7 +35,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [jammy, noble]
+        include:
+          - distro: jammy
+            vcs_file: dependencies_jammy.repos
+            rosdep_skip_keys: libcereal-dev
+          - distro: noble
+            vcs_file: dependencies.repos
+            rosdep_skip_keys: cereal
     container:
       image: ubuntu:${{ matrix.distro }}
       env:
@@ -59,7 +65,8 @@ jobs:
         uses: tesseract-robotics/colcon-action@v14
         with:
           ccache-prefix: ${{ matrix.distro }}
-          vcs-file: dependencies.repos
+          vcs-file: ${{ matrix.vcs_file }}
+          rosdep-install-args: -iry --skip-keys ${{ matrix.rosdep_skip_keys }}
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF -DTESSERACT_PACKAGE=ON

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -10,7 +10,3 @@
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
     version: 0.5.5
-- git:
-    local-name: cereal
-    uri: https://github.com/Levi-Armstrong/cereal.git
-    version: catkin

--- a/dependencies_jammy.repos
+++ b/dependencies_jammy.repos
@@ -7,10 +7,10 @@
     uri: https://github.com/tesseract-robotics/boost_plugin_loader.git
     version: 0.4.3
 - git:
-    local-name: tesseract_ext
-    uri: https://github.com/ros-industrial-consortium/tesseract_ext.git
-    version: master
-- git:
     local-name: opw_kinematics
     uri: https://github.com/Jmeyer1292/opw_kinematics.git
     version: 0.5.5
+- git:
+    local-name: cereal
+    uri: https://github.com/Levi-Armstrong/cereal.git
+    version: catkin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN --mount=type=tmpfs,target=${WORKSPACE_DIR} --mount=type=bind,target=${WORKSP
        rosdep install --from-paths ${WORKSPACE_DIR}/src --skip-keys libcereal-dev -iry; \
      else \
        vcs import src < src/tesseract/dependencies.repos --shallow; \
-       rosdep install --from-paths ${WORKSPACE_DIR}/src -iry; \
+       rosdep install --from-paths ${WORKSPACE_DIR}/src --skip-keys cereal -iry; \
      fi \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
   && cp -r ${WORKSPACE_DIR}/install ${INSTALL_DIR}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,11 +34,13 @@ RUN --mount=type=tmpfs,target=${WORKSPACE_DIR} --mount=type=bind,target=${WORKSP
   cd ${WORKSPACE_DIR} \
   && if [ "$TAG" = "focal" ]; then \
        vcs import src < src/tesseract/dependencies_focal.repos --shallow; \
+       rosdep install --from-paths ${WORKSPACE_DIR}/src --skip-keys libcereal-dev --skip-keys libfcl-dev -iry; \
+     elif [ "$TAG" = "jammy" ]; then \
+       vcs import src < src/tesseract/dependencies_jammy.repos --shallow; \
+       rosdep install --from-paths ${WORKSPACE_DIR}/src --skip-keys libcereal-dev -iry; \
      else \
        vcs import src < src/tesseract/dependencies.repos --shallow; \
+       rosdep install --from-paths ${WORKSPACE_DIR}/src -iry; \
      fi \
-  && rosdep install \
-    --from-paths ${WORKSPACE_DIR}/src \
-    -iry \
   && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
   && cp -r ${WORKSPACE_DIR}/install ${INSTALL_DIR}

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,12 @@
   <depend>liboctomap-dev</depend>
   <build_depend>libcereal-dev</build_depend>
   <build_export_depend>libcereal-dev</build_export_depend>
+
+  <!-- Add dependency on Cereal package for Ubuntu Jammy since the system package is broken. 
+  TODO: remove these keys once support for Jammy is dropped. -->
+  <build_depend>cereal</build_depend>
+  <build_export_depend>cereal</build_export_depend>
+
   <build_depend>assimp-dev</build_depend>
   <build_export_depend>assimp-dev</build_export_depend>
   <exec_depend>assimp</exec_depend>


### PR DESCRIPTION
Fix broken cereal install on focal and jammy, `libcereal-dev` is broken on these distributions. With this change, we use the original `cereal` package on these distribtions while we rely on rosdep on noble.