### PR TITLE
Fix mesh color data lost on load and on clone

### DIFF
--- a/geometry/include/tesseract/geometry/impl/mesh_material.h
+++ b/geometry/include/tesseract/geometry/impl/mesh_material.h
@@ -113,10 +113,10 @@ public:
 
 private:
   // Mesh material based on simplified glTF 2.0 pbrMetallicRoughness parameters
-  Eigen::Vector4d base_color_factor_;
+  Eigen::Vector4d base_color_factor_{ Eigen::Vector4d::Zero() };
   double metallic_factor_ = 0;
   double roughness_factor_ = 0.5;
-  Eigen::Vector4d emissive_factor_;
+  Eigen::Vector4d emissive_factor_{ Eigen::Vector4d::Zero() };
 };
 
 /**

--- a/geometry/include/tesseract/geometry/impl/polygon_mesh.h
+++ b/geometry/include/tesseract/geometry/impl/polygon_mesh.h
@@ -192,6 +192,13 @@ public:
   bool operator==(const PolygonMesh& rhs) const;
   bool operator!=(const PolygonMesh& rhs) const;
 
+protected:
+  /**
+   * @brief Deep copy of the mesh material, or nullptr when there is none
+   * @details Used by clone() so a cloned mesh shares no mutable material state with its original
+   */
+  std::shared_ptr<MeshMaterial> cloneMaterial() const;
+
 private:
   std::shared_ptr<const tesseract::common::VectorVector3d> vertices_;
   std::shared_ptr<const Eigen::VectorXi> faces_;
@@ -199,7 +206,7 @@ private:
   int vertex_count_{ 0 };
   int face_count_{ 0 };
   std::shared_ptr<const tesseract::common::Resource> resource_;
-  Eigen::Vector3d scale_;
+  Eigen::Vector3d scale_{ 1, 1, 1 };
   std::shared_ptr<const tesseract::common::VectorVector3d> normals_;
   std::shared_ptr<const tesseract::common::VectorVector4d> vertex_colors_;
   std::shared_ptr<MeshMaterial> mesh_material_;

