### PR TITLE
Use the filename writeVisual builds instead of shadowing it

### DIFF
--- a/urdf/src/visual.cpp
+++ b/urdf/src/visual.cpp
@@ -148,9 +148,6 @@ tinyxml2::XMLElement* writeVisual(const std::shared_ptr<const tesseract::scene_g
 
   try
   {
-    std::string filename = "visual/" + link_name + "_visual";
-    if (id >= 0)
-      filename += "_" + std::to_string(id);
     tinyxml2::XMLElement* xml_geometry = writeGeometry(visual->geometry, doc, package_path, filename);
     xml_element->InsertEndChild(xml_geometry);
   }

--- a/urdf/test/tesseract_urdf_visual_unit.cpp
+++ b/urdf/test/tesseract_urdf_visual_unit.cpp
@@ -6,10 +6,19 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract/geometry/impl/box.h>
 #include <tesseract/geometry/impl/compound_mesh.h>
+#include <tesseract/geometry/impl/mesh.h>
 #include <tesseract/urdf/box.h>
 #include <tesseract/urdf/visual.h>
 #include <tesseract/common/resource_locator.h>
 #include "tesseract_urdf_common_unit.h"
+
+/** @brief Creates the package directory and the visual sub-directory writeVisual expects to exist */
+static std::string getTempVisualPkgPath()
+{
+  std::filesystem::path pkg_path = std::filesystem::path(tesseract::common::getTempPath()) / "tmppkg";
+  std::filesystem::create_directories(pkg_path / "visual");
+  return pkg_path.string();
+}
 
 TEST(TesseractURDFUnit, parse_visual)  // NOLINT
 {
@@ -149,4 +158,26 @@ TEST(TesseractURDFUnit, write_visual)  // NOLINT
             visual, &tesseract::urdf::writeVisual, text, tesseract::common::getTempPath(), std::string("test"), -1));
     EXPECT_EQ(text, "");
   }
+}
+
+TEST(TesseractURDFUnit, WriteVisualMeshFilenameUsesTheVisualName)  // NOLINT
+{
+  tesseract::common::VectorVector3d vertices = { Eigen::Vector3d(0, 0, 0),
+                                                 Eigen::Vector3d(1, 0, 0),
+                                                 Eigen::Vector3d(0, 1, 0) };
+  Eigen::VectorXi indices(4);
+  indices << 3, 0, 1, 2;
+
+  auto visual = std::make_shared<tesseract::scene_graph::Visual>();
+  visual->name = "camera_mount";
+  visual->origin = Eigen::Isometry3d::Identity();
+  visual->geometry = std::make_shared<tesseract::geometry::Mesh>(
+      std::make_shared<tesseract::common::VectorVector3d>(vertices), std::make_shared<Eigen::VectorXi>(indices));
+
+  std::string text;
+  EXPECT_EQ(0,
+            writeTest<tesseract::scene_graph::Visual::Ptr>(
+                visual, &tesseract::urdf::writeVisual, text, getTempVisualPkgPath(), std::string("base_link"), 0));
+  EXPECT_NE(text.find(R"(filename="package://tmppkg/visual/base_link_camera_mount_0.ply")"), std::string::npos)
+      << "emitted: " << text;
 }


### PR DESCRIPTION
`writeVisual` builds a mesh filename from the link name, the visual name, the package path and the id — and then declares a second `filename` inside the `try` block that shadows it:

```cpp
  // Construct Filename, without extension (could be .ply or .bt)
  std::string filename = link_name;
  if (!visual->name.empty())
    filename = filename + "_" + visual->name;
  else
    filename = filename + "_visual";
  if (!package_path.empty())
    filename = "visual/" + filename;
  if (id >= 0)
    filename = filename + "_" + std::to_string(id);

  try
  {
    std::string filename = "visual/" + link_name + "_visual";   // shadows the above
    ...
```

The outer one was dead. The inner replacement differs in two ways: it never consults `visual->name`, and it prepends `visual/` unconditionally where the outer one does so only when a package path was given.

The visible consequence is the first: every visual mesh was written as `<link>_visual` instead of `<link>_<name>`, so the visual name was dropped from every emitted filename.

`writeCollision` in `collision.cpp` is the same shape without the shadow, and passes its computed `filename` straight to `writeGeometry`. Deleting the inner declaration makes the two match.

Adds `WriteVisualMeshFilenameUsesTheVisualName`, which writes a named visual with mesh geometry and asserts the emitted `filename` attribute carries the name. It fails before the change (emits `base_link_visual_0.ply` where `base_link_camera_mount_0.ply` is expected) and passes after. The existing `write_visual` case already used a name that would have exposed this, but its geometry is a `Box` — which ignores the filename entirely — and it asserts only `EXPECT_NE(text, "")`.

The second difference (the unconditional `visual/` prefix) is fixed by the same deletion but is not separately pinned: exercising it means calling `writeVisual` with an empty package path, which writes the mesh file into the process working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)