### PR TITLE
Give each thread its own random engine

### DIFF
--- a/common/include/tesseract/common/utils.h
+++ b/common/include/tesseract/common/utils.h
@@ -53,14 +53,13 @@ class XMLAttribute;
 
 namespace tesseract::common
 {
-#if __cplusplus < 201703L
-/** @brief Random number generator */
-static std::mt19937 mersenne{ static_cast<std::mt19937::result_type>(std::time(nullptr)) };
-#else
-/** @brief Random number generator */
+/**
+ * @brief Random number generator, one independently seeded instance per thread
+ * @details Seeding affects only the calling thread. On Windows each DLL additionally gets its own
+ * instance, so a seed set in one module does not reach draws made in another.
+ */
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-inline std::mt19937 mersenne{ static_cast<std::mt19937::result_type>(std::time(nullptr)) };
-#endif
+inline thread_local std::mt19937 mersenne{ std::random_device{}() };
 
 template <typename... Args>
 std::string strFormat(const std::string& format, Args... args)

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -25,6 +25,7 @@
 #include <tesseract/common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <ctime>
+#include <random>
 #include <string>
 #include <type_traits>
 #include <console_bridge/console.h>
@@ -281,14 +282,18 @@ Eigen::VectorXd calcJacobianTransformErrorDiff(const Eigen::Isometry3d& target,
 Eigen::Vector4d computeRandomColor()
 {
   Eigen::Vector4d c;
+  // Zeroed so the first condition check reads defined values, and so it enters the loop
   c.setZero();
   c[3] = 1;
+  // The hundredth grid is load-bearing: a continuous distribution would make the distinctness
+  // rejection below unreachable, because two such draws are never almost equal.
+  std::uniform_int_distribution<int> sample(0, 99);
   while (almostEqualRelativeAndAbs(c[0], c[1]) || almostEqualRelativeAndAbs(c[2], c[1]) ||
          almostEqualRelativeAndAbs(c[2], c[0]))
   {
-    c[0] = (rand() % 100) / 100.0;
-    c[1] = (rand() % 100) / 100.0;
-    c[2] = (rand() % 100) / 100.0;
+    c[0] = sample(mersenne) / 100.0;
+    c[1] = sample(mersenne) / 100.0;
+    c[2] = sample(mersenne) / 100.0;
   }
   return c;
 }


### PR DESCRIPTION
## The problem

`tesseract::common::mersenne` is one unsynchronized process-wide `std::mt19937`,
declared as an `inline` variable in `common/utils.h` and reached through public API.
Every draw is a read-modify-write of the engine's 624-word state, so two threads
drawing concurrently is a data race. ThreadSanitizer reports it directly —
`_M_gen_rand()` against itself on the global object — under 8 threads × 20 000
`generateRandomNumber` calls.

The sampled values stay inside their limits (0 of 160 000 out of range), so nothing
downstream looks wrong. What the race actually costs is the generator's guarantees —
period, equidistribution, independence between threads — plus formal undefined
behaviour. It is silent by construction, which is why it has survived.

Production reaches it through `generateRandomNumber` → `getRandomState`, on state
solvers that planners clone per thread.

Separately, `computeRandomColor` used `rand()` with no `srand()` anywhere in the
repository, so it is seeded with 1 and returns the same colour sequence on every run
of every process — "random" link colours that are identical between two robots
visualised side by side.

## The fix

`inline thread_local std::mt19937 mersenne{ std::random_device{}() };`

`thread_local` removes the sharing rather than locking around it: each thread gets
its own engine, so there is no shared state left to race on. A mutex would also
remove the UB but serialises every draw onto one stream, which nothing here wants.

The seed change is part of the same fix, not a separate cleanup. A `thread_local`
initialiser runs per thread, so keeping `std::time(nullptr)` would give every thread
constructed within the same second an identical seed and therefore an identical
sequence — several workers sampling in lockstep, a worse and far less detectable
failure than the race. `random_device` also fixes two processes launched in the same
second agreeing.

`computeRandomColor` now draws from the engine, matching `generateRandomNumber` six
lines below it. The `#if __cplusplus < 201703L` arm is deleted: it declared a
`static` engine, giving every translation unit its own copy, and was unreachable on
a C++17 project.

## What this changes for callers

Seeding becomes per-thread — `mersenne.seed(s)` affects only the calling thread.
This still compiles, so it is a silent semantic change for any downstream that seeds
for reproducibility and then draws on a worker thread. Worth a release note.

Nothing in the workspace is affected. The only `.seed()` call is
`tesseract_collision_benchmarks`, which seeds in `main` and draws on the same thread,
so its `--seed` flag keeps working; the other call sites only sample.

Costs, measured rather than assumed: `std::mt19937` is 5000 bytes per thread that
draws (libstdc++ instantiates on `uint_fast32_t`, 8 bytes on LP64). 1000 idle threads
showed no measurable RSS change. A draw across a DSO boundary costs +3.4 ns for the
TLS indirection, and GCC hoists the wrapper out of loops, so `generateRandomNumber`
emits two TLS calls regardless of iteration count. The change also removes a
namespace-scope dynamic initializer — a `time()` syscall at every library load — and
glibc `rand()`'s internal lock.

## The better fix, deliberately not done here

Replace the variable with an accessor pair defined in `utils.cpp`:

```cpp
std::mt19937& randomEngine();
void seedRandomEngine(std::mt19937::result_type seed);
```

Two things this buys that the `thread_local` variable structurally cannot:

**It works on Windows.** MSVC gives each DLL its own copy of a header-declared
`inline` variable — data symbols are not merged across module boundaries, and
`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` does not change that. So today, on Windows,
`tesseract_collision_benchmarks.exe` seeds its own copy and then draws from
`tesseract_common.dll`'s copy, and `--seed` silently does nothing. That is true of
the current code too, before this change. An accessor makes every caller reach one
exported function, hence one engine per thread per process everywhere. (Reasoned
from how MSVC handles inline data, not verified on a Windows build — worth
confirming on the conda-win job.)

**It makes the semantic change loud.** Deleting the symbol turns the silent
per-thread-seeding change described above into a compile error, so downstreams find
out at build time instead of through irreproducible results.

It removes a public symbol, so it belongs in its own PR. The census is 7 references
in 4 files, one of which — `tesseract_ros2/.../examples/action_server_memory.cpp` —
is dead: not referenced by any CMakeLists and still on ROS 1.

## Follow-up out of scope here

`rand()` survives in the *installed* header
`collision/test_suite/include/.../benchmarks/primatives_benchmarks.hpp` (lines 88,
114, 143, 171) and in `collision/test/benchmarks/collision_profile.cpp:172-174`, so
"tesseract no longer hands consumers a shared unsynchronized RNG" is only true of
the core libraries.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