--- a/geometry/include/tesseract/geometry/mesh_parser.h
+++ b/geometry/include/tesseract/geometry/mesh_parser.h
@@ -90,7 +90,7 @@ std::vector<std::shared_ptr<T>> extractMeshData(const aiScene* scene,
     auto vertices = std::make_shared<tesseract::common::VectorVector3d>();
     auto triangles = std::make_shared<Eigen::VectorXi>();
     std::shared_ptr<tesseract::common::VectorVector3d> vertex_normals = nullptr;
-    std::shared_ptr<tesseract::common::VectorVector4d> vertex_colors = nullptr;
+    std::shared_ptr<tesseract::common::VectorVector4d> vertex_colors_out = nullptr;
     MeshMaterial::Ptr material = nullptr;
     std::shared_ptr<std::vector<MeshTexture::Ptr>> textures = nullptr;
 
@@ -141,12 +141,12 @@ std::vector<std::shared_ptr<T>> extractMeshData(const aiScene* scene,
 
     if (vertex_colors && a->HasVertexColors(0))
     {
-      vertex_colors = std::make_shared<tesseract::common::VectorVector4d>();
-      vertex_colors->reserve(a->mNumVertices);
+      vertex_colors_out = std::make_shared<tesseract::common::VectorVector4d>();
+      vertex_colors_out->reserve(a->mNumVertices);
       for (unsigned int i = 0; i < a->mNumVertices; ++i)
       {
         aiColor4D v = a->mColors[0][i];
-        vertex_colors->emplace_back(
+        vertex_colors_out->emplace_back(
             static_cast<double>(v.r), static_cast<double>(v.g), static_cast<double>(v.b), static_cast<double>(v.a));
       }
     }
@@ -249,9 +249,9 @@ std::vector<std::shared_ptr<T>> extractMeshData(const aiScene* scene,
                 texture_image = tex_resource;
               }
               aiVector3D* tex_coords = a->mTextureCoords[i];
-              for (unsigned int j = 0; j < a->mNumVertices; ++j)
+              for (unsigned int k = 0; k < a->mNumVertices; ++k)
               {
-                aiVector3D v = tex_coords[j];
+                aiVector3D v = tex_coords[k];
                 uvs.emplace_back(static_cast<double>(v.x), static_cast<double>(v.y));
               }
               auto tex = std::make_shared<MeshTexture>(
@@ -273,7 +273,7 @@ std::vector<std::shared_ptr<T>> extractMeshData(const aiScene* scene,
                                          resource,
                                          scale,
                                          vertex_normals,
-                                         vertex_colors,
+                                         vertex_colors_out,
                                          material,
                                          textures));
   }

--- a/geometry/src/geometries/convex_mesh.cpp
+++ b/geometry/src/geometries/convex_mesh.cpp
@@ -74,7 +74,17 @@ void ConvexMesh::setCreationMethod(CreationMethod method) { creation_method_ = m
 
 Geometry::Ptr ConvexMesh::clone() const
 {
-  return std::make_shared<ConvexMesh>(getVertices(), getFaces(), getFaceCount(), getResource(), getScale());
+  auto cloned = std::make_shared<ConvexMesh>(getVertices(),
+                                             getFaces(),
+                                             getFaceCount(),
+                                             getResource(),
+                                             getScale(),
+                                             getNormals(),
+                                             getVertexColors(),
+                                             cloneMaterial(),
+                                             getTextures());
+  cloned->setCreationMethod(creation_method_);
+  return cloned;
 }
 
 bool ConvexMesh::operator==(const ConvexMesh& rhs) const

--- a/geometry/src/geometries/mesh.cpp
+++ b/geometry/src/geometries/mesh.cpp
@@ -74,33 +74,15 @@ Mesh::Mesh(std::shared_ptr<const tesseract::common::VectorVector3d> vertices,
 
 Geometry::Ptr Mesh::clone() const
 {
-  // getMaterial returns a pointer-to-const, so deference and make_shared, but also guard against nullptr
-  std::shared_ptr<Mesh> ptr;
-  if (getMaterial() != nullptr)
-  {
-    ptr = std::make_shared<Mesh>(getVertices(),
-                                 getFaces(),
-                                 getFaceCount(),
-                                 getResource(),
-                                 getScale(),
-                                 getNormals(),
-                                 getVertexColors(),
-                                 std::make_shared<MeshMaterial>(*getMaterial()),
-                                 getTextures());
-  }
-  else
-  {
-    ptr = std::make_shared<Mesh>(getVertices(),
-                                 getFaces(),
-                                 getFaceCount(),
-                                 getResource(),
-                                 getScale(),
-                                 getNormals(),
-                                 getVertexColors(),
-                                 nullptr,
-                                 getTextures());
-  }
-  return ptr;
+  return std::make_shared<Mesh>(getVertices(),
+                                getFaces(),
+                                getFaceCount(),
+                                getResource(),
+                                getScale(),
+                                getNormals(),
+                                getVertexColors(),
+                                cloneMaterial(),
+                                getTextures());
 }
 
 bool Mesh::operator==(const Mesh& rhs) const

--- a/geometry/src/geometries/polygon_mesh.cpp
+++ b/geometry/src/geometries/polygon_mesh.cpp
@@ -103,9 +103,15 @@ MeshMaterial::ConstPtr PolygonMesh::getMaterial() const { return mesh_material_;
 
 const std::shared_ptr<const std::vector<MeshTexture::Ptr>>& PolygonMesh::getTextures() const { return mesh_textures_; }
 
+MeshMaterial::Ptr PolygonMesh::cloneMaterial() const
+{
+  return (mesh_material_ != nullptr) ? std::make_shared<MeshMaterial>(*mesh_material_) : nullptr;
+}
+
 Geometry::Ptr PolygonMesh::clone() const
 {
-  return std::make_shared<PolygonMesh>(vertices_, faces_, face_count_, resource_, scale_);
+  return std::make_shared<PolygonMesh>(
+      vertices_, faces_, face_count_, resource_, scale_, normals_, vertex_colors_, cloneMaterial(), mesh_textures_);
 }
 
 bool PolygonMesh::operator==(const PolygonMesh& rhs) const
@@ -115,7 +121,9 @@ bool PolygonMesh::operator==(const PolygonMesh& rhs) const
   equal &= vertex_count_ == rhs.vertex_count_;
   equal &= face_count_ == rhs.face_count_;
   equal &= tesseract::common::almostEqualRelativeAndAbs(scale_, rhs.scale_);
-  /// @todo Finish PolygonMesh == operator
+  equal &= tesseract::common::pointersEqual(vertices_, rhs.vertices_);
+  equal &= tesseract::common::pointersEqual(faces_, rhs.faces_);
+  /// @todo Compare resource, normals, vertex colors, material and textures
   return equal;
 }
 bool PolygonMesh::operator!=(const PolygonMesh& rhs) const { return !operator==(rhs); }

--- a/geometry/test/tesseract_geometry_unit.cpp
+++ b/geometry/test/tesseract_geometry_unit.cpp
@@ -14,6 +14,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract/geometry/impl/signed_distance_field_utils.h>
 #include <tesseract/common/utils.h>
 #include <tesseract/common/resource_locator.h>
+#include <tesseract/common/ply_io.h>
 #include <cstring>
 
 static constexpr double BIG_TOL = 1e6;
@@ -327,6 +328,119 @@ TEST(TesseractGeometryUnit, PolygonMesh)  // NOLINT
                                        std::make_shared<Eigen::VectorXi>())));
 }
 
