### PR TITLE
Fix ROP/REP clone state loss, factory exception leaks and redundant clones

### DIFF
--- a/kinematics/core/src/rep_factory.cpp
+++ b/kinematics/core/src/rep_factory.cpp
@@ -162,15 +162,21 @@ std::unique_ptr<InverseKinematics> REPInvKinFactory::create(const std::string& s
     {
       throw std::runtime_error("REPInvKinFactory, missing 'manipulator' entry!");
     }
+
+    return std::make_unique<REPInvKin>(scene_graph,
+                                       scene_state,
+                                       std::move(inv_kin),
+                                       m_reach,
+                                       std::move(fwd_kin),
+                                       sample_range,
+                                       sample_res,
+                                       solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("REPInvKinFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<REPInvKin>(
-      scene_graph, scene_state, std::move(inv_kin), m_reach, std::move(fwd_kin), sample_range, sample_res, solver_name);
 }
 
 PLUGIN_ANCHOR_IMPL(REPInvKinFactoriesAnchor)

--- a/kinematics/core/src/rep_inv_kin.cpp
+++ b/kinematics/core/src/rep_inv_kin.cpp
@@ -124,9 +124,9 @@ void REPInvKin::init(const tesseract::scene_graph::SceneGraph& scene_graph,
                                    scene_state.link_transforms.at(positioner->getBaseLinkName());
 
   solver_name_ = std::move(solver_name);
-  manip_inv_kin_ = manipulator->clone();
+  manip_inv_kin_ = std::move(manipulator);
   manip_reach_ = manipulator_reach;
-  positioner_fwd_kin_ = positioner->clone();
+  positioner_fwd_kin_ = std::move(positioner);
   working_frame_ = positioner_fwd_kin_->getTipLinkNames()[0];
   manip_tip_link_ = manip_inv_kin_->getTipLinkNames()[0];
   dof_ = positioner_fwd_kin_->numJoints() + manip_inv_kin_->numJoints();

--- a/kinematics/core/src/rep_inv_kin.cpp
+++ b/kinematics/core/src/rep_inv_kin.cpp
@@ -169,6 +169,7 @@ REPInvKin& REPInvKin::operator=(const REPInvKin& other)
   manip_tip_link_ = other.manip_tip_link_;
   dof_ = other.dof_;
   dof_range_ = other.dof_range_;
+  solver_name_ = other.solver_name_;
 
   return *this;
 }

--- a/kinematics/core/src/rop_factory.cpp
+++ b/kinematics/core/src/rop_factory.cpp
@@ -163,15 +163,21 @@ std::unique_ptr<InverseKinematics> ROPInvKinFactory::create(const std::string& s
     {
       throw std::runtime_error("ROPInvKinFactory, missing 'manipulator' entry!");
     }
+
+    return std::make_unique<ROPInvKin>(scene_graph,
+                                       scene_state,
+                                       std::move(inv_kin),
+                                       m_reach,
+                                       std::move(fwd_kin),
+                                       sample_range,
+                                       sample_res,
+                                       solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("ROPInvKinFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<ROPInvKin>(
-      scene_graph, scene_state, std::move(inv_kin), m_reach, std::move(fwd_kin), sample_range, sample_res, solver_name);
 }
 
 PLUGIN_ANCHOR_IMPL(ROPInvKinFactoriesAnchor)

--- a/kinematics/core/src/rop_inv_kin.cpp
+++ b/kinematics/core/src/rop_inv_kin.cpp
@@ -169,9 +169,11 @@ ROPInvKin& ROPInvKin::operator=(const ROPInvKin& other)
   manip_tip_link_ = other.manip_tip_link_;
   positioner_tip_link_ = other.positioner_tip_link_;
   manip_reach_ = other.manip_reach_;
+  positioner_to_robot_ = other.positioner_to_robot_;
   joint_names_ = other.joint_names_;
   dof_ = other.dof_;
   dof_range_ = other.dof_range_;
+  solver_name_ = other.solver_name_;
 
   return *this;
 }

--- a/kinematics/test/rep_kinematics_unit.cpp
+++ b/kinematics/test/rep_kinematics_unit.cpp
@@ -208,6 +208,38 @@ TEST(TesseractKinematicsUnit, RobotWithExternalPositionerInverseKinematicUnit)  
   runKinSetJointLimitsTest(kin_group2);
 }
 
