### PR TITLE
Return nullptr when a kinematics solver constructor fails

### DIFF
--- a/collision/core/src/contact_managers_plugin_factory.cpp
+++ b/collision/core/src/contact_managers_plugin_factory.cpp
@@ -269,9 +269,12 @@ ContactManagersPluginFactory::createDiscreteContactManager(const std::string& na
     return plugin->create(name, plugin_info.config);
   }
   // LCOV_EXCL_START
-  catch (const std::exception&)
+  catch (const std::exception& e)
   {
-    CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s'", plugin_info.class_name.c_str());
+    CONSOLE_BRIDGE_logWarn("Failed to create discrete contact manager '%s' with factory '%s'! Details: %s",
+                           name.c_str(),
+                           plugin_info.class_name.c_str(),
+                           e.what());
     return nullptr;
   }
   // LCOV_EXCL_STOP
@@ -312,9 +315,12 @@ ContactManagersPluginFactory::createContinuousContactManager(const std::string& 
     return plugin->create(name, plugin_info.config);
   }
   // LCOV_EXCL_START
-  catch (const std::exception&)
+  catch (const std::exception& e)
   {
-    CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s'", plugin_info.class_name.c_str());
+    CONSOLE_BRIDGE_logWarn("Failed to create continuous contact manager '%s' with factory '%s'! Details: %s",
+                           name.c_str(),
+                           plugin_info.class_name.c_str(),
+                           e.what());
     return nullptr;
   }
   // LCOV_EXCL_STOP

--- a/kinematics/core/src/kinematics_plugin_factory.cpp
+++ b/kinematics/core/src/kinematics_plugin_factory.cpp
@@ -292,9 +292,12 @@ KinematicsPluginFactory::createFwdKin(const std::string& solver_name,
     fwd_kin_factories_[plugin_info.class_name] = plugin;
     return plugin->create(solver_name, scene_graph, scene_state, *this, plugin_info.config);
   }
-  catch (const std::exception&)
+  catch (const std::exception& e)
   {
-    CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s'", plugin_info.class_name.c_str());
+    CONSOLE_BRIDGE_logWarn("Failed to create fwd kin solver '%s' with factory '%s'! Details: %s",
+                           solver_name.c_str(),
+                           plugin_info.class_name.c_str(),
+                           e.what());
     return nullptr;
   }
 }
@@ -349,9 +352,12 @@ KinematicsPluginFactory::createInvKin(const std::string& solver_name,
     inv_kin_factories_[plugin_info.class_name] = plugin;
     return plugin->create(solver_name, scene_graph, scene_state, *this, plugin_info.config);
   }
-  catch (const std::exception& ex)
+  catch (const std::exception& e)
   {
-    CONSOLE_BRIDGE_logWarn(ex.what());
+    CONSOLE_BRIDGE_logWarn("Failed to create inv kin solver '%s' with factory '%s'! Details: %s",
+                           solver_name.c_str(),
+                           plugin_info.class_name.c_str(),
+                           e.what());
     return nullptr;
   }
 }

