### PR TITLE
Move ccache setup into colcon-action@v15

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -8,6 +8,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -22,18 +22,6 @@ jobs:
         with:
           path: target_ws/src
 
-      - name: Configure ccache
-        shell: bash
-        run: |
-          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
-          mkdir -p "$GITHUB_WORKSPACE/benchmarks/.ccache"
-          echo "CCACHE_DIR=$GITHUB_WORKSPACE/benchmarks/.ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
-          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
-          # launcher passed there is dropped by the next --cmake-args on the command line.
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-
       - name: Install Depends
         shell: bash
         run: |
@@ -42,7 +30,7 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           ccache-prefix: benchmarks
           vcs-file: dependencies_jammy.repos

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   clang_format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cmake_format:
     runs-on: ubuntu-22.04

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.job_type }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -35,18 +35,6 @@ jobs:
         with:
           path: target_ws/src
 
-      - name: Configure ccache
-        shell: bash
-        run: |
-          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
-          mkdir -p "$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache"
-          echo "CCACHE_DIR=$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
-          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
-          # launcher passed there is dropped by the next --cmake-args on the command line.
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-
       - name: Install Depends
         shell: bash
         run: |
@@ -60,7 +48,7 @@ jobs:
           apt install -y clang-tidy-17 libomp-17-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           ccache-prefix: ${{ matrix.job_type }}
           vcs-file: dependencies_jammy.repos
@@ -69,11 +57,6 @@ jobs:
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args ${{ matrix.env.TARGET_CMAKE_ARGS }}
-
-      - name: Report ccache statistics
-        if: always()
-        shell: bash
-        run: ccache -s
 
       - name: Upload CodeCov Results
         if: matrix.job_type == 'codecov'

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,6 +10,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   conda-win:
     runs-on: windows-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,11 @@ on:
       - released
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -66,16 +66,8 @@ jobs:
       run: |
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}/lib" >> "$GITHUB_ENV"
         echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}" >> "$GITHUB_ENV"
-        # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
-        mkdir -p "$GITHUB_WORKSPACE/ci-mac-build-${{ matrix.config.arch }}/.ccache"
-        echo "CCACHE_DIR=$GITHUB_WORKSPACE/ci-mac-build-${{ matrix.config.arch }}/.ccache" >> "$GITHUB_ENV"
-        echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
-        # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
-        # launcher passed there is dropped by the next --cmake-args on the command line.
-        echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-        echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v14
+      uses: tesseract-robotics/colcon-action@v15
       with:
         ccache-prefix: ci-mac-build-${{ matrix.config.arch }}
         vcs-file: .github/workflows/windows_dependencies.repos
@@ -105,9 +97,3 @@ jobs:
           -DOpenMP_C_LIB_NAMES=libomp -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp" \
           -DOpenMP_libomp_LIBRARY=${{ matrix.config.homebrew_root }}/opt/libomp/lib/libomp.dylib
         run-tests-args: --merge-install --ctest-args -E "TesseractEnvironmentUnit.checkTrajectoryUnit|TesseractCommonUnit.timer"
-
-    - name: Report ccache statistics
-      if: always()
-      shell: bash
-      run: ccache -s
-        

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -12,6 +12,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   VCPKG_PKGS: >- 
     boost-dll boost-program-options boost-stacktrace

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     if: contains(github.event.pull_request.labels.*.name, 'check-tesseract-ros') || github.event.schedule == true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,18 +35,6 @@ jobs:
         with:
           path: target_ws/src
 
-      - name: Configure ccache
-        shell: bash
-        run: |
-          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
-          mkdir -p "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
-          echo "CCACHE_DIR=$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
-          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
-          # launcher passed there is dropped by the next --cmake-args on the command line.
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-
       - name: Install Depends
         shell: bash
         run: |
@@ -55,9 +43,9 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: nightly-${{ matrix.distro }}
           vcs-file: ${{ matrix.vcs_file }}
           rosdep-install-args: -iry --skip-keys ${{ matrix.rosdep_skip_keys }}
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -40,7 +40,7 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build and test
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           ccache-enabled: false
           vcs-file: ${{ matrix.vcs_file }}

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -8,6 +8,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   Debian:
     name: ${{ matrix.distro }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,18 +37,6 @@ jobs:
         with:
           path: target_ws/src
 
-      - name: Configure ccache
-        shell: bash
-        run: |
-          # Must match the ccache-prefix given to colcon-action below: that is the directory it caches.
-          mkdir -p "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
-          echo "CCACHE_DIR=$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache" >> "$GITHUB_ENV"
-          echo "CCACHE_MAXSIZE=1G" >> "$GITHUB_ENV"
-          # Set in the environment, not via --cmake-args: colcon's --cmake-args is last-wins, so a
-          # launcher passed there is dropped by the next --cmake-args on the command line.
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
-
       - name: Install Depends
         shell: bash
         run: |
@@ -57,16 +45,11 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: ubuntu-${{ matrix.distro }}
           vcs-file: ${{ matrix.vcs_file }}
           rosdep-install-args: -iry --skip-keys ${{ matrix.rosdep_skip_keys }}
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_ENABLE_BENCHMARKING=ON -DTESSERACT_ENABLE_RUN_BENCHMARKING=OFF -DTESSERACT_PACKAGE=ON
-
-      - name: Report ccache statistics
-        if: always()
-        shell: bash
-        run: ccache -s

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,6 +12,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
         echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE\vcpkg\installed\${{ matrix.config.triplet }}" >> "$GITHUB_ENV"
 
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v14
+      uses: tesseract-robotics/colcon-action@v15
       with:
         ccache-prefix: ci-win-build-${{ matrix.config.name }}
         vcs-file: .github/workflows/windows_dependencies.repos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.config.name }}


