### PR TITLE
Guard size()-1 loop bounds against empty containers

### DIFF
--- a/collision/core/src/common.cpp
+++ b/collision/core/src/common.cpp
@@ -48,7 +48,7 @@ getCollisionObjectPairs(const std::vector<std::string>& active_links,
   clp.reserve(num_pairs);
 
   // Create active to active pairs
-  for (std::size_t i = 0; i < active_links.size() - 1; ++i)
+  for (std::size_t i = 0; i + 1 < active_links.size(); ++i)
   {
     const std::string& l1 = active_links[i];
     for (std::size_t j = i + 1; j < active_links.size(); ++j)

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -370,7 +370,7 @@ void reorder(Eigen::Ref<Eigen::VectorXd> v, std::vector<Eigen::Index> order)
 {
   assert(v.rows() == static_cast<Eigen::Index>(order.size()));
   // for all elements to put in place
-  for (std::size_t i = 0; i < order.size() - 1; ++i)
+  for (std::size_t i = 0; i + 1 < order.size(); ++i)
   {
     if (order[i] == static_cast<Eigen::Index>(i))
       continue;


### PR DESCRIPTION
`size() - 1` wraps to `SIZE_MAX` on an empty container, so the loop body runs once and indexes out of bounds. In both cases the indexing is the first statement of the body, ahead of the inner loop's own bound, so nothing downstream catches it.

- `getCollisionObjectPairs()` — an environment with no active links is an ordinary scene.
- `reorder()` — the `assert` on the row count trips first in debug, but not in release.

`i + 1 < size()` is equivalent for every non-empty input.