--- a/kinematics/kdl/src/kdl_factories.cpp
+++ b/kinematics/kdl/src/kdl_factories.cpp
@@ -56,14 +56,14 @@ KDLFwdKinChainFactory::create(const std::string& solver_name,
       tip_link = common::LinkId(n.as<std::string>());
     else
       throw std::runtime_error("KDLFwdKinChainFactory, missing 'tip_link' entry");
+
+    return std::make_unique<KDLFwdKinChain>(scene_graph, base_link, tip_link, solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("KDLFwdKinChainFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<KDLFwdKinChain>(scene_graph, base_link, tip_link, solver_name);
 }
 
 std::unique_ptr<InverseKinematics>
@@ -107,14 +107,14 @@ KDLInvKinChainLMAFactory::create(const std::string& solver_name,
 
     if (YAML::Node n = config["eps_joints"])
       kdl_config.eps_joints = n.as<double>();
+
+    return std::make_unique<KDLInvKinChainLMA>(scene_graph, base_link, tip_link, kdl_config, solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("KDLInvKinChainLMAFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<KDLInvKinChainLMA>(scene_graph, base_link, tip_link, kdl_config, solver_name);
 }
 
 std::unique_ptr<InverseKinematics>
@@ -152,14 +152,14 @@ KDLInvKinChainNRFactory::create(const std::string& solver_name,
 
     if (YAML::Node n = config["position_iterations"])
       kdl_config.pos_iterations = n.as<int>();
+
+    return std::make_unique<KDLInvKinChainNR>(scene_graph, base_link, tip_link, kdl_config, solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("KDLInvKinChainNRFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<KDLInvKinChainNR>(scene_graph, base_link, tip_link, kdl_config, solver_name);
 }
 
 std::unique_ptr<InverseKinematics>
@@ -196,14 +196,14 @@ KDLInvKinChainNR_JLFactory::create(const std::string& solver_name,
 
     if (YAML::Node n = config["position_iterations"])
       kdl_config.pos_iterations = n.as<int>();
+
+    return std::make_unique<KDLInvKinChainNR_JL>(scene_graph, base_link, tip_link, kdl_config, solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("KDLInvKinChainNR_JLFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<KDLInvKinChainNR_JL>(scene_graph, base_link, tip_link, kdl_config, solver_name);
 }
 
 PLUGIN_ANCHOR_IMPL(KDLFactoriesAnchor)

--- a/kinematics/opw/src/opw_factory.cpp
+++ b/kinematics/opw/src/opw_factory.cpp
@@ -124,14 +124,14 @@ std::unique_ptr<InverseKinematics> OPWInvKinFactory::create(const std::string& s
     }
 
     path = scene_graph.getShortestPath(base_link, tip_link);
+
+    return std::make_unique<OPWInvKin>(params, base_link, tip_link, path.active_joints, solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("OPWInvKinFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<OPWInvKin>(params, base_link, tip_link, path.active_joints, solver_name);
 }
 
 PLUGIN_ANCHOR_IMPL(OPWFactoriesAnchor)

--- a/kinematics/test/CMakeLists.txt
+++ b/kinematics/test/CMakeLists.txt
@@ -212,6 +212,10 @@ target_link_libraries(
   PRIVATE GTest::GTest
           GTest::Main
           tesseract::kinematics
+          kinematics_factories
+          kinematics_kdl_factories
+          kinematics_opw_factory
+          kinematics_ur_factory
           tesseract::urdf
           tesseract::scene_graph)
 target_compile_options(tesseract_kinematics_factory_unit PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}

--- a/kinematics/test/kinematics_factory_unit.cpp
+++ b/kinematics/test/kinematics_factory_unit.cpp
@@ -29,6 +29,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include "kinematics_test_utils.h"
 #include <tesseract/kinematics/kinematics_plugin_factory.h>
+#include <tesseract/kinematics/rop_factory.h>
+#include <tesseract/kinematics/rep_factory.h>
+#include <tesseract/kinematics/kdl/kdl_factories.h>
+#include <tesseract/kinematics/opw/opw_factory.h>
+#include <tesseract/kinematics/ur/ur_factory.h>
 #include <tesseract/state_solver/kdl/kdl_state_solver.h>
 #include <tesseract/common/resource_locator.h>
 #include <tesseract/common/yaml_utils.h>
@@ -164,12 +169,11 @@ TEST(TesseractKinematicsFactoryUnit, KDL_OPW_UR_ROP_REP_PluginTest)  // NOLINT
 
 TEST(TesseractKinematicsFactoryUnit, RopRepFactoryMissingPositionerJointUnit)  // NOLINT
 {
-  // The ROP and REP factories throw "positioner sample resolution missing joint" when
-  // the sample_res_map has the correct count but contains
-  // joint names that do not match the fwd_kin positioner joint ids. The sample names
-  // must still refer to real scene-graph joints (to pass the earlier getJoint check),
-  // so we pick abb-manipulator joints while the positioner fwd_kin reports the
-  // positioner_joint_* ids.
+  // InvKinFactory::create reports failure by returning nullptr. The ROP and REP factories fail with
+  // "positioner sample resolution missing joint" when the sample_res_map has the correct count but
+  // contains joint names that do not match the fwd_kin positioner joint ids. The sample names must
+  // still refer to real scene-graph joints (to pass the earlier getJoint check), so abb-manipulator
+  // joints are used while the positioner fwd_kin reports the positioner_joint_* ids.
   tesseract::common::GeneralResourceLocator locator;
   std::filesystem::path file_path(__FILE__);
   std::filesystem::path config_path = file_path.parent_path() / "kinematic_plugins.yaml";
@@ -236,12 +240,9 @@ manipulator:
     tesseract::scene_graph::KDLStateSolver ss(*rop_sg);
     auto state = ss.getState();
 
-    tesseract::common::PluginInfo info;
-    info.class_name = "ROPInvKinFactory";
-    info.config = YAML::Load(rop_config);
-    // KinematicsPluginFactory::createInvKin wraps the throw and returns nullptr after logging,
-    // but the target throw inside ROPInvKinFactory::create still executes.
-    EXPECT_EQ(factory.createInvKin("ROPInvKinFactory", info, *rop_sg, state), nullptr);
+    const ROPInvKinFactory rop_factory;
+    const InvKinFactory& inv_kin_factory = rop_factory;
+    EXPECT_EQ(inv_kin_factory.create("ROPInvKin", *rop_sg, state, factory, YAML::Load(rop_config)), nullptr);
   }
 
   {
@@ -249,10 +250,165 @@ manipulator:
     tesseract::scene_graph::KDLStateSolver ss(*rep_sg);
     auto state = ss.getState();
 
-    tesseract::common::PluginInfo info;
-    info.class_name = "REPInvKinFactory";
-    info.config = YAML::Load(rep_config);
-    EXPECT_EQ(factory.createInvKin("REPInvKinFactory", info, *rep_sg, state), nullptr);
+    const REPInvKinFactory rep_factory;
+    const InvKinFactory& inv_kin_factory = rep_factory;
+    EXPECT_EQ(inv_kin_factory.create("REPInvKin", *rep_sg, state, factory, YAML::Load(rep_config)), nullptr);
+  }
+}
+
+TEST(TesseractKinematicsFactoryUnit, RopRepFactoryCreateReturnsNullOnConstructionFailureUnit)  // NOLINT
+{
+  // InvKinFactory::create reports failure by returning nullptr. Neither factory checks that
+  // 'manipulator_reach' is positive, but both solver constructors reject it, so a reach of zero is
+  // a config that parses and builds both sub-solvers before construction fails.
+  tesseract::common::GeneralResourceLocator locator;
+  std::filesystem::path file_path(__FILE__);
+  std::filesystem::path config_path = file_path.parent_path() / "kinematic_plugins.yaml";
+  KinematicsPluginFactory factory(config_path, locator);
+
+  const char* manipulator_config = R"(
+  class: OPWInvKinFactory
+  config:
+    base_link: base_link
+    tip_link: tool0
+    params:
+      a1: 0.100
+      a2: -0.135
+      b: 0.00
+      c1: 0.615
+      c2: 0.705
+      c3: 0.755
+      c4: 0.086
+      offsets: [0, 0, -1.57079632679, 0, 0, 0]
+      sign_corrections: [1, 1, 1, 1, 1, 1]
+)";
+
+  const std::string rop_config = std::string(R"(
+manipulator_reach: 0.0
+positioner_sample_resolution:
+  - name: positioner_joint_1
+    value: 0.1
+positioner:
+  class: KDLFwdKinChainFactory
+  config:
+    base_link: positioner_base_link
+    tip_link: positioner_tool0
+manipulator:)") + manipulator_config;
+
+  const std::string rep_config = std::string(R"(
+manipulator_reach: 0.0
+positioner_sample_resolution:
+  - name: positioner_joint_1
+    value: 0.1
+  - name: positioner_joint_2
+    value: 0.1
+positioner:
+  class: KDLFwdKinChainFactory
+  config:
+    base_link: positioner_base_link
+    tip_link: positioner_tool0
+manipulator:)") + manipulator_config;
+
+  {
+    auto rop_sg = getSceneGraphABBOnPositioner(locator);
+    tesseract::scene_graph::KDLStateSolver ss(*rop_sg);
+    auto state = ss.getState();
+
+    const ROPInvKinFactory rop_factory;
+    const InvKinFactory& inv_kin_factory = rop_factory;
+    EXPECT_EQ(inv_kin_factory.create("ROPInvKin", *rop_sg, state, factory, YAML::Load(rop_config)), nullptr);
+  }
+
+  {
+    auto rep_sg = getSceneGraphABBExternalPositioner(locator);
+    tesseract::scene_graph::KDLStateSolver ss(*rep_sg);
+    auto state = ss.getState();
+
+    const REPInvKinFactory rep_factory;
+    const InvKinFactory& inv_kin_factory = rep_factory;
+    EXPECT_EQ(inv_kin_factory.create("REPInvKin", *rep_sg, state, factory, YAML::Load(rep_config)), nullptr);
+  }
+}
+
+TEST(TesseractKinematicsFactoryUnit, KdlFactoryCreateReturnsNullOnConstructionFailureUnit)  // NOLINT
+{
+  // FwdKinFactory::create and InvKinFactory::create report failure by returning nullptr. The KDL
+  // solvers require a scene graph that is a tree, and an unparented link makes the iiwa graph fail
+  // that check while base_link and tool0 stay valid links -- so the config parses and the solver
+  // constructor is what fails. The KDL factories ignore the scene state, so a default one is passed.
+  tesseract::common::GeneralResourceLocator locator;
+  tesseract::scene_graph::SceneGraph::UPtr scene_graph = getSceneGraphIIWA(locator);
+  scene_graph->addLink(tesseract::scene_graph::Link("unparented_link"));
+  ASSERT_FALSE(scene_graph->isTree());
+
+  const tesseract::scene_graph::SceneState scene_state;
+  const KinematicsPluginFactory plugin_factory;
+  YAML::Node config = YAML::Load(R"(base_link: base_link
+tip_link: tool0)");
+
+  {
+    const KDLFwdKinChainFactory kdl_factory;
+    const FwdKinFactory& factory = kdl_factory;
+    EXPECT_EQ(factory.create("KDLFwdKinChain", *scene_graph, scene_state, plugin_factory, config), nullptr);
+  }
+
+  {
+    const KDLInvKinChainLMAFactory kdl_factory;
+    const InvKinFactory& factory = kdl_factory;
+    EXPECT_EQ(factory.create("KDLInvKinChainLMA", *scene_graph, scene_state, plugin_factory, config), nullptr);
+  }
+
+  {
+    const KDLInvKinChainNRFactory kdl_factory;
+    const InvKinFactory& factory = kdl_factory;
+    EXPECT_EQ(factory.create("KDLInvKinChainNR", *scene_graph, scene_state, plugin_factory, config), nullptr);
+  }
+
+  {
+    const KDLInvKinChainNR_JLFactory kdl_factory;
+    const InvKinFactory& factory = kdl_factory;
+    EXPECT_EQ(factory.create("KDLInvKinChainNR_JL", *scene_graph, scene_state, plugin_factory, config), nullptr);
+  }
+}
+
+TEST(TesseractKinematicsFactoryUnit, OpwUrFactoryCreateReturnsNullOnConstructionFailureUnit)  // NOLINT
+{
+  // InvKinFactory::create reports failure by returning nullptr. Both solvers only support six
+  // joints, and the iiwa base_link -> tool0 path has seven, so getShortestPath succeeds and the
+  // solver constructor is what fails. Both factories ignore the scene state, so a default one is
+  // passed.
+  tesseract::common::GeneralResourceLocator locator;
+  tesseract::scene_graph::SceneGraph::UPtr scene_graph = getSceneGraphIIWA(locator);
+  ASSERT_EQ(scene_graph->getShortestPath("base_link", "tool0").active_joints.size(), 7);
+
+  const tesseract::scene_graph::SceneState scene_state;
+  const KinematicsPluginFactory plugin_factory;
+
+  {
+    YAML::Node config = YAML::Load(R"(base_link: base_link
+tip_link: tool0
+params:
+  a1: 0.100
+  a2: -0.135
+  b: 0.00
+  c1: 0.615
+  c2: 0.705
+  c3: 0.755
+  c4: 0.086)");
+
+    const OPWInvKinFactory opw_factory;
+    const InvKinFactory& factory = opw_factory;
+    EXPECT_EQ(factory.create("OPWInvKin", *scene_graph, scene_state, plugin_factory, config), nullptr);
+  }
+
+  {
+    YAML::Node config = YAML::Load(R"(base_link: base_link
+tip_link: tool0
+model: UR10)");
+
+    const URInvKinFactory ur_factory;
+    const InvKinFactory& factory = ur_factory;
+    EXPECT_EQ(factory.create("URInvKin", *scene_graph, scene_state, plugin_factory, config), nullptr);
   }
 }
 

--- a/kinematics/ur/src/ur_factory.cpp
+++ b/kinematics/ur/src/ur_factory.cpp
@@ -123,14 +123,14 @@ std::unique_ptr<InverseKinematics> URInvKinFactory::create(const std::string& so
     }
 
     path = scene_graph.getShortestPath(base_link, tip_link);
+
+    return std::make_unique<URInvKin>(params, base_link, tip_link, path.active_joints, solver_name);
   }
   catch (const std::exception& e)
   {
     CONSOLE_BRIDGE_logError("URInvKinFactory: Failed to parse yaml config data! Details: %s", e.what());
     return nullptr;
   }
-
-  return std::make_unique<URInvKin>(params, base_link, tip_link, path.active_joints, solver_name);
 }
 
 PLUGIN_ANCHOR_IMPL(URFactoriesAnchor)


### PR DESCRIPTION
Closes #1329.

`FwdKinFactory::create` and `InvKinFactory::create` both document *"If failed to create, nullptr is returned"*, but six factories constructed their solver **after** the `try` block, so a config that parses cleanly and then fails to build a solver threw out of `create()` instead. Same fix as #1328: the `return std::make_unique<...>` moves to the end of the `try`.

- `KDLFwdKinChainFactory`, `KDLInvKinChainLMAFactory`, `KDLInvKinChainNRFactory`, `KDLInvKinChainNR_JLFactory`
- `OPWInvKinFactory`, `URInvKinFactory`

### Also in here

The catch blocks in `KinematicsPluginFactory::createFwdKin` / `createInvKin` and in the two `ContactManagersPluginFactory` creators. They wrap both plugin loading *and* `create()`, but reported anything that escaped as `Failed to load symbol '<class>'` — so a constructor failure was attributed to symbol loading, and `createInvKin` discarded the cause entirely. `createInvKin` also passed `ex.what()` as the printf format string, which is undefined behaviour if the message contains a `%`. All four now use one shape, following the precedent already in `profile_plugin_factory.cpp`:

```
Failed to create inv kin solver '<solver>' with factory '<class>'! Details: <what>
```

The `plugin == nullptr` branches inside each `try` still log `Failed to load symbol`, which is correct there.

### Tests

Three cases in `kinematics_factory_unit.cpp`, one per failure mode, covering all eight factories. Each was verified to fail before the fix and pass after.

| Factories | Trigger |
| --- | --- |
| 4 × KDL | an unparented link makes the iiwa scene graph fail `isTree()`, so `parseSceneGraph` fails while `base_link`/`tool0` stay valid |
| OPW, UR | the iiwa `base_link` → `tool0` path has seven active joints, so `getShortestPath` succeeds and the constructor rejects it |
| ROP, REP | `manipulator_reach: 0.0` — neither factory validates it, both constructors reject it |

Two things worth flagging for review:

1. **`tesseract_kinematics_factory_unit` now links the factory plugin libraries.** `create()` is private in every concrete factory and reachable only through the `FwdKinFactory`/`InvKinFactory` interface, and `KinematicsPluginFactory` keeps its factory instances private — so there is no way to test the documented contract through the plugin path, which catches. No test in the repo linked a plugin library before this. It does not disturb the plugin-loading tests; all cases in the file still pass.

2. **#1328's regression test did not pin its fix.** `RopRepFactoryMissingPositionerJointUnit` throws *"positioner sample resolution missing joint"* from inside the `try`, so it returns `nullptr` with or without the fix — confirmed by reintroducing the defect and watching it pass. It is kept (it covers factory-level validation) and converted to the interface form for consistency, and the new ROP/REP case is what actually pins the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)