### PR DESCRIPTION
Brings this repo's ccache setup up to `colcon-action@v15`, which generalised the hand-rolled fix
from #1342. Closes #1345 for `tesseract`.

`@v15` does all of it per job, without being asked: creates and exports `CCACHE_DIR`, caps the cache
from the `ccache-maxsize` input (default `1G`), exports **both** `CMAKE_C_COMPILER_LAUNCHER` and
`CMAKE_CXX_COMPILER_LAUNCHER` into the environment where colcon's last-wins `--cmake-args` cannot
drop them, zeroes the counters after the restore, reports `ccache -s`, and saves after the build —
including after a failed one. It also resolves the cache directory by asking ccache
(`ccache --get-config cache_dir`) instead of shell-reading `CCACHE_DIR`, and warns when the result is
unusable.

So this PR is mostly a deletion.

### What changed

| file | change |
|---|---|
| `benchmarking`, `code_quality`, `nightly`, `ubuntu` | delete the `Configure ccache` step; bump to `@v15` |
| `code_quality`, `mac`, `ubuntu` | delete the `Report ccache statistics` step |
| `mac` | **partial edit** — the ccache lines live inside `update environment`, which also sets `DYLD_LIBRARY_PATH` and `CMAKE_PREFIX_PATH`. Only the ccache lines go; the step stays. |
| `windows` | version bump only |
| `ubuntu`, `nightly` | `ccache-prefix` renamed — see below |

Net: 63 lines of workflow deleted, nothing added.

### Why `ubuntu` and `nightly` get renamed prefixes

`@v15`'s restore key is `<prefix>-<runner.os>-ccache-<github.job>-`. The job id is `ci` in both of
those workflows and their `matrix.distro` values are the same two, so they resolved to identical
keys and shared one restore namespace across two different build configurations. They are now
`ubuntu-${{ matrix.distro }}` and `nightly-${{ matrix.distro }}`.

This costs nothing extra: `@v14`'s key was `<prefix>-linux-ccache-` and `@v15`'s carries
`runner.os`, which is `Linux`, not `linux` — so no `@v14` entry can match a `@v15` restore key under
any prefix. **Every workflow here is cold exactly once on this upgrade regardless of the rename.**

`code_quality` (`matrix.job_type`), `benchmarking` (`benchmarks`), `mac` and `windows` were already
distinct and are untouched.

### `package_debian.yml`

Now included, in its own commit. It passes `ccache-enabled: false`, so none of the ccache work
reaches it — the bump is for `@v15`'s *other* changes: `$SUDO` handling for containers that do not
run as root, and resolving the sub-action from `github.action_repository` instead of a hardcoded
`tesseract-robotics/colcon-action`.

Its only triggers are tag push and `workflow_dispatch`, so no pull request exercises it, and a
release-time workflow is the wrong place to ship an unverified action bump. Verified instead by
dispatching it on a fork branch holding exactly these two commits: **both distro legs green**, full
cpack set generated, both `upload-artifact` steps succeeded, no warnings. The `$SUDO` probe ran and
resolved to empty (root inside the container); `action_repository` resolved correctly even from a
fork.

### `nightly.yml`'s schedule trigger is broken and stays broken

Its job condition compares `github.event.schedule == true`; GitHub coerces the mismatched types to
number, a non-numeric string becomes `NaN`, and the branch is **always false** — the nightly has
never run on schedule. Reporting it, not fixing it, per an earlier decision. Consequence here: the
`nightly` prefix rename can only be exercised by adding the `check-tesseract-ros` label, which is
how it was verified on this PR.

### `benchmarking.yml` is broken upstream, and this PR does not fix it