+TEST(TesseractGeometryUnit, MeshParserVertexColors)  // NOLINT
+{
+  // The vertex_colors flag reaches the loaded mesh; the normals arm is the control
+  tesseract::common::VectorVector3d verts{ { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 } };
+  std::vector<Eigen::Vector3i> colors{ Eigen::Vector3i{ 255, 0, 0 },
+                                       Eigen::Vector3i{ 0, 255, 0 },
+                                       Eigen::Vector3i{ 0, 0, 255 } };
+  Eigen::VectorXi faces(4);
+  faces << 3, 0, 1, 2;
+
+  const std::string path = tesseract::common::getTempPath() + "vertex_color_mesh.ply";
+  ASSERT_TRUE(tesseract::common::writeSimplePlyFile(path, verts, colors, faces, 1));
+
+  auto resource = std::make_shared<tesseract::common::SimpleLocatedResource>(path, path);
+
+  auto with_colors = tesseract::geometry::createMeshFromResource<tesseract::geometry::Mesh>(
+      resource, Eigen::Vector3d(1, 1, 1), true, true, true, true, true);
+  ASSERT_EQ(with_colors.size(), 1U);
+  ASSERT_TRUE(with_colors.front()->getVertexColors() != nullptr);
+  ASSERT_EQ(with_colors.front()->getVertexColors()->size(), verts.size());
+  for (std::size_t i = 0; i < colors.size(); ++i)
+  {
+    const Eigen::Vector4d& c = with_colors.front()->getVertexColors()->at(i);
+    EXPECT_NEAR(c(0), colors[i](0) / 255.0, 1e-3);
+    EXPECT_NEAR(c(1), colors[i](1) / 255.0, 1e-3);
+    EXPECT_NEAR(c(2), colors[i](2) / 255.0, 1e-3);
+  }
+
+  auto without_colors = tesseract::geometry::createMeshFromResource<tesseract::geometry::Mesh>(
+      resource, Eigen::Vector3d(1, 1, 1), true, true, true, false, true);
+  ASSERT_EQ(without_colors.size(), 1U);
+  EXPECT_TRUE(without_colors.front()->getVertexColors() == nullptr);
+}
+
+/** @brief The optional data a mesh carries in addition to its vertices and faces */
+struct MeshDecorations
+{
+  std::shared_ptr<const tesseract::common::VectorVector3d> normals;
+  std::shared_ptr<const tesseract::common::VectorVector4d> vertex_colors;
+  std::shared_ptr<tesseract::geometry::MeshMaterial> material;
+  std::shared_ptr<const std::vector<tesseract::geometry::MeshTexture::Ptr>> textures;
+};
+
+/** @brief Build a full set of decorations for a mesh of @p vertex_count vertices */
+MeshDecorations makeMeshDecorations(std::size_t vertex_count)
+{
+  auto uvs = std::make_shared<tesseract::common::VectorVector2d>(1, Eigen::Vector2d(0, 0));
+  return { std::make_shared<tesseract::common::VectorVector3d>(vertex_count, Eigen::Vector3d(0, 0, 1)),
+           std::make_shared<tesseract::common::VectorVector4d>(vertex_count, Eigen::Vector4d(1, 0, 0, 1)),
+           std::make_shared<tesseract::geometry::MeshMaterial>(
+               Eigen::Vector4d(0.1, 0.2, 0.3, 1.0), 0.25, 0.75, Eigen::Vector4d(0.4, 0.5, 0.6, 1.0)),
+           std::make_shared<std::vector<tesseract::geometry::MeshTexture::Ptr>>(
+               1, std::make_shared<tesseract::geometry::MeshTexture>(nullptr, uvs)) };
+}
+
+/**
+ * @brief Check @p clone carries the decorations it was built from
+ * @details The containers are shared with the source, but the material is deep copied, so the clone must hold an
+ * equal material in a different object.
+ */
+void expectDecorationsCloned(const tesseract::geometry::PolygonMesh& clone, const MeshDecorations& source)
+{
+  EXPECT_EQ(clone.getNormals(), source.normals);
+  EXPECT_EQ(clone.getVertexColors(), source.vertex_colors);
+  EXPECT_EQ(clone.getTextures(), source.textures);
+
+  const auto material = clone.getMaterial();
+  ASSERT_TRUE(material != nullptr);
+  EXPECT_NE(material.get(), source.material.get());
+  EXPECT_TRUE(material->getBaseColorFactor().isApprox(source.material->getBaseColorFactor()));
+  EXPECT_TRUE(material->getEmissiveFactor().isApprox(source.material->getEmissiveFactor()));
+  EXPECT_DOUBLE_EQ(material->getMetallicFactor(), source.material->getMetallicFactor());
+  EXPECT_DOUBLE_EQ(material->getRoughnessFactor(), source.material->getRoughnessFactor());
+}
+
+TEST(TesseractGeometryUnit, PolygonMeshCloneAndEquality)  // NOLINT
+{
+  auto vertices = std::make_shared<tesseract::common::VectorVector3d>();
+  vertices->emplace_back(1, 1, 0);
+  vertices->emplace_back(1, -1, 0);
+  vertices->emplace_back(-1, -1, 0);
+
+  auto faces = std::make_shared<Eigen::VectorXi>();
+  faces->resize(4);
+  (*faces) << 3, 0, 1, 2;
+
+  auto deco = makeMeshDecorations(3);
+
+  using T = tesseract::geometry::PolygonMesh;
+  auto geom = std::make_shared<T>(vertices,
+                                  faces,
+                                  1,
+                                  nullptr,
+                                  Eigen::Vector3d(1, 1, 1),
+                                  deco.normals,
+                                  deco.vertex_colors,
+                                  deco.material,
+                                  deco.textures);
+
+  auto clone = std::static_pointer_cast<T>(geom->clone());
+  expectDecorationsCloned(*clone, deco);
+  EXPECT_TRUE(tesseract::geometry::isIdentical(*geom, *clone));
+
+  // Equality looks at the geometry, not just the counts and scale
+  auto other_vertices = std::make_shared<tesseract::common::VectorVector3d>();
+  other_vertices->emplace_back(5, 5, 0);
+  other_vertices->emplace_back(5, -5, 0);
+  other_vertices->emplace_back(-5, -5, 0);
+  T other(other_vertices, faces, 1);
+  other.setUUID(geom->getUUID());
+  EXPECT_TRUE(*geom != other);
+}
+
 TEST(TesseractGeometryUnit, ConvexMesh)  // NOLINT
 {
   auto vertices = std::make_shared<tesseract::common::VectorVector3d>();
@@ -343,8 +457,17 @@ TEST(TesseractGeometryUnit, ConvexMesh)  // NOLINT
   (*faces)(3) = 2;
   (*faces)(4) = 3;
 
+  auto deco = makeMeshDecorations(4);
+
   using T = tesseract::geometry::ConvexMesh;
-  auto geom = std::make_shared<T>(vertices, faces);
+  auto geom = std::make_shared<T>(vertices,
+                                  faces,
+                                  nullptr,
+                                  Eigen::Vector3d(1, 1, 1),
+                                  deco.normals,
+                                  deco.vertex_colors,
+                                  deco.material,
+                                  deco.textures);
   EXPECT_TRUE(geom->getVertices() != nullptr);
   EXPECT_TRUE(geom->getFaces() != nullptr);
   EXPECT_TRUE(geom->getVertexCount() == 4);
@@ -355,21 +478,22 @@ TEST(TesseractGeometryUnit, ConvexMesh)  // NOLINT
   EXPECT_EQ(geom->getCreationMethod(), tesseract::geometry::ConvexMesh::CreationMethod::CONVERTED);
   EXPECT_FALSE(geom->getUUID().is_nil());
 
-  auto geom_clone = geom->clone();
-  EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getVertices() != nullptr);
-  EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getFaces() != nullptr);
-  EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getVertexCount() == 4);
-  EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getFaceCount() == 1);
-  EXPECT_EQ(geom_clone->getType(), tesseract::geometry::GeometryType::CONVEX_MESH);
-  EXPECT_EQ(geom->getCreationMethod(), tesseract::geometry::ConvexMesh::CreationMethod::CONVERTED);
-  EXPECT_FALSE(geom_clone->getUUID().is_nil());
-  EXPECT_NE(geom_clone->getUUID(), geom->getUUID());
+  auto clone = std::static_pointer_cast<T>(geom->clone());
+  EXPECT_TRUE(clone->getVertices() != nullptr);
+  EXPECT_TRUE(clone->getFaces() != nullptr);
+  EXPECT_TRUE(clone->getVertexCount() == 4);
+  EXPECT_TRUE(clone->getFaceCount() == 1);
+  EXPECT_EQ(clone->getType(), tesseract::geometry::GeometryType::CONVEX_MESH);
+  EXPECT_EQ(clone->getCreationMethod(), tesseract::geometry::ConvexMesh::CreationMethod::CONVERTED);
+  expectDecorationsCloned(*clone, deco);
+  EXPECT_FALSE(clone->getUUID().is_nil());
+  EXPECT_NE(clone->getUUID(), geom->getUUID());
 
