### PR TITLE
Quote git diff output and remove pull_request path filters

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -37,5 +37,5 @@ jobs:
           ./.run-clang-format
           if [ $? -ge 1 ]; then return 1; fi
           output=$(git diff)
-          echo $output
+          echo "$output"
           if [ -n "$output" ]; then exit 1; else exit 0; fi

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -6,20 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - '.github/workflows/clang_format.yml'
-      - '**clang-format'
   schedule:
     - cron: '0 5 * * *'
 

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -6,22 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - 'CMakeLists.txt'
-      - 'package.xml'
-      - '.github/workflows/cmake_format.yml'
-      - '**cmake-format'
   schedule:
     - cron: '0 5 * * *'
 

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -6,22 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - 'CMakeLists.txt'
-      - 'package.xml'
-      - '.github/workflows/code_quality.yml'
-      - '.clang-tidy'
   schedule:
     - cron: '0 5 * * *'
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,23 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - 'CMakeLists.txt'
-      - 'package.xml'
-      - '.github/workflows/conda.yml'
-      - '.github/workflows/conda/**'
-      - '**.repos'
   release:
     types:
       - released

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,22 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - 'CMakeLists.txt'
-      - 'package.xml'
-      - '.github/workflows/mac.yml'
-      - '**.repos'
   schedule:
     - cron: '0 5 * * *'
   release:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,22 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - 'CMakeLists.txt'
-      - 'package.xml'
-      - '.github/workflows/ubuntu.yml'
-      - '**.repos'
   schedule:
     - cron: '0 5 * * *'
   release:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,23 +6,6 @@ on:
       - master
       - 'dev**'
   pull_request:
-    paths:
-      - 'collision/**'
-      - 'common/**'
-      - 'environment/**'
-      - 'geometry/**'
-      - 'kinematics/**'
-      - 'scene_graph/**'
-      - 'srdf/**'
-      - 'state_solver/**'
-      - 'support/**'
-      - 'urdf/**'
-      - 'visualization/**'
-      - 'CMakeLists.txt'
-      - 'package.xml'
-      - '.github/workflows/windows.yml'
-      - '.github/workflows/windows_dependencies.repos'
-      - '**.repos'
   schedule:
     - cron: '0 5 * * *'
 


### PR DESCRIPTION
### Quote git diff output in clang_format workflow

Without quotes, the shell collapses whitespace, so newlines and multi-space indents in the diff become a single line of words. This would make the CI failure log unreadable when the formatter found issues.

Note: This is already done in some other repos, e.g. Trajopt.

### Remove pull_request path filters from CI workflows

Found while opening this PR: it touches only a workflow file, so `clang_format` was the only workflow whose `paths:` filter matched. Every other required check sat at "Waiting for status to be reported" and the PR was blocked indefinitely — a workflow that is never triggered reports no status at all. (A job skipped by an `if:` condition does report a `skipped` conclusion, which satisfies a required check; a workflow that never runs does not.)

The filters bought little in return. They only fire for PRs touching exclusively unlisted paths, and the `push:` triggers on master are unfiltered, so the same builds run on merge regardless. They were also drifting out of sync with the tree — `ci/**` and `docs/**` appear in no filter.

Bare `pull_request:` is already the majority convention across the organization: trajopt's `ubuntu.yml` and `unstable.yml`, tesseract_qt's `ubuntu.yml` and `unstable.yml`, and tesseract_planning's `clang_format.yml`, `cmake_format.yml` and `conda.yml` all use it. tesseract was the only repo where every build workflow was filtered.

`docker.yml` keeps its filter — it is narrow (`docker/Dockerfile` only) and not a required check.