+// Regression: REPInvKin::operator= dropped solver_name_, so every clone silently reverted to the
+// default name. The existing clone checks miss it because they build the solver with that default.
+TEST(TesseractKinematicsUnit, RobotWithExternalPositionerClonePreservesStateUnit)  // NOLINT
+{
+  tesseract::common::GeneralResourceLocator locator;
+  auto scene_graph = getSceneGraphABBExternalPositioner(locator);
+
+  tesseract::scene_graph::KDLStateSolver state_solver(*scene_graph);
+  tesseract::scene_graph::SceneState scene_state = state_solver.getState();
+
+  auto robot_fwd_kin = getRobotFwdKinematics(*scene_graph);
+  auto opw_kin = std::make_unique<OPWInvKin>(getOPWKinematicsParamABB(),
+                                             robot_fwd_kin->getBaseLinkName(),
+                                             robot_fwd_kin->getTipLinkNames()[0],
+                                             robot_fwd_kin->getJointNames());
+  auto positioner_kin = getPositionerFwdKinematics(*scene_graph);
+  Eigen::VectorXd positioner_resolution = Eigen::VectorXd::Constant(2, 1, 0.1);
+
+  const std::string custom_solver_name{ "CustomREPSolverName" };
+  REPInvKin original(*scene_graph,
+                     scene_state,
+                     opw_kin->clone(),
+                     2.5,
+                     positioner_kin->clone(),
+                     positioner_resolution,
+                     custom_solver_name);
+
+  auto cloned = original.clone();
+  ASSERT_TRUE(cloned != nullptr);
+  EXPECT_EQ(cloned->getSolverName(), custom_solver_name);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/kinematics/test/rop_kinematics_unit.cpp
+++ b/kinematics/test/rop_kinematics_unit.cpp
@@ -212,6 +212,67 @@ TEST(TesseractKinematicsUnit, RobotOnPositionerInverseKinematicUnit)  // NOLINT
   runKinSetJointLimitsTest(kin_group2);
 }
 
