### PR TITLE
Give each Visual its own default material

### DIFF
--- a/scene_graph/include/tesseract/scene_graph/link.h
+++ b/scene_graph/include/tesseract/scene_graph/link.h
@@ -67,7 +67,7 @@ public:
   using Ptr = std::shared_ptr<Material>;
   using ConstPtr = std::shared_ptr<const Material>;
 
-  Material() = default;
+  Material();
   explicit Material(std::string name);
   ~Material() = default;
 
@@ -78,6 +78,11 @@ public:
 
   const std::string& getName() const;
 
+  /**
+   * @brief Get a new instance of the default material
+   * @details Each call returns a distinct object, so two Visuals constructed independently do not
+   * share one. Copying a Visual still shares its material with the copy.
+   */
   static std::shared_ptr<Material> getDefaultMaterial();
 
   std::string texture_filename;

--- a/scene_graph/src/link.cpp
+++ b/scene_graph/src/link.cpp
@@ -30,12 +30,13 @@ namespace tesseract::scene_graph
 /*********************************************************/
 /******                 Material                     *****/
 /*********************************************************/
+Material::Material() { this->clear(); }
+
 Material::Material(std::string name) : name_(std::move(name)) { this->clear(); }
 
 std::shared_ptr<Material> Material::getDefaultMaterial()
 {
-  static auto default_material = std::make_shared<Material>("default_tesseract_material");
-  return default_material;
+  return std::make_shared<Material>("default_tesseract_material");
 }
 
 const std::string& Material::getName() const { return name_; }

--- a/scene_graph/test/tesseract_scene_graph_link_unit.cpp
+++ b/scene_graph/test/tesseract_scene_graph_link_unit.cpp
@@ -66,7 +66,7 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkVisualUnit)  // NOLINT
   Visual m;
 
   EXPECT_TRUE(m.origin.isApprox(Eigen::Isometry3d::Identity()));
-  EXPECT_TRUE(m.material == Material::getDefaultMaterial());
+  EXPECT_TRUE(*m.material == *Material::getDefaultMaterial());
   EXPECT_TRUE(m.geometry == nullptr);
   EXPECT_TRUE(m.name.empty());
 
@@ -78,9 +78,31 @@ TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkVisualUnit)  // NOLINT
   m.clear();
 
   EXPECT_TRUE(m.origin.isApprox(Eigen::Isometry3d::Identity()));
-  EXPECT_TRUE(m.material == Material::getDefaultMaterial());
+  EXPECT_TRUE(*m.material == *Material::getDefaultMaterial());
   EXPECT_TRUE(m.geometry == nullptr);
   EXPECT_TRUE(m.name.empty());
+}
+
+TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkDefaultMaterialUnit)  // NOLINT
+{
+  using namespace tesseract::scene_graph;
+
+  // The defaulted default constructor initializes color, so a default material equals itself
+  Material m;
+  EXPECT_TRUE(m.color.isApprox(Eigen::Vector4d(0.5, 0.5, 0.5, 1.0)));
+  EXPECT_TRUE(m.texture_filename.empty());
+  EXPECT_TRUE(Material{} == Material{});
+
+  // Each Visual owns its material, so recoloring one leaves the others alone
+  Visual v1;
+  Visual v2;
+  ASSERT_TRUE(v1.material != nullptr);
+  ASSERT_TRUE(v2.material != nullptr);
+  EXPECT_NE(v1.material.get(), v2.material.get());
+
+  v1.material->color = Eigen::Vector4d(1, 0, 0, 1);
+  EXPECT_TRUE(v2.material->color.isApprox(Eigen::Vector4d(0.5, 0.5, 0.5, 1.0)));
+  EXPECT_TRUE(Material::getDefaultMaterial()->color.isApprox(Eigen::Vector4d(0.5, 0.5, 0.5, 1.0)));
 }
 
 TEST(TesseractSceneGraphUnit, TesseractSceneGraphLinkCollisionUnit)  // NOLINT


### PR DESCRIPTION
`Material::getDefaultMaterial()` returned a function-local static:

```cpp
static auto default_material = std::make_shared<Material>("default_tesseract_material");
return default_material;
```

`Material` is mutable and the accessor hands out a non-const `shared_ptr`, so every `Visual` that
falls back to the default shares one object. Recolouring a single link recolours every other link
that has no material of its own — silently, at a distance, and only for links that happened to take
the default.

It now returns a fresh instance per call. Copying a `Visual` still shares its material with the
copy, which is the existing shallow-copy behaviour of `Link::clone()` and is not changed here.

`Material()` was also `= default`, unlike `Material(std::string)` next door which calls `clear()`,
so a default-constructed material left its colour uninitialised. It now calls `clear()` too, keeping
one definition of the default state.

## Contract change

`getDefaultMaterial()` no longer returns a singleton, so pointer comparison against it stops
working. Two assertions in the existing tests compared identity and now compare value. Anything
downstream doing the same needs the same edit — it fails loudly at the assertion rather than
silently.

## Testing

New `TesseractSceneGraphLinkDefaultMaterialUnit` asserts two calls return distinct objects with
equal contents. Full suite green.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
