### PR TITLE
Make ccache actually cache

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -14,7 +14,6 @@ jobs:
     container:
       image: ubuntu:jammy
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/benchmark/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -22,6 +21,17 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: target_ws/src
+
+      - name: Configure ccache
+        shell: bash
+        run: |
+          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
+          mkdir -p "$GITHUB_WORKSPACE/benchmarks/.ccache"
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/benchmarks/.ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
+          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
+          # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends
         shell: bash

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -31,6 +31,7 @@ jobs:
           echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
           # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
           # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -20,14 +20,13 @@ jobs:
         include:
           - job_type: clang-tidy
             env:
-              TARGET_CMAKE_ARGS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CLANG_TIDY=ON -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF -DCLANG_TIDY_NAMES=clang-tidy-17"
+              TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CLANG_TIDY=ON -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF -DCLANG_TIDY_NAMES=clang-tidy-17"
           - job_type: codecov
             env:
-              TARGET_CMAKE_ARGS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
+              TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
     container:
       image: ubuntu:22.04
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -35,6 +34,17 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: target_ws/src
+
+      - name: Configure ccache
+        shell: bash
+        run: |
+          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
+          mkdir -p "$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache"
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
+          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
+          # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends
         shell: bash
@@ -51,13 +61,18 @@ jobs:
       - name: Build and Tests
         uses: tesseract-robotics/colcon-action@v14
         with:
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: ${{ matrix.job_type }}
           vcs-file: dependencies_jammy.repos
           run-tests: false
           rosdep-install-args: -iry --skip-keys=libomp-dev --skip-keys=libcereal-dev
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args ${{ matrix.env.TARGET_CMAKE_ARGS }}
+
+      - name: Report ccache statistics
+        if: always()
+        shell: bash
+        run: ccache -s
 
       - name: Upload CodeCov Results
         if: matrix.job_type == 'codecov'

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -44,6 +44,7 @@ jobs:
           echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
           # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
           # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -66,10 +66,17 @@ jobs:
       run: |
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}/lib" >> "$GITHUB_ENV"
         echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}" >> "$GITHUB_ENV"
+        # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
+        mkdir -p "$GITHUB_WORKSPACE/ci-mac-build-${{ matrix.config.arch }}/.ccache"
+        echo "CCACHE_DIR=$GITHUB_WORKSPACE/ci-mac-build-${{ matrix.config.arch }}/.ccache" >> "$GITHUB_ENV"
+        echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
+        # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
+        # launcher passed there is dropped by the next --cmake-args on the command line.
+        echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
     - name: Build and Tests
       uses: tesseract-robotics/colcon-action@v14
       with:
-        ccache-prefix: ci-mac-build-${{ matrix.config.name }}
+        ccache-prefix: ci-mac-build-${{ matrix.config.arch }}
         vcs-file: .github/workflows/windows_dependencies.repos
         rosdep-enabled: false
         upstream-args: >-
@@ -97,4 +104,9 @@ jobs:
           -DOpenMP_C_LIB_NAMES=libomp -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp" \
           -DOpenMP_libomp_LIBRARY=${{ matrix.config.homebrew_root }}/opt/libomp/lib/libomp.dylib
         run-tests-args: --merge-install --ctest-args -E "TesseractEnvironmentUnit.checkTrajectoryUnit|TesseractCommonUnit.timer"
+
+    - name: Report ccache statistics
+      if: always()
+      shell: bash
+      run: ccache -s
         

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -72,6 +72,7 @@ jobs:
         echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
         # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
         # launcher passed there is dropped by the next --cmake-args on the command line.
+        echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
         echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
     - name: Build and Tests
       uses: tesseract-robotics/colcon-action@v14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,6 @@ jobs:
     container:
       image: ubuntu:${{ matrix.distro }}
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -35,6 +34,17 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: target_ws/src
+
+      - name: Configure ccache
+        shell: bash
+        run: |
+          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
+          mkdir -p "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
+          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
+          # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,7 @@ jobs:
           echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
           # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
           # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,7 +29,6 @@ jobs:
     container:
       image: ubuntu:${{ matrix.distro }}
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -37,6 +36,17 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: target_ws/src
+
+      - name: Configure ccache
+        shell: bash
+        run: |
+          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
+          mkdir -p "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
+          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
+          # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends
         shell: bash
@@ -54,3 +64,8 @@ jobs:
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF -DTESSERACT_PACKAGE=ON
+
+      - name: Report ccache statistics
+        if: always()
+        shell: bash
+        run: ccache -s

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -46,6 +46,7 @@ jobs:
           echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
           # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
           # launcher passed there is dropped by the next --cmake-args on the command line.
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
 
       - name: Install Depends


### PR DESCRIPTION
ccache has never done anything in this repo's CI. Two independent faults, both silent.

### 1. ccache wrote to a directory nothing stored

