### PR TITLE
Guard index access in TrajectoryPlayer and TrajectoryInterpolator

### DIFF
--- a/visualization/src/trajectory_interpolator.cpp
+++ b/visualization/src/trajectory_interpolator.cpp
@@ -136,6 +136,8 @@ double TrajectoryInterpolator::getStateDuration(long index) const
   int s = static_cast<int>(trajectory_.size());
   if (index >= s)
     index = s - 1;
+  if (index < 0)
+    index = 0;
 
   return trajectory_[static_cast<std::size_t>(index)].time;
 }

--- a/visualization/src/trajectory_player.cpp
+++ b/visualization/src/trajectory_player.cpp
@@ -124,6 +124,9 @@ tesseract::common::JointState TrajectoryPlayer::getNext()
 
 tesseract::common::JointState TrajectoryPlayer::getByIndex(long index) const
 {
+  if (!trajectory_ || trajectory_->empty())
+    throw std::runtime_error("Trajectory is empty!");
+
   return trajectory_->getState(trajectory_->getStateDuration(index));
 }
 

--- a/visualization/test/trajectory_player_unit.cpp
+++ b/visualization/test/trajectory_player_unit.cpp
@@ -216,6 +216,31 @@ TEST(TesseracTrajectoryInterpolatorUnit, TrajectoryInterpolatorTest)  // NOLINT
     double duration = interpolator.getStateDuration(i);
     EXPECT_NEAR(duration, static_cast<double>(i) * time_scale, 1e-5);
   }
+
+  // An out-of-range index clamps to the nearest end, in both directions. The second trajectory
+  // starts at a non-zero time so that the lower clamp is distinguishable from an out-of-range read.
+  EXPECT_NEAR(interpolator.getStateDuration(10), 9 * time_scale, 1e-5);
+
+  JointTrajectory offset_trajectory = trajectory;
+  for (auto& state : offset_trajectory)
+    state.time += 5.0;
+
+  TrajectoryInterpolator offset_interpolator(offset_trajectory);
+  EXPECT_NEAR(offset_interpolator.getStateDuration(0), 5.0, 1e-5);
+  EXPECT_NEAR(offset_interpolator.getStateDuration(-1), 5.0, 1e-5);
+}
+
+TEST(TesseracTrajectoryPlayerUnit, PlayerWithoutTrajectoryTest)  // NOLINT
+{
+  using namespace tesseract::visualization;
+
+  // Every accessor that dereferences the trajectory rejects a player that has none
+  TrajectoryPlayer player;
+  EXPECT_EQ(player.size(), 0);
+  EXPECT_THROW(player.getByIndex(0), std::runtime_error);                 // NOLINT
+  EXPECT_THROW(player.getNext(), std::runtime_error);                     // NOLINT
+  EXPECT_THROW(player.setCurrentDuration(0), std::runtime_error);         // NOLINT
+  EXPECT_THROW(player.setCurrentDurationByIndex(0), std::runtime_error);  // NOLINT
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Two missing guards on the same index path.

**`TrajectoryInterpolator::getStateDuration` clamps from above but not from below.** `index >= s` is folded to `s - 1`, but a negative index falls straight through to `trajectory_[static_cast<std::size_t>(index)]`, so `-1` subscripts the vector at `SIZE_MAX`.

This is silent by default — the read lands in mapped memory and the caller gets a plausible-looking small double. Compiled into a standalone harness it returns `4.8270213598689787e-321` for `getStateDuration(-1)` where `0` is correct. That is also why the obvious regression assertion (`EXPECT_NEAR(getStateDuration(-1), 0, 1e-5)`) is worthless: a denormal is within `1e-5` of zero, so it passes against the unfixed code. The assertion added here instead uses a trajectory whose first state time is `5.0`, which garbage does not match.

**`TrajectoryPlayer::getByIndex` is the only public method that does not check `trajectory_`.** Its four neighbours all `throw std::runtime_error("Trajectory is empty!")`; this one dereferences a null `unique_ptr` when called before `setTrajectory`. It is also the only path that can pass an unfiltered negative index into `getStateDuration` — `setCurrentDurationByIndex` special-cases `index <= 0` and never calls it — so the two defects meet here.

The added `PlayerWithoutTrajectoryTest` segfaults against the unfixed code rather than failing; nothing in the suite constructed a player without a trajectory before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)