+// Regression: ROPInvKin::operator= dropped positioner_to_robot_ and solver_name_. Because the copy
+// ctor delegates to operator= and clone() copy-constructs, every clone silently reverted to an
+// identity positioner->robot transform and the default solver name. The stock rig hides this: its
+// positioner_robot_joint origin is identity, so the dropped transform is unobservable.
+TEST(TesseractKinematicsUnit, RobotOnPositionerClonePreservesStateUnit)  // NOLINT
+{
+  tesseract::common::GeneralResourceLocator locator;
+  auto scene_graph = getSceneGraphABBOnPositioner(locator);
+
+  // Offset the robot base from the positioner tip so positioner_to_robot_ is non-identity.
+  Eigen::Isometry3d robot_offset{ Eigen::Isometry3d::Identity() };
+  robot_offset.translation() = Eigen::Vector3d(0.25, -0.15, 0.35);
+  ASSERT_TRUE(scene_graph->changeJointOrigin("positioner_robot_joint", robot_offset));
+
+  tesseract::scene_graph::KDLStateSolver state_solver(*scene_graph);
+  tesseract::scene_graph::SceneState scene_state = state_solver.getState();
+
+  auto robot_fwd_kin = getRobotFwdKinematics(*scene_graph);
+  auto opw_kin = std::make_unique<OPWInvKin>(getOPWKinematicsParamABB(),
+                                             robot_fwd_kin->getBaseLinkName(),
+                                             robot_fwd_kin->getTipLinkNames()[0],
+                                             robot_fwd_kin->getJointNames());
+  auto positioner_kin = getPositionerFwdKinematics(*scene_graph);
+  Eigen::VectorXd positioner_resolution = Eigen::VectorXd::Constant(1, 1, 0.1);
+
+  const std::string custom_solver_name{ "CustomROPSolverName" };
+  ROPInvKin original(*scene_graph,
+                     scene_state,
+                     opw_kin->clone(),
+                     2.5,
+                     positioner_kin->clone(),
+                     positioner_resolution,
+                     custom_solver_name);
+
+  auto cloned = original.clone();
+  ASSERT_TRUE(cloned != nullptr);
+
+  // solver_name_ must survive the copy.
+  EXPECT_EQ(cloned->getSolverName(), custom_solver_name);
+
+  // positioner_to_robot_ must survive: build a target by forward kinematics so it is reachable,
+  // then require the clone to return exactly the solutions the original does.
+  auto full_fwd_kin = getFullFwdKinematics(*scene_graph);
+  Eigen::VectorXd q = Eigen::VectorXd::Zero(full_fwd_kin->numJoints());
+  q(1) = 0.3;
+  q(2) = -0.4;
+  q(4) = 0.5;
+  tesseract::common::TransformMap tip_link_poses{ { "tool0", full_fwd_kin->calcFwdKin(q).at("tool0") } };
+  Eigen::VectorXd seed = Eigen::VectorXd::Zero(full_fwd_kin->numJoints());
+
+  IKSolutions original_solutions;
+  original.calcInvKin(original_solutions, tip_link_poses, seed);
+  IKSolutions cloned_solutions;
+  cloned->calcInvKin(cloned_solutions, tip_link_poses, seed);
+
+  ASSERT_FALSE(original_solutions.empty());
+  ASSERT_EQ(original_solutions.size(), cloned_solutions.size());
+  for (std::size_t i = 0; i < original_solutions.size(); ++i)
+    EXPECT_TRUE(original_solutions[i].isApprox(cloned_solutions[i], 1e-12));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
# Fix ROP/REP clone state loss, factory exception leaks and redundant clones

Three independent fixes to the robot-on-positioner (ROP) and robot-with-external-positioner (REP) inverse kinematics, plus regression tests. Each commit stands alone and can be reviewed separately.

## 1. `operator=` dropped members (correctness bug)

`ROPInvKin::operator=` did not copy `positioner_to_robot_` or `solver_name_`; `REPInvKin::operator=` did not copy `solver_name_`. Since the copy constructor delegates to `operator=` and `clone()` copy-constructs, **every clone silently reverted `positioner_to_robot_` to identity and the solver name to the default**.

For ROP this is not cosmetic: on any rig where the positioner tip and the robot base frames are not coincident, a cloned solver runs inverse kinematics against the wrong base transform. In the added regression test the original solver finds 140 solutions where the clone finds 0.

The existing suite could not catch either half:

* `positioner_robot_joint` in `abb_irb2400_on_positioner.urdf` has an identity origin, so `positioner_to_robot_` is identity in the only ROP rig and the dropped copy is unobservable. The new test offsets that joint before constructing the solver.
* The existing clone checks assert `getSolverName()` against the *default* name — exactly what a dropped `solver_name_` falls back to. The new tests construct with a custom name instead.

## 2. Factories let constructor exceptions escape `create()`

`ROPInvKinFactory::create()` and `REPInvKinFactory::create()` constructed the solver *after* the `try` block, so anything the `ROPInvKin`/`REPInvKin` constructor threw propagated out of `create()` instead of being logged and converted to `nullptr`.

That breaks the contract the plugin loader relies on — `createInvKin()` is expected to signal failure by returning `nullptr` — and every constructor validation path could trip it: empty solver name, invalid scene-graph root, null manipulator or positioner, non-positive manipulator reach, and mismatched or non-positive positioner sample resolution.

Construction now happens inside the `try`, so these become logged `nullptr` returns like every other failure in these factories.

## 3. `REPInvKin::init` cloned its sink parameters

`init()` takes the manipulator and positioner as `unique_ptr` sinks but cloned them into the members, costing two extra heap allocations and full solver copies per construction for pointers it already owned. Neither parameter is read after the assignment. `ROPInvKin::init` already moves — REP was the odd one out.

## Testing

Added `RobotOnPositionerClonePreservesStateUnit` and `RobotWithExternalPositionerClonePreservesStateUnit`. Both check that `clone()` preserves the solver name; the ROP test additionally builds a reachable target via forward kinematics and requires the clone to return exactly the same IK solutions as the original.

Verified locally that both new tests fail against the unpatched library (140 vs 0 solutions for ROP, default vs custom solver name for both) and that all four tests in `tesseract_kinematics_rop_unit` / `tesseract_kinematics_rep_unit` pass with the fixes applied.