`CCACHE_DIR` was set in the container `env:` block as `"$GITHUB_WORKSPACE/.../.ccache"`. GitHub does not run a shell over that block, so the value arrived with `$GITHUB_WORKSPACE` unexpanded — the container creation line shows it verbatim: `-e "CCACHE_DIR=$GITHUB_WORKSPACE/clang-tidy/.ccache"`. Post-job cleanup reported `Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.` on every run.

Compounding it, `code_quality.yml` passed `ccache-prefix: ${{ matrix.distro }}` and `mac.yml` passed `ci-mac-build-${{ matrix.config.name }}`, but neither workflow defines those matrix keys — `code_quality` matrixes on `job_type`, and the mac config entries have `arch`. Both resolved to empty, so `colcon-action` cached `/.ccache` and `ci-mac-build-/.ccache`. `benchmarking.yml` had a milder version: directory `benchmark/`, prefix `benchmarks`.

`CCACHE_DIR` is now set from a step, where the variable expands.

### 2. The compiler launcher was being thrown away

Fixing the directory was not enough — a run with it fixed still reported:

```
Hits:               0 /    0
Misses:             0
Cache size (GB): 0.00 / 1.00 (0.00 %)
```

Zero hits *and* zero misses: ccache was never invoked. `colcon-action` appends its own `--cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache` and then the caller's `--cmake-args ...` follows it. colcon declares `--cmake-args` with `nargs='*'` and a plain `store` action, so **the last one wins and the launcher is dropped**. Reproduced on a throwaway package:

```
colcon build --cmake-args -DCMAKE_CXX_COMPILER_LAUNCHER=ccache --cmake-args -DCMAKE_BUILD_TYPE=Release
→ CMakeCache.txt contains CMAKE_BUILD_TYPE, and no CMAKE_CXX_COMPILER_LAUNCHER
```

This is also why `code_quality.yml` was the one workflow carrying the launcher inside its own `TARGET_CMAKE_ARGS` — that is the only position that survives.

The launchers now come from the environment instead. CMake reads `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER` from the environment (documented since 3.17), which colcon cannot clobber, it covers the upstream and target builds alike, and it lets the duplicated flag come out of `TARGET_CMAKE_ARGS`.

### Also here

`CCACHE_MAXSIZE=1G` per job, and a `ccache -s` step on the three workflows whose prefix was wrong or whose runtime dominates. Windows is untouched: that half of `colcon-action` has no cache step at all — see tesseract-robotics/colcon-action#29.

### Reviewing this

Measured on this branch, warm cache against the cold run before it:

| | cold | warm |
|---|---|---|
| **Ubuntu jammy, whole job** | 19.6 min | **10.2 min** |
| **Ubuntu noble, whole job** | 18.1 min | **11.3 min** |
| jammy, `colcon build` of tesseract | 9min 10s | 41.8s |
| noble, `colcon build` of tesseract | 8min 49s | 39.5s |
| upstream workspace | 8.8s | 1.2s |

with `Cache restored from key: jammy-linux-ccache-...` and `Cacheable calls: 576 / 576 (100.0%)`. Tests unaffected: 887 and 888 passing respectively.

The job roughly halves rather than collapsing, because compilation is only part of it. What ccache cannot touch stays: the ctest run is about 5 minutes on its own, and apt, rosdep update, `vcs import`, the upstream workspace and the cache upload account for most of the rest. So expect these jobs to settle around 10-11 minutes, not under one.

One reading trap in those logs: `ccache -s` shows roughly 50% hits on the warm run. ccache keeps its counters *inside* `CCACHE_DIR`, so the restore brings the previous run's misses back along with the objects; the per-run figure is 288 hits out of 288, which is what a 9-minute build collapsing to 42 seconds implies. colcon-action#30 adds a `ccache -z` after the restore so the number reads as expected.

### What this leaves for colcon-action

Both faults are really the action's, and colcon-action#30 fixes them in `linux/` and `macos/` (#29 does the same for Windows). Once that is merged and released, most of what this PR adds can be deleted (tracked in #1345): the `Configure ccache` steps in all five workflows, and `benchmarking.yml`'s directory rename. #30 deliberately honours a caller-set `CCACHE_DIR` and `CCACHE_MAXSIZE`, so the two compose in either order and there is no flag day.

Two parts of this PR stay necessary even then:

- **The `ccache-prefix` corrections**, because the action cannot see the matrix. `code_quality.yml` (job id `ci`) and `mac.yml` (`build-macos`) each run two matrix legs under a single job id, and only the prefix distinguishes their cache keys. With the old undefined values both legs resolve to empty, collide on one key, and restore each other's caches — clang-tidy and codecov are not the same build.
- **Dropping `CCACHE_DIR` from the container `env:` blocks**, since the action takes a caller-set value at face value and would otherwise cache a directory literally named `$GITHUB_WORKSPACE`.

The same broken `CCACHE_DIR` pattern exists at ~14 sites in trajopt, tesseract_planning, tesseract_qt, tesseract_collision_coal and tesseract_ros2, and fault 2 affects every repo using the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