-  geom->setUUID(geom_clone->getUUID());
-  EXPECT_EQ(geom_clone->getUUID(), geom->getUUID());
+  geom->setUUID(clone->getUUID());
+  EXPECT_EQ(clone->getUUID(), geom->getUUID());
 
   // Test isIdentical
-  EXPECT_TRUE(tesseract::geometry::isIdentical(*geom, *geom_clone));
+  EXPECT_TRUE(tesseract::geometry::isIdentical(*geom, *clone));
   EXPECT_FALSE(tesseract::geometry::isIdentical(
       *geom,
       tesseract::geometry::ConvexMesh(std::make_shared<tesseract::common::VectorVector3d>(),
@@ -536,8 +660,15 @@ TEST(TesseractGeometryUnit, Mesh)  // NOLINT
   }
 
   {
-    auto mat = std::make_shared<tesseract::geometry::MeshMaterial>();
-    auto geom = std::make_shared<T>(vertices, faces, nullptr, Eigen::Vector3d(1, 1, 1), nullptr, nullptr, mat);
+    auto deco = makeMeshDecorations(4);
+    auto geom = std::make_shared<T>(vertices,
+                                    faces,
+                                    nullptr,
+                                    Eigen::Vector3d(1, 1, 1),
+                                    deco.normals,
+                                    deco.vertex_colors,
+                                    deco.material,
+                                    deco.textures);
     EXPECT_TRUE(geom->getVertices() != nullptr);
     EXPECT_TRUE(geom->getFaces() != nullptr);
     EXPECT_TRUE(geom->getVertexCount() == 4);
@@ -546,21 +677,21 @@ TEST(TesseractGeometryUnit, Mesh)  // NOLINT
     EXPECT_EQ(geom->getType(), tesseract::geometry::GeometryType::MESH);
     EXPECT_FALSE(geom->getUUID().is_nil());
 
-    auto geom_clone = geom->clone();
-    EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getVertices() != nullptr);
-    EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getFaces() != nullptr);
-    EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getVertexCount() == 4);
-    EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getFaceCount() == 2);
-    EXPECT_TRUE(std::static_pointer_cast<T>(geom_clone)->getMaterial() != nullptr);
-    EXPECT_EQ(geom_clone->getType(), tesseract::geometry::GeometryType::MESH);
-    EXPECT_FALSE(geom_clone->getUUID().is_nil());
-    EXPECT_NE(geom_clone->getUUID(), geom->getUUID());
+    auto clone = std::static_pointer_cast<T>(geom->clone());
+    EXPECT_TRUE(clone->getVertices() != nullptr);
+    EXPECT_TRUE(clone->getFaces() != nullptr);
+    EXPECT_TRUE(clone->getVertexCount() == 4);
+    EXPECT_TRUE(clone->getFaceCount() == 2);
+    expectDecorationsCloned(*clone, deco);
+    EXPECT_EQ(clone->getType(), tesseract::geometry::GeometryType::MESH);
+    EXPECT_FALSE(clone->getUUID().is_nil());
+    EXPECT_NE(clone->getUUID(), geom->getUUID());
 