It has failed since **2026-01-05** (last green `9a70ea6eb`). `Run Benchmarks` cannot find the
executables the preceding `Build` step should have left at `./test/benchmarks/`:
`/bin/sh: 1: ./test/benchmarks/collision_bullet_discrete_simple_benchmarks: not found`. Identical
signature on run 31906782499 (2026-08-15, before #1342), so it predates this work by months.

Because it only runs on push-to-master, no PR can exercise it. Verified out of band by dispatching
it on a fork branch: its **ccache half is fully verified** — cold run saved a cache, warm run
restored it and hit **220/220 (100%)**, with the `Build` step going 8.7m → 3.3m. The run still ends
red at `Run Benchmarks`, after every signal that matters.

### Verification

Two completed runs per platform, plus a third set after rebasing onto #1352. Green CI proves nothing
on its own here — every fault in this chain was a warning-shaped no-op — so these are read against
the logs.

**Warm results, second run (the first is cold by construction: the restore key changes shape at
`@v15`, so no `@v14` entry can match it under any prefix):**

| leg | cold | warm | hits |
|---|---|---|---|
| ubuntu jammy | 17.1m | 9.7m | 317/317 (100%) |
| ubuntu noble | 18.9m | 9.6m | 297/313 (94.9%) |
| nightly jammy / noble | 18.6 / 17.6m | 9.9 / 9.4m | 317/317, 297/313 |
| code_quality clang-tidy | 62.5m | 43.7m | 317/317 (100%) |
| code_quality codecov | 11.9m | 4.1m | 309/309 (100%) |
| mac x64 / arm64 | 56.5 / 16.9m | 12.9 / 5.0m | 289/302 (95.7%) |
| **windows MSVC-2019 / 2022** | 26.5 / 29.9m | **5.1 / 5.5m** | **285/285 (100%)** |

Against the `@v14`+#1342 baseline the Linux and macOS legs are at **parity** (deltas are sub-minute
on shared runners, i.e. noise) — which is the bar: same result, 63 fewer lines of workflow, no
hand-maintained ccache block. **Windows is a net gain of ~21 min per leg per run**, since `@v14`'s
`windows/action.yml` had no ccache at all.

Every leg: `Statistics zeroed`, both `CMAKE_C_` and `CMAKE_CXX_COMPILER_LAUNCHER` exported,
`ccache-maxsize: 1G` honoured, `CCACHE_DIR` resolved by the action rather than a caller value, a real
save key, **no `::warning::`** and no `Path Validation Error`.

#### Reading the numbers — two traps

**`@v14`'s counts are not comparable to `@v15`'s.** `@v14` never zeroed, and ccache's stats file
lives inside the restored `CCACHE_DIR`, so its `ccache -s` printed counters accumulated over every
run since the cache was first warmed — 3487 "cacheable calls" where the true per-job figure is 313.
Only wall-clock, warm vs warm, is comparable across the upgrade.

**The sub-100% hit rates are CMake, not ccache.** Every one of the 16 non-hits on noble is a
`try_compile` probe under `CMakeFiles/CMakeScratch/TryCompile-<random>/` — the directory name is
random per configure and forms part of ccache's hash, so those can never hit, in any project.
**Real translation units hit 297/297 = 100%**, identical to jammy. jammy shows 100% only because
cmake 3.22 runs its probes from a stable path; noble and macOS ship newer cmake. Confirmed by
`CCACHE_LOGFILE` on a scratch branch. Nothing to fix.

Windows' 25 uncacheable calls (8%) are link steps: exactly 25 on both cold and warm runs on both
legs, invariant to cache state. `Cacheable calls: 285/310`, not `0/0`, so the MSVC `/Zi` trap
(colcon-action#33) does not fire here — `-G "Ninja"` with `CMAKE_BUILD_TYPE=Release` means no `/Zi`
reaches the compiler.

---

## Second commit: cancel superseded pull-request runs

Pushing to a pull request left the previous run's whole matrix building to completion, so every
force-push doubled the queue for results nobody reads. Eleven workflows gain:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`cancel-in-progress` is scoped to `pull_request` deliberately. Pushes, schedules and releases keep
their runs and **queue** instead — on those events `github.ref` is the branch, so two builds of the
same branch would otherwise race to save the same ccache key.

Two of the thirteen workflows are excluded:

- **`docs.yml`** already has `group: "pages"` / `cancel-in-progress: false`, which is what a Pages
  deployment needs; leaving it alone keeps that.
- **`api_docs.yml`** is an invalid workflow file that has never run — see #1353. Because GitHub
  cannot read the triggers of an unparseable file, *any* push that edits it produces a failing run
  even for events it does not subscribe to. Editing it added a red `.github/workflows/api_docs.yml`
  run to this PR; reverting the edit removed it. Left untouched here, tracked there.

All thirteen workflow files were validated against the
[SchemaStore GitHub Actions schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json);
only `api_docs.yml` fails, and it failed before this branch existed.

### Verified

Pushed twice in quick succession and read the conclusions of the first push's runs:

| workflow | state at 2nd push | conclusion |
| --- | --- | --- |
| Ubuntu | in_progress | **cancelled** |
| Windows | in_progress | **cancelled** |
| Mac OSX | queued | **cancelled** |
| Conda | in_progress | **cancelled** |
| Docker | in_progress | **cancelled** |
| Code Quality | in_progress | **cancelled** |
| Clang-Format | already completed | success (not superseded) |
| CMake-Format | already completed | success (not superseded) |

Six of six still-live runs superseded within seconds, including one that had not yet been assigned a
runner. Runs that had already finished are untouched, as intended.
