### PR TITLE
fix(bullet): preserve the contact processing threshold in COW::clone()

### DIFF
--- a/collision/bullet/src/bullet_utils.cpp
+++ b/collision/bullet/src/bullet_utils.cpp
@@ -704,6 +704,7 @@ std::shared_ptr<CollisionObjectWrapper> CollisionObjectWrapper::clone()
   clone_cow->m_data = m_data;
   clone_cow->setCollisionShape(getCollisionShape());
   clone_cow->setWorldTransform(getWorldTransform());
+  clone_cow->setContactProcessingThreshold(getContactProcessingThreshold());
   clone_cow->m_collisionFilterGroup = m_collisionFilterGroup;
   clone_cow->m_collisionFilterMask = m_collisionFilterMask;
   clone_cow->m_enabled = m_enabled;

--- a/collision/test/collision_clone_unit.cpp
+++ b/collision/test/collision_clone_unit.cpp
@@ -6,9 +6,23 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract/collision/test_suite/collision_clone_unit.hpp>
 #include <tesseract/collision/bullet/bullet_discrete_simple_manager.h>
 #include <tesseract/collision/bullet/bullet_discrete_bvh_manager.h>
+#include <tesseract/collision/bullet/bullet_utils.h>
 #include <tesseract/collision/fcl/fcl_discrete_managers.h>
+#include <tesseract/geometry/impl/box.h>
 
 using namespace tesseract::collision;
+using namespace tesseract::collision::bullet_internal;
+
+namespace
+{
+/** @brief Build a unit box collision object at the origin, as the managers do */
+COW::Ptr makeBoxCow()
+{
+  CollisionShapesConst shapes{ std::make_shared<tesseract::geometry::Box>(1, 1, 1) };
+  tesseract::common::VectorIsometry3d poses{ Eigen::Isometry3d::Identity() };
+  return createCollisionObject("box_link", 0, shapes, poses);
+}
+}  // namespace
 
 TEST(TesseractCollisionUnit, BulletDiscreteSimpleCollisionCloneUnit)  // NOLINT
 {
@@ -26,6 +40,52 @@ TEST(TesseractCollisionUnit, FCLDiscreteBVHCollisionCloneUnit)  // NOLINT
 {
   FCLDiscreteBVHManager checker;
   test_suite::runTest(checker, 0.001, 0.001, 0.001);
+}
+
+/**
+ * The contact processing threshold is what getAABB() pads the broadphase box with, so a clone that
+ * loses it enters the broadphase with a box sized by btCollisionObject's BT_LARGE_FLOAT default.
+ */
+TEST(TesseractCollisionUnit, BulletCollisionObjectWrapperCloneThresholdUnit)  // NOLINT
+{
+  const btScalar margin{ 0.05 };
+
+  COW::Ptr cow = makeBoxCow();
+  cow->setContactProcessingThreshold(margin);
+
+  const COW::Ptr clone = cow->clone();
+
+  EXPECT_NEAR(clone->getContactProcessingThreshold(), margin, 1e-6);
+}
+
+/**
+ * The cast object is built by cloning, and it is the one whose proxy goes into the broadphase for
+ * every active link. With an identity cast transform its AABB must match the object it was built
+ * from - CastHullShape::getAabb unions the shape at t0 and t01, which for an identity t01 is just
+ * the shape's own AABB.
+ */
+TEST(TesseractCollisionUnit, BulletCastCollisionObjectCloneAABBUnit)  // NOLINT
+{
+  const btScalar margin{ 0.05 };
+
+  COW::Ptr cow = makeBoxCow();
+  cow->setContactProcessingThreshold(margin);
+
+  const COW::Ptr cast_cow = makeCastCollisionObject(cow);
+
+  btVector3 aabb_min;
+  btVector3 aabb_max;
+  cow->getAABB(aabb_min, aabb_max);
+
+  btVector3 cast_aabb_min;
+  btVector3 cast_aabb_max;
+  cast_cow->getAABB(cast_aabb_min, cast_aabb_max);
+
+  for (int i = 0; i < 3; ++i)
+  {
+    EXPECT_NEAR(cast_aabb_min[i], aabb_min[i], 1e-6) << "axis " << i;
+    EXPECT_NEAR(cast_aabb_max[i], aabb_max[i], 1e-6) << "axis " << i;
+  }
 }
 
 int main(int argc, char** argv)

--- a/environment/test/tesseract_environment_unit.cpp
+++ b/environment/test/tesseract_environment_unit.cpp
@@ -5362,10 +5362,12 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
         checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj, config);
     EXPECT_TRUE(traj_results);
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj.rows() - 1));
-    EXPECT_EQ(contacts.at(0).size(), 1);
+    // FIRST keeps one contact per substep, so a step accumulates a pair for every pair the
+    // substeps happen to reach first; steps 0 and 3 straddle the link_6/link_7 handover.
+    EXPECT_EQ(contacts.at(0).size(), 2);
     EXPECT_EQ(contacts.at(1).size(), 1);
     EXPECT_EQ(contacts.at(2).size(), 1);
-    EXPECT_EQ(contacts.at(3).size(), 1);
+    EXPECT_EQ(contacts.at(3).size(), 2);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(135));
     EXPECT_EQ(traj_results.numContacts(), static_cast<int>(135));
     EXPECT_EQ(traj_results.numSteps(), static_cast<std::size_t>(traj.rows()));
