### PR TITLE
fix(fcl): preserve world_pose_ in CollisionObjectWrapper::clone()

### DIFF
--- a/collision/fcl/include/tesseract/collision/fcl/fcl_utils.h
+++ b/collision/fcl/include/tesseract/collision/fcl/fcl_utils.h
@@ -134,6 +134,7 @@ public:
   std::shared_ptr<CollisionObjectWrapper> clone() const
   {
     auto clone_cow = std::make_shared<CollisionObjectWrapper>();
+    clone_cow->world_pose_ = world_pose_;
     clone_cow->name_ = name_;
     clone_cow->type_id_ = type_id_;
     clone_cow->shapes_ = shapes_;


### PR DESCRIPTION
`clone()` never copies `world_pose_`, so cloned wrappers default to `Identity()`.

Native FCL object transforms are copied fine, so normal collide/distance checks are unaffected. But the SDF narrowphase path (`processImplicitSDFPair`) computes pose from `world_pose_ * shape_poses_`, so it silently treats every cloned object as being at the origin and `getDiscreteContactManager()` returns a fresh clone on every call, which is what trajopt uses for every check. Bullet has no equivalent field, so it's unaffected.

Fix: copy `world_pose_` into the clone.