### PR TITLE
Fix finished flag and guard index access in the trajectory player

### DIFF
--- a/visualization/src/trajectory_interpolator.cpp
+++ b/visualization/src/trajectory_interpolator.cpp
@@ -136,6 +136,8 @@ double TrajectoryInterpolator::getStateDuration(long index) const
   int s = static_cast<int>(trajectory_.size());
   if (index >= s)
     index = s - 1;
+  if (index < 0)
+    index = 0;
 
   return trajectory_[static_cast<std::size_t>(index)].time;
 }

--- a/visualization/src/trajectory_player.cpp
+++ b/visualization/src/trajectory_player.cpp
@@ -125,6 +125,9 @@ tesseract::common::JointState TrajectoryPlayer::getNext()
 
 tesseract::common::JointState TrajectoryPlayer::getByIndex(long index) const
 {
+  if (!trajectory_ || trajectory_->empty())
+    throw std::runtime_error("Trajectory is empty!");
+
   return trajectory_->getState(trajectory_->getStateDuration(index));
 }
 

--- a/visualization/src/trajectory_player.cpp
+++ b/visualization/src/trajectory_player.cpp
@@ -55,6 +55,7 @@ tesseract::common::JointState TrajectoryPlayer::setCurrentDurationByIndex(long i
   if (!trajectory_ || trajectory_->empty())
     throw std::runtime_error("Trajectory is empty!");
 
+  finished_ = false;
   if (trajectory_->getStateCount() > 0)
   {
     if (index > 0)

--- a/visualization/test/trajectory_player_unit.cpp
+++ b/visualization/test/trajectory_player_unit.cpp
@@ -81,6 +81,16 @@ void CheckTrajectory(const tesseract::common::JointTrajectory& trajectory, int f
   }
 
   {
+    // Seeking by index clears finished, just as seeking by duration does
+    player.setCurrentDuration(last + 1);
+    ASSERT_TRUE(player.isFinished());
+    JointState s = player.setCurrentDurationByIndex(0);
+    EXPECT_NEAR(s.time, first, 1e-5);
+    EXPECT_NEAR(s.position(0), first, 1e-5);
+    EXPECT_FALSE(player.isFinished());
+  }
+
+  {
     JointState s = player.setCurrentDurationByIndex(-1);
     EXPECT_NEAR(s.time, first, 1e-5);
     EXPECT_NEAR(s.position(0), first, 1e-5);

--- a/visualization/test/trajectory_player_unit.cpp
+++ b/visualization/test/trajectory_player_unit.cpp
@@ -226,6 +226,31 @@ TEST(TesseracTrajectoryInterpolatorUnit, TrajectoryInterpolatorTest)  // NOLINT
     double duration = interpolator.getStateDuration(i);
     EXPECT_NEAR(duration, static_cast<double>(i) * time_scale, 1e-5);
   }
+
+  // An out-of-range index clamps to the nearest end, in both directions. The second trajectory
+  // starts at a non-zero time so that the lower clamp is distinguishable from an out-of-range read.
+  EXPECT_NEAR(interpolator.getStateDuration(10), 9 * time_scale, 1e-5);
+
+  JointTrajectory offset_trajectory = trajectory;
+  for (auto& state : offset_trajectory)
+    state.time += 5.0;
+
+  TrajectoryInterpolator offset_interpolator(offset_trajectory);
+  EXPECT_NEAR(offset_interpolator.getStateDuration(0), 5.0, 1e-5);
+  EXPECT_NEAR(offset_interpolator.getStateDuration(-1), 5.0, 1e-5);
+}
+
+TEST(TesseracTrajectoryPlayerUnit, PlayerWithoutTrajectoryTest)  // NOLINT
+{
+  using namespace tesseract::visualization;
+
+  // Every accessor that dereferences the trajectory rejects a player that has none
+  TrajectoryPlayer player;
+  EXPECT_EQ(player.size(), 0);
+  EXPECT_THROW(player.getByIndex(0), std::runtime_error);                 // NOLINT
+  EXPECT_THROW(player.getNext(), std::runtime_error);                     // NOLINT
+  EXPECT_THROW(player.setCurrentDuration(0), std::runtime_error);         // NOLINT
+  EXPECT_THROW(player.setCurrentDurationByIndex(0), std::runtime_error);  // NOLINT
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Three small defects on `TrajectoryPlayer`'s index path.

### `setCurrentDurationByIndex` never cleared `finished_`

`setCurrentDuration` opens with `finished_ = false` and re-derives the flag from the requested duration. Its sibling never touched it, so seeking past the end and then scrubbing back by index left `isFinished()` true with the playhead in the middle:

```
seek past end                -> isFinished = true
setCurrentDuration(3)        -> isFinished = false   (control: the duration overload)
setCurrentDurationByIndex(3) -> isFinished = true
```

`isFinished()` is the loop condition callers drive playback with, so a player scrubbed back by index reports itself done and stops on the next frame. The regression assertion goes into `CheckTrajectory`, so it runs for both the zero-start and non-zero-start trajectories, and fails on both before the fix.

### `TrajectoryInterpolator::getStateDuration` clamps from above but not below

`index >= s` is folded to `s - 1`, but a negative index falls straight through to `trajectory_[static_cast<std::size_t>(index)]`, so `-1` subscripts the vector at `SIZE_MAX`.

This is silent by default — the read lands in mapped memory and the caller gets a plausible-looking small double. Compiled into a standalone harness it returns `4.8270213598689787e-321` for `getStateDuration(-1)` where `0` is correct. That is also why the obvious regression assertion (`EXPECT_NEAR(getStateDuration(-1), 0, 1e-5)`) is worthless: a denormal is within `1e-5` of zero, so it passes against the unfixed code. The assertion here instead uses a trajectory whose first state time is `5.0`, which garbage does not match.

### `TrajectoryPlayer::getByIndex` did not check `trajectory_`

Its four neighbours all `throw std::runtime_error("Trajectory is empty!")`; this one dereferenced a null `unique_ptr` when called before `setTrajectory`. It is also the only path that can pass an unfiltered negative index into `getStateDuration` — `setCurrentDurationByIndex` special-cases `index <= 0` and never calls it — so the previous two defects meet here.

The added `PlayerWithoutTrajectoryTest` segfaults against the unfixed code rather than failing; nothing in the suite constructed a player without a trajectory before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)