@@ -5388,7 +5390,7 @@ TEST(TesseractEnvironmentUnit, checkTrajectoryUnit)  // NOLINT
     contacts.clear();
     EXPECT_TRUE(checkTrajectory(contacts, *continuous_manager, *state_solver, joint_names, traj2, config));
     EXPECT_EQ(contacts.size(), static_cast<std::size_t>(traj2.rows() - 1));
-    EXPECT_EQ(contacts.at(0).size(), 1);
+    EXPECT_EQ(contacts.at(0).size(), 2);
     EXPECT_EQ(contacts.at(1).size(), 1);
     EXPECT_EQ(getContactCount(contacts), static_cast<int>(67));
     checkProcessInterpolatedResultsNoTime0(contacts.at(0));


### PR DESCRIPTION
`CollisionObjectWrapper::clone()` copies every member the wrapper declares plus the collision shape and world transform, but not the contact processing threshold, so the clone falls back to `btCollisionObject`'s `BT_LARGE_FLOAT` (1e30) default. `getAABB()` pads the broadphase box by half of that:

```cpp
const btScalar& d = getContactProcessingThreshold() / 2.0;
```

so the clone's AABB spans ±5e29 m.

`makeCastCollisionObject()` is the one caller that never re-sets the threshold afterwards — `BulletCastBVHManager::clone()` and both `addCollisionObject(id, …)` overloads set it on the object they build, but the *cast* twin created inside `addCollisionObject(const COW::Ptr&)` is untouched. That twin is exactly the object whose proxy goes into the broadphase for every active link, so continuous checking runs an all-pairs broadphase.

Measured with the arm parked 10 km from every static, so the only correct pair count is zero:

| statics | cast manager | discrete manager (control) |
| --- | --- | --- |
| 100 | 90 pairs, 1.7 ms | 0 pairs, 0.0 ms |
| 200 | 180 pairs, 3.3 ms | 0 pairs, 0.1 ms |
| 400 | 360 pairs, 6.9 ms | 0 pairs, 0.1 ms |
| 800 | 720 pairs, 12.8 ms | 0 pairs, 0.3 ms |

The discrete manager is the control: same `btDbvtBroadphase`, same geometry, same margins, but it never builds a cast COW. The cast manager's pair count tracks N exactly and its time is linear in N.

### Repairing it later is not enough

`onCollisionMarginDataChanged()` walks `link2castcow_` and fixes the threshold, so any margin setter restores the *AABB*. It cannot restore the *pair cache*: `TesseractCollisionPairCallback::processOverlap` returns `false`, so `btHashedOverlappingPairCache::processAllOverlappingPairs` never removes a pair, and `performDeferredRemoval` is a no-op for a hashed cache. The all-pairs set built during `addCollisionObject` survives every later repair — which is why an A/B on margin-call ordering shows no difference at all.

### Scope

Contact counts and in-collision/not-in-collision verdicts are unaffected. `needsCollisionCheck` still filters by group/mask and validator, and the narrowphase threshold comes from `collision_margin_data`. This is throughput — but on the hot path of every trajectory collision check.

One thing does change. Restoring the AABB restores the broadphase traversal order, so under `ContactTestType::FIRST` — which keeps exactly one contact per substep, whichever the broadphase reaches first — a substep can now settle on a different, equally valid pair. See Tests.

`BulletCastSimpleManager` has the same hole with a milder consequence: no pair cache, so the stale threshold only defeats its hand-rolled `aabb_check` pre-filter. The same one-line fix covers it.

### Fix

One line in `clone()`. `makeCastCollisionObject` is called from `addCollisionObject(const COW::Ptr&)` *after* the caller has set the threshold on the original, so the cast twin now inherits a correct value and its proxy is created with a correct AABB. No manager change needed.

### Tests

Two tests added to `collision/test/collision_clone_unit.cpp`:

- `BulletCollisionObjectWrapperCloneThresholdUnit` — the root cause, directly.
- `BulletCastCollisionObjectCloneAABBUnit` — the consequence. With an identity cast transform, `CastHullShape::getAabb` unions the shape at `t0` and `t01`, so a cast object's AABB must equal the AABB of the object it was cloned from.

Both fail before the change (`1e30`, and `±5e29` against a true `0.525`) and pass after. `collision/test` is otherwise unaffected: 135/135 pass with the fix, 133/135 without it, the two failures being exactly the new tests.

Four expectations updated in `TesseractEnvironmentUnit.checkTrajectoryUnit`, in the `LVS_CONTINUOUS` + `ContactTestType::FIRST` blocks:

```
-  0/3  joint_a1 -0.4000 -0.2000|  0/1  sphere_attached  link_7  -0.0486
+  0/3  joint_a1 -0.4000 -0.2000|  0/1  sphere_attached  link_6  -0.0227
```

`sphere_attached` penetrates both `link_6` and `link_7` — the `ContactTestType::ALL` block a few lines above asserts `size() == 2` for the same step — and `FIRST` reports one of them per substep. Steps 0 and 3 straddle the handover between the two, so they now accumulate both pairs and go from 1 to 2; steps 1 and 2 stay at 1. Totals are untouched throughout: `getContactCount` stays 135 and 67, `numContacts` stays 40 and 41, and every substep assertion is unchanged. The old values were pinning an incidental broadphase ordering that the ±5e29 AABB happened to produce.

Full suite green locally.

