### PR TITLE
DO NOT MERGE: test colcon-action@main

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -35,7 +35,7 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build
-        uses: tesseract-robotics/colcon-action@v15
+        uses: tesseract-robotics/colcon-action@main
         with:
           ccache-prefix: benchmarks
           vcs-file: dependencies_jammy.repos

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -53,7 +53,7 @@ jobs:
           apt install -y clang-tidy-17 libomp-17-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v15
+        uses: tesseract-robotics/colcon-action@main
         with:
           ccache-prefix: ${{ matrix.job_type }}
           vcs-file: dependencies_jammy.repos

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -71,7 +71,7 @@ jobs:
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}/lib" >> "$GITHUB_ENV"
         echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}" >> "$GITHUB_ENV"
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v15
+      uses: tesseract-robotics/colcon-action@main
       with:
         ccache-prefix: ci-mac-build-${{ matrix.config.arch }}
         vcs-file: .github/workflows/windows_dependencies.repos

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v15
+        uses: tesseract-robotics/colcon-action@main
         with:
           ccache-prefix: nightly-${{ matrix.distro }}
           vcs-file: ${{ matrix.vcs_file }}

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -45,7 +45,7 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build and test
-        uses: tesseract-robotics/colcon-action@v15
+        uses: tesseract-robotics/colcon-action@main
         with:
           ccache-enabled: false
           vcs-file: ${{ matrix.vcs_file }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
           apt install -y liboctomap-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v15
+        uses: tesseract-robotics/colcon-action@main
         with:
           ccache-prefix: ubuntu-${{ matrix.distro }}
           vcs-file: ${{ matrix.vcs_file }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
         echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE\vcpkg\installed\${{ matrix.config.triplet }}" >> "$GITHUB_ENV"
 
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v15
+      uses: tesseract-robotics/colcon-action@main
       with:
         ccache-prefix: ci-win-build-${{ matrix.config.name }}
         vcs-file: .github/workflows/windows_dependencies.repos


### PR DESCRIPTION
Throwaway draft, opened to exercise the unreleased `colcon-action` against a real consumer before a
`v16` tag is cut. **Not for merge — I will close it once the legs report.**

Switches all seven workflows from `@v15` to `@main`. Four of them run on `pull_request` and are the
actual test: `ubuntu`, `mac`, `windows`, `code_quality`. (`benchmarking` and `package_debian` are
`push`-only, `nightly` needs a dispatch, so those three are along for the ride.)

What is being tested, from tesseract-robotics/colcon-action#32:

- **macOS** is the real change — `Install base deps` now probes each tool and installs only what is
  missing, instead of `brew update` plus a `brew install` that upgraded the runner's cmake, git and
  python3 every run. `mac.yml` is why this repository was chosen: it is the only `@v15` consumer with
  a macOS leg.
- **Linux** applies the same guard via `command -v`, plus one fewer `apt update`.
- **The ROS key fetch** now passes `curl -f`, so a throttled `raw.githubusercontent.com` fails at the
  fetch rather than writing an error page into the keyring.

The interesting failure modes are a tool the guard wrongly considers present, and the `-f` firing on
a transient 429. Windows is untouched by that PR and is here as a regression check.