### PR TITLE
Follow vcpkg releases instead of master on macOS

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -65,7 +65,6 @@ jobs:
         extra-args: --clean-after-build --overlay-triplets=${{ github.workspace }}/target_ws/src/.github/workflows/vcpkg_triplets
         token: ${{ github.token }}
         cache-key: osx-${{ matrix.config.arch }}-vcpkg
-        revision: master
     - name: update environment
       shell: bash
       run: |


### PR DESCRIPTION
One line. `mac.yml` checks vcpkg out at `master`; this drops that so the action uses the latest vcpkg
stable release instead — which is what `windows.yml` in this repository already does.

### Why it costs time

`johnwason/vcpkg-action@v8` keys its cache on

```
<runner.os>-<triplet>-vcpkg-<hashFiles(vcpkg_dry_run.txt)>-<cache-key>
```

and `vcpkg_dry_run.txt` is the nuget packages config written by `vcpkg install --dry-run` — that is,
the **ABI hashes of every package**. Checking out `master` means those hashes move whenever the ports
move, the cache key moves with them, and the job rebuilds the entire dependency set from source.

That is 25–65 minutes per leg and it recurs. Observed in `tesseract_planning`: the macOS x64 key held
`…f6fc93077f` and hit on every run from 11:38 to 21:59 on 2026-08-21, then changed to `…e16d794ac8`
by 23:15 and missed — 66.0 m and then 42.4 m of `vcpkg build` on consecutive runs.

With an empty `revision` the action checks out the latest vcpkg **release** tag, so the key moves at
release cadence (roughly monthly) rather than continuously.

### Why this is safe to drop

The pin dates back to the commit that first added `mac.yml`, and nothing in the history ties it to a
port fix that was only available on `master`.

Verified on a throwaway branch before opening this: the action resolves **`2026.07.29`**, both legs
build the full package set — bullet3, pcl, ompl, fcl, gperftools, openblas and the rest — and **897
of 897 tests pass on each**. Timings there were vcpkg 28.8 m / build 23.0 m on arm64 and vcpkg
43.3 m / build 33.8 m on x64, both from a completely cold cache.

Expect one cold macOS run after this merges, since the key changes. That is the same one-off every
key change costs, and it is what stops the recurring one.

### What this is not

**This follows releases; it does not pin.** The key still moves when vcpkg cuts a release, and the
action resolves "latest" through the releases API on every run. A real pin would mean naming a tag —
`revision: 2026.07.29` — and bumping it deliberately. That is a reasonable thing to want and a
separate decision; this change only stops the key churning daily.

vcpkg's own versioning features are not an option here: `builtin-baseline`, `version>=` and
`overrides` are [manifest-mode only](https://learn.microsoft.com/en-us/vcpkg/consume/lock-package-versions),
and this repository uses classic mode with no `vcpkg.json`. In classic mode the checked-out vcpkg
commit is the only lever there is.