-    geom->setUUID(geom_clone->getUUID());
-    EXPECT_EQ(geom_clone->getUUID(), geom->getUUID());
+    geom->setUUID(clone->getUUID());
+    EXPECT_EQ(clone->getUUID(), geom->getUUID());
 
     // Test isIdentical
-    EXPECT_TRUE(tesseract::geometry::isIdentical(*geom, *geom_clone));
+    EXPECT_TRUE(tesseract::geometry::isIdentical(*geom, *clone));
     EXPECT_FALSE(tesseract::geometry::isIdentical(
         *geom,
         tesseract::geometry::Mesh(std::make_shared<tesseract::common::VectorVector3d>(),


### PR DESCRIPTION
Mesh colour data was being dropped in two places: when a mesh is loaded, and when one is cloned.

## Loading: the `vertex_colors` flag never reached the loader

`extractMeshData` takes a `bool vertex_colors` parameter, and then declares a local
`std::shared_ptr<VectorVector4d> vertex_colors = nullptr` that shadows it. The gate is

```cpp
if (vertex_colors && a->HasVertexColors(0))
```

which from that point on tests the null `shared_ptr`, not the flag. It is never true, so **no mesh
has ever loaded vertex colours through this path**, whatever the caller passed. The local is renamed
`vertex_colors_out`.

A second shadowing in the same function is cosmetic — the texture-coordinate loop reuses `j` from an
enclosing scope — but it is the same mistake one scope down, so it is fixed here too.

## Cloning: everything past the scale was dropped

`PolygonMesh::clone()` and `ConvexMesh::clone()` forwarded only vertices, faces, face count,
resource and scale, discarding normals, vertex colours, material and textures. `ConvexMesh::clone()`
additionally lost the creation method, so a cloned `CONVERTED` mesh came back as `DEFAULT`.

`Mesh::clone()` did carry them, through a 28-line two-armed `if` that spelled out the whole nine
argument constructor twice to guard the material against null. That is now a shared
`PolygonMesh::cloneMaterial()` helper, used by all three, so the material is deep-copied in one
place and a clone shares no mutable material state with its original.

## Uninitialised state

`MeshMaterial::base_color_factor_` and `emissive_factor_` had no initialiser, so a default
constructed material read as whatever was on the stack. They now default to zero, alongside the
`metallic_factor_`/`roughness_factor_` defaults that were already there. `PolygonMesh::scale_` is
likewise given its identity default.

## `operator==`

`PolygonMesh::operator==` compared only the counts and the scale, so two meshes with entirely
different geometry compared equal — which also means the clone fixes above could not be tested. It
now compares the vertex and face data as well.

Materials and textures are deliberately still not compared. `cereal` does not serialise them, so
completing the comparison breaks the serialisation round-trip tests, which use `operator==` as their
oracle. The `@todo` is narrowed to name exactly what is left rather than removed.

## Testing

New `MeshParserVertexColors` writes a coloured PLY and asserts the colours arrive with
`vertex_colors=true` and are null with `false` — the control arm is what pins the shadowing fix.
New `PolygonMeshCloneAndEquality` covers the clone and the comparison.

The existing `TesseractGeometryUnit.ConvexMesh` test already checked the creation method after a
clone, but asserted on the original object rather than the clone, so it passed against the bug. It
now asserts on the clone.

Full suite green.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
