### PR TITLE
Silence PCL's malloc-convention guard in the point cloud parser

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -27,9 +27,6 @@ jobs:
     - name: vcs import
       run: >
         vcs import --input "${{ github.workspace }}/workspace/src/tesseract/.github/workflows/windows_dependencies.repos" workspace/src/
-    - name: vcs import kdl source
-      run: >
-        vcs import --input "${{ github.workspace }}/workspace/src/tesseract/.github/workflows/conda/windows_kdl.repos" workspace/src/
     - uses: conda-incubator/setup-miniconda@v4
       with:
         channel-priority: strict

--- a/.github/workflows/conda/recipe/build.bat
+++ b/.github/workflows/conda/recipe/build.bat
@@ -1,29 +1,7 @@
 
-rem PCL and the other conda dependencies are built with AVX, i.e. 32-byte Eigen alignment, and their headers
-rem require consumers to match (pcl/memory.h #errors otherwise). Build all of Tesseract with AVX so Eigen's static
-rem and malloc alignment are 32 in every translation unit, giving one uniform layout/ABI across the whole workspace.
-set "CXXFLAGS=%CXXFLAGS% /arch:AVX"
-
-rem conda-forge's Windows orocos-kdl is a static library compiled without AVX, so the Eigen
-rem allocation/free convention inlined into its objects (16-byte, plain malloc) is incompatible with
-rem this AVX workspace (32-byte, offset-prefixed pointers): any KDL-owned Eigen buffer allocated on
-rem one side and freed on the other corrupts the heap. Build orocos-kdl from source with the
-rem workspace flags so both sides share one convention. It is built in its own colcon invocation
-rem because tesseract's package.xml names the rosdep key (liborocos-kdl-dev), not the colcon package
-rem name, so colcon cannot derive the build order itself.
 colcon build --merge-install --install-base="%PREFIX%\opt\tesseract_robotics" ^
    --event-handlers console_cohesion+ ^
-   --packages-select orocos_kdl ^
-   --cmake-args -GNinja -DCMAKE_BUILD_TYPE=Release ^
-   -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"
-
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-rem The workspace install prefix precedes the conda prefix so find_package(orocos_kdl) resolves the
-rem source-built KDL rather than the conda package.
-colcon build --merge-install --install-base="%PREFIX%\opt\tesseract_robotics" ^
-   --event-handlers console_cohesion+ ^
-   --packages-ignore gtest osqp osqp_eigen tesseract_examples trajopt_ifopt trajopt_sqp orocos_kdl python_orocos_kdl ^
+   --packages-ignore gtest osqp osqp_eigen_ext tesseract_examples trajopt_ifopt trajopt_sqp ^
    --cmake-args -GNinja -DCMAKE_BUILD_TYPE=Release ^
    -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="/MD /O2 /Ob0 /Zi /DNDEBUG" ^
    -DCMAKE_RELWITHDEBINFO_POSTFIX="" ^
@@ -31,7 +9,7 @@ colcon build --merge-install --install-base="%PREFIX%\opt\tesseract_robotics" ^
    -DUSE_MSVC_RUNTIME_LIBRARY_DLL=ON ^
    -DBUILD_IPOPT=OFF ^
    -DBUILD_SNOPT=OFF ^
-   -DCMAKE_PREFIX_PATH:PATH="%PREFIX%\opt\tesseract_robotics;%LIBRARY_PREFIX%" ^
+   -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
    -DTESSERACT_ENABLE_CLANG_TIDY=OFF ^
    -DTESSERACT_ENABLE_CODE_COVERAGE=OFF ^
    -DPYTHON_EXECUTABLE="%PREFIX%\python.exe" ^
@@ -50,7 +28,7 @@ set TESSERACT_PYTHON_DLL_PATH=%PREFIX%\opt\tesseract_robotics\bin
 set TESSERACT_RESOURCE_PATH=%PREFIX%\opt\tesseract_robotics\share
 
 colcon test --event-handlers console_direct+ --return-code-on-test-failure ^
-   --packages-ignore gtest osqp osqp_eigen tesseract_examples trajopt_ifopt trajopt_sqp orocos_kdl python_orocos_kdl ^
+   --packages-ignore gtest osqp osqp_eigen_ext tesseract_examples trajopt_ifopt trajopt_sqp ^
    --merge-install --install-base="%PREFIX%\opt\tesseract_robotics"
 
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/.github/workflows/conda/recipe/build.sh
+++ b/.github/workflows/conda/recipe/build.sh
@@ -11,7 +11,7 @@ fi
 
 colcon build --merge-install --install-base="$PREFIX/opt/tesseract_robotics" \
    --event-handlers console_direct+ \
-   --packages-ignore gtest osqp osqp_eigen tesseract_examples trajopt_ifopt trajopt_sqp \
+   --packages-ignore gtest osqp osqp_eigen_ext tesseract_examples trajopt_ifopt trajopt_sqp \
    --cmake-args -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_SHARED_LIBS=ON \
    -DBUILD_IPOPT=OFF \
@@ -33,7 +33,7 @@ source "$PREFIX/opt/tesseract_robotics/setup.sh"
 export TESSERACT_RESOURCE_PATH="$PREFIX/opt/tesseract_robotics/share/"
 
 colcon test --event-handlers console_direct+ --return-code-on-test-failure \
-   --packages-ignore gtest osqp osqp_eigen tesseract_examples trajopt_ifopt trajopt_sqp \
+   --packages-ignore gtest osqp osqp_eigen_ext tesseract_examples trajopt_ifopt trajopt_sqp \
    --merge-install --install-base="$PREFIX/opt/tesseract_robotics" \
    --ctest-args -E "ResourceLocatorUnit.GeneralResourceLocatorUnit2|TesseractCommonUnit.timer|TesseractEnvironmentUnit.checkTrajectoryUnit"
 

--- a/.github/workflows/conda/windows_kdl.repos
+++ b/.github/workflows/conda/windows_kdl.repos
@@ -1,8 +1,0 @@
-# conda-win builds orocos-kdl from source: the conda-forge Windows package is a static library
-# compiled without AVX, so its inlined Eigen allocation convention (16-byte, plain malloc/free) is
-# incompatible with the AVX workspace build (32-byte, offset-prefixed) and corrupts the heap whenever
-# a KDL-owned Eigen buffer is allocated on one side and freed on the other (see conda/recipe/build.bat).
-- git:
-    local-name: orocos_kinematics_dynamics
-    uri: https://github.com/orocos/orocos_kinematics_dynamics.git
-    version: 1.5.3

--- a/urdf/src/point_cloud.cpp
+++ b/urdf/src/point_cloud.cpp
@@ -27,6 +27,17 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <stdexcept>
 
 #include <console_bridge/console.h>
+// pcl/memory.h #errors when Eigen's allocation convention in this translation unit differs from the
+// one PCL was built with (a PCL built with AVX uses Eigen's handmade aligned malloc; a consumer at
+// Eigen's default alignment uses plain malloc, and a buffer allocated by one and freed by the other
+// corrupts the heap). That check is a blanket include-time test with no way to see which API is
+// called, and the hazard it guards against is not present here: the only object handed to pcl_io is
+// a PCLPointCloud2, whose storage uses std::allocator, and PCDReader::read is a header template, so
+// the Eigen::aligned_allocator resize of PointCloud::points and its release both happen in this
+// translation unit. Any PCL call added to this file must preserve that -- never pass an
+// Eigen-allocated container into pcl_io to be resized, and do not raise this file's Eigen alignment
+// above the rest of the workspace to silence the check instead.
+#define PCL_SILENCE_MALLOC_WARNING 1
 #include <pcl/io/pcd_io.h>
 #include <tesseract/common/utils.h>
 #include <tinyxml2.h>


### PR DESCRIPTION
`pcl/memory.h` `#error`s when Eigen's allocation convention in the consuming translation unit differs from the one PCL was built with. conda-forge's Windows PCL is built with AVX, so it uses Eigen's handmade aligned malloc, while the rest of the workspace uses plain malloc. Until now that was handled by compiling all of conda-win with `/arch:AVX` and building `orocos-kdl` from source to match — see #1325 and the recipe changes that came in with #1274.

That is more than the situation needs. The guard is a blanket include-time check with no way to see which API is called, and the hazard it protects against is not present in `parsePointCloud`:

- the only object handed to `pcl_io` is a `PCLPointCloud2`, whose storage uses `std::allocator`;
- `PCDReader::read` is a header template with no `extern template` declaration, so the `Eigen::aligned_allocator` resize of `PointCloud::points` — and its release — both happen in our translation unit;
- the two Eigen objects passed by reference, `Vector4f` and `Quaternionf`, are 16 bytes and `alignas(16)` under either configuration.

So no Eigen-allocated buffer ever crosses the DLL boundary. This defines `PCL_SILENCE_MALLOC_WARNING` in `point_cloud.cpp` only, with a comment recording the invariant and warning against breaking it, and drops the `/arch:AVX` flag, the source-built `orocos-kdl` and `conda/windows_kdl.repos` from the conda recipe.

The result is a single Eigen configuration everywhere, and downstream repositories that build tesseract from source on conda-win no longer need to replicate any of it.

To be explicit about what is *not* reverted: `urdf/CMakeLists.txt` keeps stripping PCL's exported `INTERFACE_COMPILE_OPTIONS` on every platform, and #1325's MSVC carve-out does not come back. That strip and the `/arch:AVX` flag were added together in one commit and were mutually dependent — the strip was only viable on MSVC because the recipe was supplying the alignment instead. This PR breaks that pairing and re-justifies the strip on a different basis: with the guard silenced where it does not apply, nothing needs PCL's flags any more, so they can be kept away from our code everywhere.

Restoring the carve-out would undo what #1325 set out to fix. PCL is linked `PRIVATE` into `urdf`, so its exported `/arch:AVX` applies to that whole target and nothing else — which puts `Isometry3d` members such as `Joint::parent_to_joint_origin_transform` at `alignas(32)` inside `tesseract_urdf` and `alignas(16)` in `tesseract_scene_graph`, for objects that cross between them during parsing.

The commit also carries an unrelated one-token fix: the conda recipes ignored `osqp_eigen`, which is not the workspace package name — it is `osqp_eigen_ext` (https://github.com/tesseract-robotics/trajopt/pull/575).

Note the guard cannot be exercised on Linux CI: PCL 1.14 predates `PCL_USES_EIGEN_HANDMADE_ALIGNED_MALLOC`. conda-win against PCL 1.15.1 is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
